### PR TITLE
fix(ui): prevent flash on custom-drug page by removing isFetching from loading check

### DIFF
--- a/web/app/custom-drug/[id]/page.tsx
+++ b/web/app/custom-drug/[id]/page.tsx
@@ -251,7 +251,7 @@ export default function CustomDrugPage() {
     },
   });
 
-  if (isLoading || isFetching) {
+  if (isLoading) {
     return (
       <main className="min-h-screen bg-gray-50 p-8">
         <div className="max-w-4xl mx-auto">


### PR DESCRIPTION
## Summary
Fixes #41 — the `/custom-drug/[id]` page flashes blank every 3 seconds during background polling.

## Root Cause
The loading guard used `isLoading || isFetching`. React Query's `isFetching` is `true` on every background refetch (including the 3-second polling interval), causing the full-page loading state to re-render and blank out the content.

## Fix
Changed the loading check from:
```tsx
if (isLoading || isFetching) {
```
to:
```tsx
if (isLoading) {
```

`isLoading` is only `true` on the very first fetch when no data exists yet — which is the only time we actually want to show a loading state.

## Testing
- Navigate to `/custom-drug/[id]` while a job is pending/running
- Content should no longer flash on background polls
- Initial loading state still shows correctly on first visit