### PR TITLE
fix: use getToken() helper consistently instead of direct sessionStorage access

### DIFF
--- a/web/app/crowdfund/[id]/page.tsx
+++ b/web/app/crowdfund/[id]/page.tsx
@@ -7,6 +7,7 @@ import { Heart, Users, Target, Share2, CheckCircle } from "lucide-react";
 import { loadStripe } from "@stripe/stripe-js";
 import { Elements, PaymentElement, useStripe, useElements } from "@stripe/react-stripe-js";
 import { api } from "@/lib/api";
+import { getToken } from "@/lib/auth";
 
 const stripePromise = loadStripe(process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY ?? "");
 
@@ -46,7 +47,7 @@ function DonateForm({
     if (!usd || usd < 1) { setError("Enter a valid amount (min $1)"); return; }
 
     try {
-      const token = sessionStorage.getItem("kc_token");
+      const token = getToken();
       const res = await fetch(
         `${process.env.NEXT_PUBLIC_API_URL}/api/crowdfund/${slug}/donate`,
         {

--- a/web/app/marketplace/page.tsx
+++ b/web/app/marketplace/page.tsx
@@ -18,6 +18,7 @@ import {
   Send,
 } from "lucide-react";
 import { api } from "@/lib/api";
+import { getToken } from "@/lib/auth";
 
 const orderSchema = z.object({
   drug_spec: z.string().min(20, "Please provide a detailed drug specification").max(2000),
@@ -203,7 +204,7 @@ function OrderModal({
   const onSubmit = async (data: OrderForm) => {
     setStatus("submitting");
     try {
-      const token = sessionStorage.getItem("kc_token");
+      const token = getToken();
       const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/marketplace/order`, {
         method: "POST",
         headers: {

--- a/web/app/oncologist/page.tsx
+++ b/web/app/oncologist/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { getToken } from "@/lib/auth";
 import { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { motion } from "framer-motion";
@@ -22,7 +23,7 @@ interface ReviewPayload {
 const API = process.env.NEXT_PUBLIC_API_URL ?? "";
 
 function authHeaders(): Record<string, string> {
-  const token = typeof window !== "undefined" ? sessionStorage.getItem("kc_token") : null;
+  const token = getToken();
   return token ? { Authorization: `Bearer ${token}` } : {};
 }
 


### PR DESCRIPTION
## Summary
Closes #47

Replace direct `sessionStorage.getItem("kc_token")` calls with the centralized `getToken()` helper from `@/lib/auth`.

## Changes
- **`web/app/crowdfund/[id]/page.tsx`**: Replace `sessionStorage.getItem("kc_token")` → `getToken()`, add import
- **`web/app/marketplace/page.tsx`**: Same replacement + import  
- **`web/app/oncologist/page.tsx`**: Refactor `authHeaders()` to use `getToken()` instead of inline `sessionStorage.getItem("kc_token")`

## Why
The token key `"kc_token"` was hardcoded in 3 places. Using `getToken()` centralizes the token retrieval so any future change to the storage key only needs to happen in `auth.ts`.

No behavioral change — `getToken()` reads from the same `sessionStorage` key.