### PR TITLE
fix: clear the 16 CVEs Trivy flagged in the API image

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -9,7 +9,8 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 COPY api/requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel \
+    && pip install --no-cache-dir -r requirements.txt
 
 COPY api/. .
 COPY ai/. ./ai/

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,6 +1,6 @@
-fastapi==0.111.0
+fastapi==0.141.1
 uvicorn[standard]==0.29.0
-pydantic[email]==2.7.1
+pydantic[email]==2.13.4
 pydantic-settings==2.2.1
 sqlalchemy[asyncio]==2.0.30
 asyncpg==0.29.0
@@ -16,8 +16,8 @@ requests>=2.32.4          # pin transitive dep to a version past PYSEC-2026-187x
 httpx==0.27.0
 tenacity==8.5.0
 slowapi==0.1.9
-pytest==8.2.0
-pytest-asyncio==0.23.6
+pytest==9.1.1
+pytest-asyncio==1.4.0
 aiosqlite==0.20.0          # async sqlite driver for the in-memory test DB (api/tests/conftest.py)
 stripe==9.8.0
 resend==2.13.1            # >=2.x relaxes the requests==2.31.0 pin (CVE); same Emails.send API


### PR DESCRIPTION
Follow up to the docker context fix. Once that merged, Trivy actually ran for the first time and found 16 fixable HIGH/CRITICAL vulnerabilities in the API image, all in Python packages.

pip 24.0, setuptools 79.0.1 and its vendored wheel and jaraco.context were just whatever came bundled with the python:3.11-slim base image, never touched by requirements.txt. The Dockerfile now upgrades pip, setuptools and wheel before installing anything else.

starlette 0.37.2 was pulled in transitively by fastapi==0.111.0 and had six CVEs of its own. The only real fix is a newer fastapi, which requires pydantic>=2.9.0, so bumped fastapi to 0.141.1 and pydantic to 2.13.4 to match. pydantic-settings stayed on 2.2.1, it already declares pydantic>=2.3.0 so no conflict there.

pytest 8.2.0 had one CVE. Bumped to 9.1.1 and moved pytest-asyncio to 1.4.0 alongside it since that's the version pip actually resolves against the newer pytest.

Installed the full updated requirements.txt into a clean venv first to check for dependency conflicts before touching anything, then ran the real suites locally, 657 api tests and 42 ai tests, all passing, ruff still clean too. Same limitation as last time though, no Trivy binary locally, so this still needs a real run against main to confirm the findings actually clear.