### PR TITLE
fix: strip pip from the API image to clear its vendored CVEs

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -9,8 +9,14 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 COPY api/requirements.txt .
+# pip vendors its own internal copies of msgpack and setuptools (pip/_vendor/),
+# independent of the top-level setuptools pinned above. Even the latest pip
+# release still ships older vulnerable versions of those, so once packages are
+# installed pip itself is removed, taking its vendored copies with it. The
+# app runs via uvicorn and never needs pip at runtime.
 RUN pip install --no-cache-dir --upgrade pip setuptools wheel \
-    && pip install --no-cache-dir -r requirements.txt
+    && pip install --no-cache-dir -r requirements.txt \
+    && pip uninstall -y pip
 
 COPY api/. .
 COPY ai/. ./ai/


### PR DESCRIPTION
Merged the last fix expecting all 16 Trivy findings to clear, but three came back after the real scan ran on main: msgpack 1.1.2 and setuptools 70.3.0, both flagged HIGH or MEDIUM.

Turned out these were never the top level packages I bumped last time. pip vendors its own private copies of msgpack and setuptools under pip/_vendor for its internal build and cache handling, completely separate from whatever setuptools version is installed at the top level. Checked pip's own vendor.txt and even the newest release, 26.2.1, still ships msgpack 1.1.2 and setuptools 70.3.0 in there, so bumping our own pins was never going to touch it.

The API is served by uvicorn and never calls pip at runtime, so instead of waiting on upstream to update their vendored copies, this uninstalls pip right after it finishes installing requirements.txt, which takes its vendored copies with it.

Tested this in a venv before touching the Dockerfile: installed the full dependency set, ran pip uninstall -y pip, then imported api/main.py directly and confirmed the FastAPI app object still builds fine with pip completely gone. Also grepped the codebase for pkg_resources or import setuptools, nothing in api or ai touches it at runtime.