### PR TITLE
Stop Tier 2 recommending non-oncology drugs, and say so when nothing is left

### DIFF
--- a/api/alembic/versions/0010_excluded_candidates_audit.py
+++ b/api/alembic/versions/0010_excluded_candidates_audit.py
@@ -1,0 +1,28 @@
+"""Add results.excluded_candidates for the oncology-relevance gate audit trail.
+
+Tier 2 repurposing now drops candidates that WHO ATC classifies as something
+other than a cancer therapy (see api/services/oncology_atc.py). Those drugs
+were previously only written to the application log, which means a filter that
+removes treatment options from a patient's report left no record in the report
+itself. This column stores what was withheld and why.
+
+Revision ID: 0010
+Revises: a8bf7eb4833c
+Create Date: 2026-08-12
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0010"
+down_revision = "a8bf7eb4833c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("results", sa.Column("excluded_candidates", sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("results", "excluded_candidates")

--- a/api/models/result.py
+++ b/api/models/result.py
@@ -42,6 +42,12 @@ class Result(Base):
     # Combination therapy suggestions (list of drug-pair recommendations)
     combination_therapy: Mapped[Any] = mapped_column(JSON, nullable=True)
 
+    # Candidates the oncology-relevance gate withheld, as
+    # [{drug_name, atc_codes, reason}]. Kept so a reviewer can audit what the
+    # filter removed rather than having to trust it silently. See
+    # services/oncology_atc.py.
+    excluded_candidates: Mapped[Any] = mapped_column(JSON, nullable=True)
+
     # S3 key for the generated PDF report
     report_pdf_s3_key: Mapped[str] = mapped_column(String(512), nullable=True)
 

--- a/api/routes/results.py
+++ b/api/routes/results.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import selectinload
 from database import get_db
 from models.submission import Submission
 from models.patient import Patient
+from models.result import Result
 from routes.auth import get_current_patient
 from schemas import ResultsResponse, SubmissionStatusOut
 from utils.http import conflict_error, not_found_error
@@ -46,7 +47,7 @@ async def get_results(
         )
         .options(
             selectinload(Submission.mutations),
-            selectinload(Submission.result),
+            selectinload(Submission.result).selectinload(Result.repurposing_candidates),
         )
     )).scalar_one_or_none()
 
@@ -62,9 +63,29 @@ async def get_results(
 
     result = submission.result
     mutations = submission.mutations
-    custom_drug_possible = bool((result and result.target_gene) or mutations)
+
+    # Which of the three end states this analysis reached. An empty candidate
+    # list used to be indistinguishable from "we never looked", which became a
+    # real possibility once the oncology-relevance gate started removing
+    # non-cancer drugs from Tier 2. Callers need to tell the cases apart.
+    has_target = bool(result and result.target_gene)
+    has_candidates = bool(result and result.repurposing_candidates)
+    if not mutations:
+        recommendation_state = "no_mutations_detected"
+    elif not has_target:
+        recommendation_state = "no_targetable_mutation"
+    elif not has_candidates:
+        recommendation_state = "no_approved_therapy_found"
+    else:
+        recommendation_state = "candidates_available"
+
+    custom_drug_possible = bool(has_target or mutations)
     custom_drug_reason = (
-        "target_gene_available" if (result and result.target_gene) else
+        # A confirmed target with nothing approved against it is exactly the
+        # population custom discovery exists for, so say that rather than the
+        # generic "we have a target".
+        "no_approved_therapy_found" if recommendation_state == "no_approved_therapy_found" else
+        "target_gene_available" if has_target else
         "mutation_profile_available" if mutations else
         "insufficient_genomic_signal"
     )
@@ -156,6 +177,8 @@ async def get_results(
         "immunotherapy_profile": result.immunotherapy_profile if result else None,
         "mutational_signature": result.mutational_signature if result else None,
         "combination_therapy": result.combination_therapy or [] if result else [],
+        "recommendation_state": recommendation_state,
+        "excluded_candidates": (result.excluded_candidates or []) if result else [],
     }
 
 

--- a/api/schemas/__init__.py
+++ b/api/schemas/__init__.py
@@ -1,5 +1,6 @@
 from .responses import (
     DrugCandidateOut,
+    ExcludedCandidateOut,
     MutationOut,
     OncologistReportOut,
     ResultsResponse,
@@ -9,6 +10,7 @@ from .responses import (
 
 __all__ = [
     "DrugCandidateOut",
+    "ExcludedCandidateOut",
     "MutationOut",
     "OncologistReportOut",
     "ResultsResponse",

--- a/api/schemas/responses.py
+++ b/api/schemas/responses.py
@@ -102,6 +102,16 @@ class CombinationSuggestionOut(BaseModel):
     trial_ids: list[str] = Field(default_factory=list)
 
 
+class ExcludedCandidateOut(BaseModel):
+    """A drug the oncology-relevance gate withheld from the ranked list.
+
+    Reported rather than dropped silently so a reviewer can audit the filter.
+    """
+    drug_name: str
+    atc_codes: list[str] = Field(default_factory=list)
+    reason: str
+
+
 class ResultsResponse(BaseModel):
     submission_id: str
     cancer_type: Optional[str] = None
@@ -125,3 +135,8 @@ class ResultsResponse(BaseModel):
     immunotherapy_profile: Optional[ImmunotherapyProfileOut] = None
     mutational_signature: Optional[MutationalSignatureOut] = None
     combination_therapy: list[CombinationSuggestionOut] = Field(default_factory=list)
+    # Which end state the analysis reached: no_mutations_detected,
+    # no_targetable_mutation, no_approved_therapy_found, candidates_available.
+    # Distinguishes "we looked and found nothing" from "we never looked".
+    recommendation_state: Optional[str] = None
+    excluded_candidates: list[ExcludedCandidateOut] = Field(default_factory=list)

--- a/api/services/llm_explainer.py
+++ b/api/services/llm_explainer.py
@@ -192,18 +192,23 @@ def _template_summary(
             f"this gene and may be repurposed for your case. This could potentially reduce "
             f"the cost and time normally required to develop brand-new treatments."
             if top_drug
-            else "Our AI is searching for existing medicines that could be repurposed for your mutation."
+            # Not "we are still searching". The search has finished by the time
+            # this text is written, so saying otherwise promises a result that is
+            # never coming. See _generate_summary in workers/ai_worker.py.
+            else "We searched for existing medicines that could be repurposed for your "
+                 "mutation and did not find an approved cancer treatment that matches it. "
+                 "Clinical trials and custom drug design may still be options for you."
         )
         cosmic_sentence = (
             f"This type of change in {gene} has been recorded in {cosmic_count:,} tumour samples "
-            f"in the COSMIC database — the world's largest catalogue of cancer mutations — "
+            f"in the COSMIC database, the world's largest catalogue of cancer mutations, "
             f"which means it is a well-studied alteration."
             if cosmic_count > 0
             else ""
         )
         return (
             f"Your DNA test found a change in a gene called {gene}. "
-            f"This is called a 'targetable mutation' — it means there may be medicines "
+            f"This is called a 'targetable mutation', which means there may be medicines "
             f"that could target cancer cells with this specific change.\n\n"
             f"{cosmic_sentence}\n\n"
             f"{drug_sentence}\n\n"
@@ -213,8 +218,8 @@ def _template_summary(
     else:
         return (
             "Your DNA test did not find a mutation that matches a targeted therapy "
-            "in our research database. This does not mean there are no treatment options — "
-            "your oncologist will consider many factors beyond this one test.\n\n"
+            "in our research database. This does not mean there are no treatment options. "
+            "Your oncologist will consider many factors beyond this one test.\n\n"
             "Please share these results with your doctor as soon as possible.\n\n"
             "This report is not medical advice. "
             "Please discuss these results with your oncologist."

--- a/api/services/oncology_atc.py
+++ b/api/services/oncology_atc.py
@@ -1,0 +1,241 @@
+"""Oncology-relevance gate for Tier 2 repurposing candidates.
+
+WHY THIS EXISTS
+---------------
+Tier 2 repurposing pulled any FDA-approved drug with a recorded gene
+interaction from DGIdb/OpenTargets. The only filter was "is this approved for
+anything?", with no check that the drug is an oncology therapy at all. Real
+output from the 2026-07-28 concordance pilot:
+
+    ATP1A2 mutation -> acetyldigitoxin, deslanoside, digitoxin  (cardiac glycosides)
+    DPYS   mutation -> atenolol, dexrazoxane                    (beta blocker)
+    ARG1   mutation -> glycerol phenylbutyrate, sildenafil
+    ARSB   mutation -> ascorbic acid, galsulfase                (vitamin C)
+    ADRA1A mutation -> alfuzosin, doxazosin                     (BPH drugs)
+
+Those were presented to cancer patients as ranked drug candidates. Digitoxin
+in particular is a narrow-therapeutic-index cardiac glycoside. Showing it as a
+treatment option is worse than returning nothing.
+
+This matters at scale: the 200-patient TCGA benchmark reports 7.5% Tier 1 and
+92.5% escalation, so Tier 2 is the path most patients actually land on.
+
+HOW IT DECIDES
+--------------
+WHO ATC classification, sourced from ChEMBL, never hand-written here:
+
+    L01 = antineoplastic agents
+    L02 = endocrine therapy
+
+A drug is oncology-relevant if any of its ATC codes starts with L01 or L02.
+Verified to separate the real cases above: imatinib L01EA01 and tamoxifen
+L02BA01 pass; atenolol C07AB03, digitoxin C01AA04 and ascorbic acid G01AD03
+do not.
+
+A DRUG IS DROPPED ONLY ON POSITIVE EVIDENCE THAT IT IS NOT ONCOLOGY
+-------------------------------------------------------------------
+The rule is deliberately NOT "keep only what we can prove is oncology". That
+version was written first and rejected: it dropped tamoxifen, sunitinib,
+bevacizumab, trastuzumab and everolimus, because ChEMBL's search endpoint
+answers inconsistently under repeated queries and many biologics carry no ATC
+there at all. A filter that removes trastuzumab from a patient's options is far
+worse than the noise it was built to remove.
+
+So the decision is inverted:
+
+    has an ATC starting L01/L02   -> KEEP  (oncology therapy)
+    has ATC codes, none L01/L02   -> DROP  (positively classified as something
+                                            else: digitoxin C01AA04, atenolol
+                                            C07AB03, ascorbic acid G01AD03)
+    no ATC codes / lookup failed  -> KEEP  (unknown is not evidence)
+
+Every absurd case from the pilot carries a known non-oncology ATC, so all of
+them are still removed, while a failed lookup or an unclassified biologic
+degrades to today's behaviour instead of deleting a real therapy. For a filter
+standing between a patient and their treatment options, that is the correct
+direction to fail.
+
+This will still REDUCE reported coverage, and that is the point. The previous
+"100% coverage, zero empty outputs" figure was partly an artifact of never
+filtering: the system could always find some approved drug with a gene
+interaction, so it never had to report that it found nothing.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+from typing import Any, Iterable, Optional
+
+logger = logging.getLogger(__name__)
+
+_CHEMBL_BASE = "https://www.ebi.ac.uk/chembl/api/data"
+_ONCOLOGY_ATC_PREFIXES = ("L01", "L02")
+
+_CACHE_PATH = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "..", "..",
+    "validation_results", "atc_cache.json",
+)
+
+_lock = threading.Lock()
+_cache: Optional[dict[str, list[str]]] = None
+
+
+def _load_cache() -> dict[str, list[str]]:
+    global _cache
+    if _cache is None:
+        try:
+            with open(os.path.abspath(_CACHE_PATH), encoding="utf-8") as fh:
+                _cache = json.load(fh)
+        except (OSError, ValueError):
+            _cache = {}
+    return _cache
+
+
+def _save_cache() -> None:
+    try:
+        path = os.path.abspath(_CACHE_PATH)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(_cache or {}, fh, indent=2, sort_keys=True)
+    except OSError as exc:  # cache is an optimisation; never fail the request
+        logger.warning("[atc] could not write cache: %s", exc)
+
+
+def normalise(name: str) -> str:
+    return " ".join((name or "").strip().lower().split())
+
+
+def atc_codes(drug_name: str, *, allow_network: bool = True) -> list[str]:
+    """ATC codes for a drug. Empty list means unknown, not 'no codes exist'."""
+    key = normalise(drug_name)
+    if not key:
+        return []
+
+    cache = _load_cache()
+    if key in cache:
+        return cache[key]
+    if not allow_network:
+        return []
+
+    codes: list[str] = []
+    try:
+        import httpx
+
+        # Take several hits, not one. ChEMBL's first search result is often a
+        # null record or a salt form carrying no ATC, with the real molecule
+        # ranked second or third -- querying SUNITINIB returns (None, []) first
+        # and ('SUNITINIB', ['L01EX01']) second. Reading only hit[0] silently
+        # dropped genuine cancer drugs, which is the dangerous direction for a
+        # filter that excludes unknowns.
+        resp = httpx.get(
+            f"{_CHEMBL_BASE}/molecule/search.json",
+            params={"q": drug_name, "limit": 10},
+            timeout=30,
+        )
+        if resp.status_code == 200:
+            molecules = resp.json().get("molecules") or []
+            seen: set[str] = set()
+            for molecule in molecules:
+                for code in molecule.get("atc_classifications") or []:
+                    if code and str(code) not in seen:
+                        seen.add(str(code))
+                        codes.append(str(code))
+        else:
+            logger.warning("[atc] ChEMBL returned %s for %r", resp.status_code, drug_name)
+            return []  # transient failure: do not poison the cache
+    except Exception as exc:  # noqa: BLE001 - network/parse issues are non-fatal
+        logger.warning("[atc] lookup failed for %r: %s", drug_name, exc)
+        return []
+
+    with _lock:
+        cache[key] = codes
+        _save_cache()
+    return codes
+
+
+def is_oncology_drug(drug_name: str, *, allow_network: bool = True) -> bool:
+    """True if the drug carries an ATC L01/L02 (antineoplastic/endocrine) code.
+
+    Note this is a positive test only. Do not use it directly to filter -- an
+    unknown drug answers False here but must NOT be dropped. Use
+    `should_exclude` or `partition_candidates` for filtering decisions.
+    """
+    return any(
+        code.upper().startswith(_ONCOLOGY_ATC_PREFIXES)
+        for code in atc_codes(drug_name, allow_network=allow_network)
+    )
+
+
+def should_exclude(drug_name: str, *, allow_network: bool = True) -> bool:
+    """True only when the drug is positively classified as non-oncology.
+
+    Unknown drugs (no ATC on record, or a failed lookup) return False and are
+    therefore kept. See the module docstring for why this direction matters.
+    """
+    codes = atc_codes(drug_name, allow_network=allow_network)
+    if not codes:
+        return False  # unknown is not evidence of anything
+    return not any(c.upper().startswith(_ONCOLOGY_ATC_PREFIXES) for c in codes)
+
+
+def partition_candidates(
+    candidates: Iterable[dict[str, Any]],
+    *,
+    name_key: str = "drug_name",
+    allow_network: bool = True,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Split candidates into (oncology_relevant, excluded).
+
+    Excluded candidates are returned rather than discarded so a caller can show
+    them under a separate, clearly-labelled heading instead of silently
+    dropping evidence. They must not be mixed into the ranked recommendations.
+    """
+    keep: list[dict[str, Any]] = []
+    dropped: list[dict[str, Any]] = []
+    for candidate in candidates:
+        name = candidate.get(name_key) or ""
+        codes = atc_codes(name, allow_network=allow_network)
+        oncology = any(c.upper().startswith(_ONCOLOGY_ATC_PREFIXES) for c in codes)
+        # Drop only on positive evidence of a non-oncology class. No codes means
+        # unknown, and unknown is kept.
+        exclude = bool(codes) and not oncology
+        annotated = {
+            **candidate,
+            "atc_codes": codes,
+            "oncology_relevant": oncology,
+            "atc_classified": bool(codes),
+        }
+        (dropped if exclude else keep).append(annotated)
+    if dropped:
+        logger.info(
+            "[atc] filtered %d non-oncology candidate(s): %s",
+            len(dropped), ", ".join(d.get(name_key, "?") for d in dropped[:5]),
+        )
+    return keep, dropped
+
+
+# ── STATUS: NOT WIRED IN ─────────────────────────────────────────────────────
+# Nothing calls this module yet, and it must not be wired into
+# _query_repurposing_candidates until the ATC source is reliable.
+#
+# The decision logic above is correct and safe: verified to keep 12/12 real
+# oncology drugs (imatinib, olaparib, tamoxifen, sunitinib, pazopanib,
+# capmatinib, sorafenib, bevacizumab, trastuzumab, everolimus, belzutifan,
+# larotrectinib) while dropping acetyldigitoxin, atenolol, ascorbic acid and
+# alfuzosin.
+#
+# The blocker is the data source, not the logic. ChEMBL's /molecule/search
+# endpoint answers inconsistently: digitoxin returned C01AA04 early in testing
+# and UNKNOWN on later attempts, including across three retries with backoff.
+# Because unknown means keep, a degraded ChEMBL makes this filter inert rather
+# than dangerous -- it stops removing noise, it never removes a real therapy.
+#
+# To finish this, replace the per-drug live search with a bulk, offline ATC
+# source and commit the resulting cache so lookups are deterministic:
+#   - ChEMBL bulk download (chembl_*_atc_classification.txt), or
+#   - the WHO ATC/DDD index, or
+#   - DrugBank/RxNorm ATC mappings
+# Then populate validation_results/atc_cache.json once, verify no oncology drug
+# is dropped, and only then wire partition_candidates() into Tier 2.

--- a/api/services/oncology_atc.py
+++ b/api/services/oncology_atc.py
@@ -216,26 +216,16 @@ def partition_candidates(
     return keep, dropped
 
 
-# ── STATUS: NOT WIRED IN ─────────────────────────────────────────────────────
-# Nothing calls this module yet, and it must not be wired into
-# _query_repurposing_candidates until the ATC source is reliable.
+# ── STATUS: WIRED IN ─────────────────────────────────────────────────────────
+# Called from api/workers/ai_worker.py::_query_repurposing_candidates with
+# allow_network=False, so it reads only the committed offline cache
+# (validation_results/atc_cache.json -- 4,841 drugs from ChEMBL's bulk
+# atc_class endpoint, 374 of them L01/L02). No live lookup on the request path,
+# and the gate is wrapped so it can never fail a case.
 #
-# The decision logic above is correct and safe: verified to keep 12/12 real
-# oncology drugs (imatinib, olaparib, tamoxifen, sunitinib, pazopanib,
-# capmatinib, sorafenib, bevacizumab, trastuzumab, everolimus, belzutifan,
-# larotrectinib) while dropping acetyldigitoxin, atenolol, ascorbic acid and
-# alfuzosin.
+# The cache is committed rather than fetched at runtime because ChEMBL's
+# per-drug /molecule/search endpoint is unreliable: digitoxin resolved to
+# C01AA04 on one attempt and returned nothing on later ones. The bulk
+# atc_class endpoint is stable, so it is fetched once and stored.
 #
-# The blocker is the data source, not the logic. ChEMBL's /molecule/search
-# endpoint answers inconsistently: digitoxin returned C01AA04 early in testing
-# and UNKNOWN on later attempts, including across three retries with backoff.
-# Because unknown means keep, a degraded ChEMBL makes this filter inert rather
-# than dangerous -- it stops removing noise, it never removes a real therapy.
-#
-# To finish this, replace the per-drug live search with a bulk, offline ATC
-# source and commit the resulting cache so lookups are deterministic:
-#   - ChEMBL bulk download (chembl_*_atc_classification.txt), or
-#   - the WHO ATC/DDD index, or
-#   - DrugBank/RxNorm ATC mappings
-# Then populate validation_results/atc_cache.json once, verify no oncology drug
-# is dropped, and only then wire partition_candidates() into Tier 2.
+# Rebuild with: python scripts/build_atc_cache.py

--- a/api/tests/test_oncology_atc.py
+++ b/api/tests/test_oncology_atc.py
@@ -1,0 +1,65 @@
+"""Tests for the Tier 2 oncology-relevance gate (services/oncology_atc.py).
+
+These pin the exact drugs the pipeline previously recommended to cancer
+patients through Tier 2 repurposing, taken from the 2026-07-28 concordance
+pilot's real output.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from services.oncology_atc import (  # noqa: E402
+    partition_candidates,
+    should_exclude,
+)
+
+# Real Tier 2 output from the pilot. Cardiac glycosides, a beta blocker,
+# vitamin C and BPH drugs, all shown as ranked cancer treatment candidates.
+NON_ONCOLOGY = [
+    "ACETYLDIGITOXIN", "DESLANOSIDE", "DIGITOXIN", "ATENOLOL",
+    "ASCORBIC ACID", "ALFUZOSIN", "DOXAZOSIN",
+]
+
+ONCOLOGY = [
+    "IMATINIB", "OLAPARIB", "TAMOXIFEN", "SUNITINIB", "PAZOPANIB",
+    "CAPMATINIB", "SORAFENIB", "TRASTUZUMAB", "EVEROLIMUS", "OSIMERTINIB",
+]
+
+
+class TestOncologyGate:
+    def test_non_oncology_drugs_are_excluded(self):
+        for drug in NON_ONCOLOGY:
+            assert should_exclude(drug, allow_network=False), drug
+
+    def test_real_oncology_drugs_are_never_excluded(self):
+        """The property that matters most. A filter that drops trastuzumab is
+        worse than the noise it removes."""
+        for drug in ONCOLOGY:
+            assert not should_exclude(drug, allow_network=False), drug
+
+    def test_unknown_drug_is_kept_not_dropped(self):
+        """Unknown is not evidence. A drug absent from the ATC cache, or a
+        failed lookup, must degrade to current behaviour rather than delete a
+        potentially real therapy."""
+        assert not should_exclude("NOT-A-REAL-DRUG-XYZ", allow_network=False)
+        assert not should_exclude("", allow_network=False)
+
+    def test_partition_separates_without_losing_candidates(self):
+        candidates = [{"drug_name": n} for n in ONCOLOGY + NON_ONCOLOGY]
+        keep, dropped = partition_candidates(candidates, allow_network=False)
+        assert len(keep) + len(dropped) == len(candidates)
+        assert {c["drug_name"] for c in dropped} == set(NON_ONCOLOGY)
+        assert {c["drug_name"] for c in keep} == set(ONCOLOGY)
+
+    def test_partition_annotates_candidates(self):
+        keep, dropped = partition_candidates(
+            [{"drug_name": "IMATINIB"}, {"drug_name": "ATENOLOL"}],
+            allow_network=False,
+        )
+        assert keep[0]["oncology_relevant"] is True
+        assert any(c.startswith("L01") for c in keep[0]["atc_codes"])
+        assert dropped[0]["oncology_relevant"] is False

--- a/api/tests/test_recommendation_state.py
+++ b/api/tests/test_recommendation_state.py
@@ -1,0 +1,85 @@
+"""Tests for the three end states an analysis can reach.
+
+Background: an empty drug list used to be indistinguishable from "we never
+looked". The summary rendered it as "Top candidate drugs: currently being
+analyzed", which reads as work still in progress even though the search had
+finished and returned nothing.
+
+That case stopped being hypothetical when the oncology-relevance gate started
+removing non-cancer drugs from Tier 2 (services/oncology_atc.py). A patient who
+previously saw digitoxin now sees nothing, and nothing is only an improvement
+over digitoxin if it is clearly labelled as nothing.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from types import SimpleNamespace
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from workers.ai_worker import _generate_summary  # noqa: E402
+
+
+def _mut(gene: str) -> SimpleNamespace:
+    return SimpleNamespace(gene=gene)
+
+
+class TestSummaryStates:
+    def test_no_targetable_mutation(self):
+        summary = _generate_summary([_mut("TTN"), _mut("MUC16")], [], [])
+        assert "found 2 genetic variation(s)" in summary
+        assert "None of these mutations" in summary
+
+    def test_candidates_found_lists_them(self):
+        summary = _generate_summary(
+            [_mut("EGFR")],
+            [_mut("EGFR")],
+            [{"drug_name": "osimertinib"}, {"drug_name": "erlotinib"}],
+        )
+        assert "osimertinib" in summary
+        assert "erlotinib" in summary
+        assert "currently being analyzed" not in summary
+
+    def test_target_found_but_no_drug_says_so(self):
+        """The state the oncology gate creates. Must not imply work in progress."""
+        summary = _generate_summary([_mut("ARID1A")], [_mut("ARID1A")], [])
+        assert "currently being analyzed" not in summary
+        assert "completed the drug search" in summary
+        assert "did not find an approved cancer therapy" in summary
+        assert "ARID1A" in summary
+
+    def test_empty_state_points_somewhere(self):
+        """A dead end is not an acceptable answer. Name the remaining paths."""
+        summary = _generate_summary([_mut("ARID1A")], [_mut("ARID1A")], [])
+        assert "Clinical trials" in summary
+        assert "custom drug discovery" in summary
+
+    def test_excluded_drugs_are_named_in_the_empty_state(self):
+        """If the reason the list is empty is that we filtered everything out,
+        say what was filtered. Silently returning nothing hides the decision."""
+        summary = _generate_summary(
+            [_mut("ATP1A2")],
+            [_mut("ATP1A2")],
+            [],
+            [{"drug_name": "digitoxin"}, {"drug_name": "deslanoside"}],
+        )
+        assert "2 drug(s)" in summary
+        assert "digitoxin" in summary
+        assert "not cancer treatments" in summary
+
+    def test_excluded_is_optional(self):
+        """Callers that predate the gate must keep working."""
+        assert _generate_summary([_mut("EGFR")], [_mut("EGFR")], [])
+        assert _generate_summary([_mut("EGFR")], [_mut("EGFR")], [], None)
+
+    def test_no_em_dashes_in_patient_facing_text(self):
+        """House style. These strings reach the patient report."""
+        for summary in (
+            _generate_summary([_mut("TTN")], [], []),
+            _generate_summary([_mut("EGFR")], [_mut("EGFR")], []),
+            _generate_summary([_mut("EGFR")], [_mut("EGFR")], [{"drug_name": "osimertinib"}]),
+        ):
+            assert "—" not in summary
+            assert "–" not in summary

--- a/api/tests/test_routes.py
+++ b/api/tests/test_routes.py
@@ -154,7 +154,58 @@ class TestGetResults:
         )
         body = resp.json()
         assert body["custom_drug_possible"] is True
+        # The fixture has a target gene and no ranked candidates, which is the
+        # specific case custom discovery exists for, so the reason is the more
+        # precise one rather than the generic "we have a target".
+        assert body["custom_drug_reason"] == "no_approved_therapy_found"
+
+    async def test_recommendation_state_reported(
+        self, client: AsyncClient, seeded_submission
+    ):
+        """A target with no ranked drug must not look like a pending analysis."""
+        resp = await client.get(
+            f"/api/results/{seeded_submission.id}",
+            headers={"Authorization": "Bearer test-token"},
+        )
+        body = resp.json()
+        assert body["recommendation_state"] == "no_approved_therapy_found"
+        assert body["excluded_candidates"] == []
+
+    async def test_recommendation_state_candidates_available(
+        self, client: AsyncClient, db_session, seeded_submission
+    ):
+        from models.repurposing import RepurposingCandidate
+        from models.result import Result
+        from sqlalchemy import select
+
+        result = (await db_session.execute(
+            select(Result).where(Result.submission_id == seeded_submission.id)
+        )).scalar_one()
+        result.excluded_candidates = [
+            {
+                "drug_name": "digitoxin",
+                "atc_codes": ["C01AA04"],
+                "reason": "not classified as an oncology therapy (WHO ATC L01/L02)",
+            }
+        ]
+        db_session.add(RepurposingCandidate(
+            result_id=result.id,
+            drug_name="osimertinib",
+            rank_score=0.9,
+        ))
+        await db_session.commit()
+
+        resp = await client.get(
+            f"/api/results/{seeded_submission.id}",
+            headers={"Authorization": "Bearer test-token"},
+        )
+        body = resp.json()
+        assert body["recommendation_state"] == "candidates_available"
         assert body["custom_drug_reason"] == "target_gene_available"
+        # The gate's audit trail survives even when candidates were found, so a
+        # reviewer can always check the filter did not remove a real therapy.
+        assert body["excluded_candidates"][0]["drug_name"] == "digitoxin"
+        assert body["excluded_candidates"][0]["atc_codes"] == ["C01AA04"]
 
 
 # ── /api/submit/ ─────────────────────────────────────────────────────────────

--- a/api/workers/ai_worker.py
+++ b/api/workers/ai_worker.py
@@ -114,6 +114,7 @@ def run_ai_analysis(
         target_gene = None
         alphafold_pdb_path: str | None = None
         combination_therapy_data: list[dict] = []
+        excluded_candidates: list[dict] = []
 
         if targetable_mutations:
             top_mutation = targetable_mutations[0]
@@ -124,7 +125,7 @@ def run_ai_analysis(
 
             # Aggregate candidate drugs from multiple evidence sources, then
             # score them against the mutation-specific structure when possible.
-            drugs, alphafold_pdb_path = _query_repurposing_candidates(
+            drugs, alphafold_pdb_path, excluded_candidates = _query_repurposing_candidates(
                 target_gene,
                 protein_variant=top_variant,
                 hgvs=top_mutation.hgvs_notation,
@@ -270,7 +271,23 @@ def run_ai_analysis(
         # Step 5: Build result with LLM plain-language summary
         with get_sync_session() as db:
             has_target = len(targetable_mutations) > 0
-            summary = _generate_summary(mutations, targetable_mutations, repurposing_candidates)
+            summary = _generate_summary(
+                mutations, targetable_mutations, repurposing_candidates, excluded_candidates
+            )
+
+            # Audit trail for the oncology-relevance gate. Recorded even when
+            # ranked candidates were still found, so a reviewer can always tell
+            # what the filter withheld and check it did not remove a genuine
+            # cancer therapy. Empty list is stored as NULL.
+            excluded_data = [
+                {
+                    "drug_name": d.get("drug_name"),
+                    "atc_codes": d.get("atc_codes") or [],
+                    "reason": "not classified as an oncology therapy (WHO ATC L01/L02)",
+                }
+                for d in excluded_candidates
+                if d.get("drug_name")
+            ]
 
             # Generate patient-friendly plain-language summary (LLM or template fallback)
             top_drug = (
@@ -309,6 +326,7 @@ def run_ai_analysis(
                 immunotherapy_profile=imm_profile_data if targetable_mutations else None,
                 mutational_signature=sig_data if targetable_mutations else None,
                 combination_therapy=combination_therapy_data or None,
+                excluded_candidates=excluded_data or None,
             )
             db.add(result)
             db.flush()
@@ -712,7 +730,7 @@ def _query_repurposing_candidates(
     hgvs: str | None = None,
     cancer_type: str | None = None,
     submission_id: str = "unknown",
-) -> tuple[list[dict], str | None]:
+) -> tuple[list[dict], str | None, list[dict]]:
     """Query multiple evidence sources for FDA-approved repurposing candidates.
 
     Sources queried (in priority order):
@@ -728,7 +746,11 @@ def _query_repurposing_candidates(
     mutated protein structure is folded first and passed to DiffDock for
     mutation-specific binding scores.
 
-    Returns (drugs, alphafold_pdb_path) — pdb_path is None if AlphaFold failed.
+    Returns (drugs, alphafold_pdb_path, excluded). pdb_path is None if AlphaFold
+    failed. `excluded` holds the candidates the oncology-relevance gate removed,
+    returned rather than dropped so the caller can record what was withheld and
+    why. A filter that stands between a patient and a treatment option should
+    leave an audit trail, not just a log line.
     """
     from services.opentargets import get_target_id, get_drugs_for_target
     from services.chembl import get_molecule, search_molecule_by_name
@@ -736,7 +758,7 @@ def _query_repurposing_candidates(
     from services.dgidb import get_interactions as get_dgidb_interactions
     from ai.diffdock.score import score_binding
 
-    async def _fetch() -> tuple[list[dict], str | None]:
+    async def _fetch() -> tuple[list[dict], str | None, list[dict]]:
         # ── Source 1: OpenTargets (expanded to 50 drugs) ─────────────────────
         ensg_id = await get_target_id(gene)
         ot_drugs = await get_drugs_for_target(ensg_id, max_drugs=50) if ensg_id else []
@@ -915,6 +937,7 @@ def _query_repurposing_candidates(
         # ascorbic acid and BPH drugs to cancer patients as ranked candidates.
         # Drops only on positive WHO ATC evidence of a non-oncology class;
         # an unknown or unclassified drug is kept. See services/oncology_atc.py.
+        non_oncology: list[dict] = []
         try:
             from services.oncology_atc import partition_candidates
 
@@ -930,10 +953,10 @@ def _query_repurposing_candidates(
         except Exception as exc:  # noqa: BLE001 - never fail a case on the gate
             logger.warning("[repurpose] oncology gate unavailable (%s); unfiltered", exc)
 
-        return fda_approved_candidates, pre_folded_pdb_key
+        return fda_approved_candidates, pre_folded_pdb_key, non_oncology
 
-    drugs, pdb_path = asyncio.run(_fetch())
-    return drugs, pdb_path
+    drugs, pdb_path, excluded = asyncio.run(_fetch())
+    return drugs, pdb_path, excluded
 
 
 def _run_diffdock(chembl_id: str | None, gene: str, hgvs: str | None) -> float | None:
@@ -942,27 +965,66 @@ def _run_diffdock(chembl_id: str | None, gene: str, hgvs: str | None) -> float |
     return None
 
 
-def _generate_summary(mutations, targetable, repurposing) -> str:
-    """Generate a technical summary for oncologist review."""
+def _generate_summary(mutations, targetable, repurposing, excluded=None) -> str:
+    """Generate a technical summary for oncologist review.
+
+    Three outcomes are reported separately, because they call for different
+    next steps and used to collapse into the same optimistic wording:
+
+      1. no targetable mutation was found
+      2. a targetable mutation was found, but no approved cancer therapy
+         matched it
+      3. a targetable mutation was found and candidate drugs were ranked
+
+    Case 2 previously rendered as "Top candidate drugs: currently being
+    analyzed", which reads as work still in progress. The search had in fact
+    finished and returned nothing. That case became more common once the
+    oncology-relevance gate started removing non-cancer drugs from Tier 2
+    (see services/oncology_atc.py), so it has to say plainly that we looked
+    and came up empty. An empty result is only an improvement over
+    recommending digitoxin if it is labelled as an empty result.
+    """
     total = len(mutations)
     n_target = len(targetable)
+    excluded = excluded or []
 
     if n_target == 0:
         return (
             f"We analyzed your DNA sample and found {total} genetic variation(s). "
             "None of these mutations currently have known targeted treatment options. "
-            "This does not mean treatment is unavailable — your oncologist can advise on other options."
+            "This does not mean treatment is unavailable. Your oncologist can advise "
+            "on other options."
         )
 
+    genes = ", ".join(m.gene for m in targetable)
     drug_names = [r["drug_name"] for r in repurposing[:3] if r.get("drug_name")]
-    drug_str = ", ".join(drug_names) if drug_names else "currently being analyzed"
+
+    if not drug_names:
+        parts = [
+            f"We found {n_target} targetable mutation(s) in genes: {genes}.",
+            "We completed the drug search and did not find an approved cancer "
+            "therapy matching these mutations.",
+        ]
+        if excluded:
+            names = ", ".join(
+                d.get("drug_name") for d in excluded[:3] if d.get("drug_name")
+            )
+            parts.append(
+                f"{len(excluded)} drug(s) that interact with these genes were set "
+                f"aside because they are not cancer treatments ({names})."
+            )
+        parts.append(
+            "Clinical trials and custom drug discovery may still apply. "
+            "Please review this report with a qualified oncologist."
+        )
+        return " ".join(parts)
 
     return (
-        f"We found {n_target} targetable mutation(s) in genes: "
-        f"{', '.join(m.gene for m in targetable)}. "
-        f"These mutations may be treatable with existing or repurposed drugs. "
-        f"Top candidate drugs: {drug_str}. "
-        "Please review this report with a qualified oncologist before making any treatment decisions."
+        f"We found {n_target} targetable mutation(s) in genes: {genes}. "
+        "These mutations may be treatable with existing or repurposed drugs. "
+        f"Top candidate drugs: {', '.join(drug_names)}. "
+        "Please review this report with a qualified oncologist before making any "
+        "treatment decisions."
     )
 
 

--- a/api/workers/ai_worker.py
+++ b/api/workers/ai_worker.py
@@ -907,6 +907,29 @@ def _query_repurposing_candidates(
             gene,
             len(merged_drugs),
         )
+
+        # Oncology-relevance gate. "FDA-approved" alone is not a therapeutic
+        # rationale: DGIdb/OpenTargets will happily return any approved drug
+        # with a recorded gene interaction, which previously surfaced cardiac
+        # glycosides (digitoxin, deslanoside), a beta blocker (atenolol),
+        # ascorbic acid and BPH drugs to cancer patients as ranked candidates.
+        # Drops only on positive WHO ATC evidence of a non-oncology class;
+        # an unknown or unclassified drug is kept. See services/oncology_atc.py.
+        try:
+            from services.oncology_atc import partition_candidates
+
+            fda_approved_candidates, non_oncology = partition_candidates(
+                fda_approved_candidates, allow_network=False
+            )
+            if non_oncology:
+                logger.info(
+                    "[repurpose] excluded %d non-oncology candidate(s) for %s: %s",
+                    len(non_oncology), gene,
+                    ", ".join(d.get("drug_name", "?") for d in non_oncology[:5]),
+                )
+        except Exception as exc:  # noqa: BLE001 - never fail a case on the gate
+            logger.warning("[repurpose] oncology gate unavailable (%s); unfiltered", exc)
+
         return fda_approved_candidates, pre_folded_pdb_key
 
     drugs, pdb_path = asyncio.run(_fetch())

--- a/scripts/build_atc_cache.py
+++ b/scripts/build_atc_cache.py
@@ -1,0 +1,84 @@
+"""Rebuild the WHO ATC drug-classification cache used by the Tier 2 oncology gate.
+
+Writes validation_results/atc_cache.json as {normalised_drug_name: [atc_codes]}.
+That file is committed so api/services/oncology_atc.py can classify drugs
+offline, with no network call on the request path.
+
+Why bulk rather than per-drug lookup: ChEMBL's /molecule/search endpoint is
+unreliable under repeated queries. The same drug (digitoxin) resolved to
+C01AA04 on one attempt and returned nothing on later attempts, including with
+retries and backoff. Since the gate keeps unknown drugs, that flakiness would
+silently make the filter inert. The /atc_class bulk endpoint is stable, so it
+is paginated once here and the result committed.
+
+Usage:
+    python scripts/build_atc_cache.py
+"""
+from __future__ import annotations
+
+import json
+import os
+import time
+
+import httpx
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+_OUT = os.path.join(_REPO_ROOT, "validation_results", "atc_cache.json")
+_URL = "https://www.ebi.ac.uk/chembl/api/data/atc_class.json"
+_PAGE = 1000
+
+
+def _get(params: dict, tries: int = 5) -> dict | None:
+    for attempt in range(tries):
+        try:
+            resp = httpx.get(_URL, params=params, timeout=120)
+            if resp.status_code == 200:
+                return resp.json()
+        except Exception:  # noqa: BLE001 - retried below
+            pass
+        time.sleep(3 * (attempt + 1))
+    return None
+
+
+def main() -> None:
+    rows: list[dict] = []
+    offset = 0
+    key: str | None = None
+
+    while True:
+        payload = _get({"limit": _PAGE, "offset": offset})
+        if payload is None:
+            raise SystemExit(f"ChEMBL unreachable at offset {offset}; cache not written")
+        if key is None:
+            key = next(k for k in payload if k != "page_meta")
+        batch = payload.get(key) or []
+        if not batch:
+            break
+        rows.extend(batch)
+        offset += _PAGE
+        print(f"fetched {len(rows)}")
+
+    cache: dict[str, list[str]] = {}
+    for row in rows:
+        name = " ".join((row.get("who_name") or "").strip().lower().split())
+        code = row.get("level5")
+        if not name or not code:
+            continue
+        codes = cache.setdefault(name, [])
+        if code not in codes:
+            codes.append(code)
+
+    os.makedirs(os.path.dirname(_OUT), exist_ok=True)
+    with open(_OUT, "w", encoding="utf-8") as fh:
+        json.dump(cache, fh, indent=1, sort_keys=True)
+
+    oncology = sum(
+        1 for codes in cache.values()
+        if any(c.startswith(("L01", "L02")) for c in codes)
+    )
+    print(f"wrote {_OUT}")
+    print(f"  {len(cache)} drugs, {oncology} oncology (ATC L01/L02)")
+
+
+if __name__ == "__main__":
+    main()

--- a/validation_results/atc_cache.json
+++ b/validation_results/atc_cache.json
@@ -1,35 +1,15263 @@
 {
-  "acetyldigitoxin": [
-    "C01AA01"
-  ],
-  "alfuzosin": [
-    "G04CA01"
-  ],
-  "ascorbic acid": [
-    "G01AD03",
-    "A11GA01",
-    "S01XA15"
-  ],
-  "atenolol": [
-    "C07AB03",
-    "C07AB11"
-  ],
-  "belzutifan": [
-    "L01XX74"
-  ],
-  "capmatinib": [
-    "L01EX17"
-  ],
-  "imatinib": [
-    "L01EA01"
-  ],
-  "olaparib": [
-    "L01XK01"
-  ],
-  "pazopanib": [
-    "L01EX03"
-  ],
-  "sorafenib": [
-    "L01EX02"
-  ]
+ "(2-benzhydryloxyethyl)diethyl-methylammonium iodide": [
+  "A03AB16"
+ ],
+ "13c-urea": [
+  "V04CX05"
+ ],
+ "2-(4-chlorphenoxy)-ethanol": [
+  "D01AE06"
+ ],
+ "4-aminosalicylic acid": [
+  "J04AA01"
+ ],
+ "4-dimethylaminophenol": [
+  "V03AB27"
+ ],
+ "abacavir": [
+  "J05AF06"
+ ],
+ "abaloparatide": [
+  "H05AA04"
+ ],
+ "abametapir": [
+  "P03AX07"
+ ],
+ "abarelix": [
+  "L02BX01"
+ ],
+ "abatacept": [
+  "L04AA24"
+ ],
+ "abciximab": [
+  "B01AC13"
+ ],
+ "abemaciclib": [
+  "L01EF03"
+ ],
+ "abetimus": [
+  "L04AA22"
+ ],
+ "abicipar pegol": [
+  "S01LA07"
+ ],
+ "abiraterone": [
+  "L02BX03"
+ ],
+ "abiraterone and corticosteroids": [
+  "L02BX53"
+ ],
+ "abrocitinib": [
+  "D11AH08"
+ ],
+ "absorbable gelatin sponge": [
+  "B02BC01"
+ ],
+ "acadesine": [
+  "C01EB13"
+ ],
+ "acalabrutinib": [
+  "L01EL02"
+ ],
+ "acamprosate": [
+  "N07BB03"
+ ],
+ "acarbose": [
+  "A10BF01"
+ ],
+ "acebutolol": [
+  "C07AB04"
+ ],
+ "acebutolol and thiazides": [
+  "C07BB04"
+ ],
+ "aceclidine": [
+  "S01EB08"
+ ],
+ "aceclidine, combinations": [
+  "S01EB58"
+ ],
+ "aceclofenac": [
+  "M01AB16",
+  "M02AA25"
+ ],
+ "acefylline piperazine": [
+  "R03DA09"
+ ],
+ "acemetacin": [
+  "M01AB11"
+ ],
+ "aceneuramic acid": [
+  "M09AX05"
+ ],
+ "acenocoumarol": [
+  "B01AA07"
+ ],
+ "acepromazine": [
+  "N05AA04"
+ ],
+ "acetarsol": [
+  "A07AX02",
+  "G01AB01",
+  "P01CD02"
+ ],
+ "acetazolamide": [
+  "S01EC01"
+ ],
+ "acetic acid": [
+  "G01AD02",
+  "S02AA10"
+ ],
+ "acetohexamide": [
+  "A10BB31"
+ ],
+ "acetohydroxamic acid": [
+  "G04BX03"
+ ],
+ "acetophenazine": [
+  "N05AB07"
+ ],
+ "acetoxolone": [
+  "A02BX09"
+ ],
+ "acetrizoic acid": [
+  "V08AA07"
+ ],
+ "acetylcarnitine": [
+  "N06BX12"
+ ],
+ "acetylcholine": [
+  "S01EB09"
+ ],
+ "acetylcysteine": [
+  "R05CB01",
+  "S01XA08",
+  "V03AB23"
+ ],
+ "acetyldigitoxin": [
+  "C01AA01"
+ ],
+ "acetyldigoxin": [
+  "C01AA02"
+ ],
+ "acetyldigoxin, combinations": [
+  "C01AA52"
+ ],
+ "acetyldihydrocodeine": [
+  "R05DA12"
+ ],
+ "acetylglycinamide chloral hydrate": [
+  "N05CC03"
+ ],
+ "acetylleucine": [
+  "N07CA04"
+ ],
+ "acetylsalicylic acid": [
+  "A01AD05",
+  "B01AC06",
+  "N02BA01"
+ ],
+ "acetylsalicylic acid and corticosteroids": [
+  "M01BA03"
+ ],
+ "acetylsalicylic acid, combinations excl. psycholeptics": [
+  "N02BA51"
+ ],
+ "acetylsalicylic acid, combinations with proton pump inhibitors": [
+  "B01AC56"
+ ],
+ "acetylsalicylic acid, combinations with psycholeptics": [
+  "N02BA71"
+ ],
+ "aciclovir": [
+  "D06BB03",
+  "J05AB01",
+  "S01AD03"
+ ],
+ "aciclovir, combinations": [
+  "D06BB53"
+ ],
+ "acipimox": [
+  "C10AD06"
+ ],
+ "acitretin": [
+  "D05BB02"
+ ],
+ "aclarubicin": [
+  "L01DB04"
+ ],
+ "aclidinium bromide": [
+  "R03BB05"
+ ],
+ "acoramidis": [
+  "C01EB25"
+ ],
+ "acotiamide": [
+  "A03FA10"
+ ],
+ "acriflavinium chloride": [
+  "R02AA13"
+ ],
+ "acrivastine": [
+  "R06AX18"
+ ],
+ "adagrasib": [
+  "L01XX77"
+ ],
+ "adalimumab": [
+  "L04AB04"
+ ],
+ "adapalene": [
+  "D10AD03"
+ ],
+ "adapalene, combinations": [
+  "D10AD53"
+ ],
+ "adefovir dipivoxil": [
+  "J05AF08"
+ ],
+ "ademetionine": [
+  "A16AA02"
+ ],
+ "adenosine": [
+  "C01EB10"
+ ],
+ "adinazolam": [
+  "N05BA07"
+ ],
+ "adipiodone": [
+  "V08AC04"
+ ],
+ "adrafinil": [
+  "N06BX17"
+ ],
+ "adrenalone": [
+  "A01AD06",
+  "B02BC05"
+ ],
+ "aducanumab": [
+  "N06DX03"
+ ],
+ "afamelanotide": [
+  "D02BB02"
+ ],
+ "afatinib": [
+  "L01EB03"
+ ],
+ "afelimomab": [
+  "L04AB03"
+ ],
+ "aflibercept": [
+  "L01XX44",
+  "S01LA05"
+ ],
+ "agalsidase alfa": [
+  "A16AB03"
+ ],
+ "agalsidase beta": [
+  "A16AB04"
+ ],
+ "agni casti fructus": [
+  "G02CX03"
+ ],
+ "agomelatine": [
+  "N06AX22"
+ ],
+ "ajmaline": [
+  "C01BA05"
+ ],
+ "alanyl glutamine": [
+  "B05XB02"
+ ],
+ "alaproclate": [
+  "N06AB07"
+ ],
+ "albendazole": [
+  "P02CA03"
+ ],
+ "albiglutide": [
+  "A10BJ04"
+ ],
+ "albinterferon alfa-2b": [
+  "L03AB12"
+ ],
+ "albumin": [
+  "B05AA01"
+ ],
+ "albumin tannate": [
+  "A07XA01"
+ ],
+ "albumin tannate, combinations": [
+  "A07XA51"
+ ],
+ "alcaftadine": [
+  "S01GX11"
+ ],
+ "alclofenac": [
+  "M01AB06"
+ ],
+ "alclometasone": [
+  "D07AB10",
+  "S01BA10"
+ ],
+ "alcuronium": [
+  "M03AA01"
+ ],
+ "aldesleukin": [
+  "L03AC01"
+ ],
+ "aldesulfone sodium": [
+  "J04BA03"
+ ],
+ "aldosterone": [
+  "H02AA01"
+ ],
+ "alectinib": [
+  "L01ED03"
+ ],
+ "alefacept": [
+  "L04AA15"
+ ],
+ "alemtuzumab": [
+  "L04AG06"
+ ],
+ "alendronic acid": [
+  "M05BA04"
+ ],
+ "alendronic acid and alfacalcidol, sequential": [
+  "M05BB06"
+ ],
+ "alendronic acid and colecalciferol": [
+  "M05BB03"
+ ],
+ "alendronic acid, calcium and colecalciferol, sequential": [
+  "M05BB05"
+ ],
+ "alfa1 antitrypsin": [
+  "B02AB02"
+ ],
+ "alfacalcidol": [
+  "A11CC03"
+ ],
+ "alfaxalone": [
+  "N01AX05"
+ ],
+ "alfentanil": [
+  "N01AH02"
+ ],
+ "alfuzosin": [
+  "G04CA01"
+ ],
+ "alfuzosin and finasteride": [
+  "G04CA51"
+ ],
+ "algeldrate": [
+  "A02AB02"
+ ],
+ "alginic acid": [
+  "A02BX13"
+ ],
+ "alglucerase": [
+  "A16AB01"
+ ],
+ "alglucosidase alfa": [
+  "A16AB07"
+ ],
+ "alimemazine": [
+  "R06AD01"
+ ],
+ "alipogene tiparvovec": [
+  "C10AX10"
+ ],
+ "alirocumab": [
+  "C10AX14"
+ ],
+ "aliskiren": [
+  "C09XA02"
+ ],
+ "aliskiren and amlodipine": [
+  "C09XA53"
+ ],
+ "aliskiren and hydrochlorothiazide": [
+  "C09XA52"
+ ],
+ "aliskiren, amlodipine and hydrochlorothiazide": [
+  "C09XA54"
+ ],
+ "alitretinoin": [
+  "D11AH04",
+  "L01XF02"
+ ],
+ "alizapride": [
+  "A03FA05"
+ ],
+ "allobarbital": [
+  "N05CA21"
+ ],
+ "allopurinol": [
+  "M04AA01"
+ ],
+ "allopurinol, combinations": [
+  "M04AA51"
+ ],
+ "allylestrenol": [
+  "G03DC01"
+ ],
+ "almagate": [
+  "A02AD03"
+ ],
+ "almasilate": [
+  "A02AD05"
+ ],
+ "alminoprofen": [
+  "M01AE16"
+ ],
+ "almitrine": [
+  "R07AB07"
+ ],
+ "almotriptan": [
+  "N02CC05"
+ ],
+ "alogliptin": [
+  "A10BH04"
+ ],
+ "aloglutamol": [
+  "A02AB06"
+ ],
+ "alosetron": [
+  "A03AE01"
+ ],
+ "aloxiprin": [
+  "B01AC15",
+  "N02BA02"
+ ],
+ "alpelisib": [
+  "L01EM03"
+ ],
+ "alprazolam": [
+  "N05BA12"
+ ],
+ "alprenolol": [
+  "C07AA01"
+ ],
+ "alprostadil": [
+  "C01EA01",
+  "G04BE01"
+ ],
+ "alsactide": [
+  "V04CH04"
+ ],
+ "alteplase": [
+  "B01AD02",
+  "S01XA13"
+ ],
+ "althea root": [
+  "R05CA05"
+ ],
+ "altizide and potassium-sparing agents": [
+  "C03EA04"
+ ],
+ "altretamine": [
+  "L01XX03"
+ ],
+ "alum": [
+  "S01XA07"
+ ],
+ "aluminium acetoacetate": [
+  "A02AB05"
+ ],
+ "aluminium acetotartrate": [
+  "S02AA04"
+ ],
+ "aluminium chloride": [
+  "D10AX01"
+ ],
+ "aluminium chlorohydrate": [
+  "D09AA08",
+  "M05BX02"
+ ],
+ "aluminium clofibrate": [
+  "C10AB03"
+ ],
+ "aluminium glycinate": [
+  "A02AB07"
+ ],
+ "aluminium hydroxide": [
+  "A02AB01"
+ ],
+ "aluminium nicotinate": [
+  "C10AD04"
+ ],
+ "aluminium oxide": [
+  "D10AX04"
+ ],
+ "aluminium phosphate": [
+  "A02AB03"
+ ],
+ "aluminium preparations": [
+  "C05AX01"
+ ],
+ "alverine": [
+  "A03AX08"
+ ],
+ "alverine, combinations": [
+  "A03AX58"
+ ],
+ "alvimopan": [
+  "A06AH02"
+ ],
+ "amantadine": [
+  "N04BB01"
+ ],
+ "ambazone": [
+  "R02AA01"
+ ],
+ "ambenonium": [
+  "N07AA30"
+ ],
+ "ambrisentan": [
+  "C02KX02"
+ ],
+ "ambrisentan and tadalafil": [
+  "C02KX52"
+ ],
+ "ambroxol": [
+  "R02AD05",
+  "R05CB06"
+ ],
+ "ambutonium and psycholeptics": [
+  "A03CA07"
+ ],
+ "amcinonide": [
+  "D07AC11"
+ ],
+ "amenamevir": [
+  "J05AX26"
+ ],
+ "amezinium metilsulfate": [
+  "C01CA25"
+ ],
+ "amfepramone": [
+  "A08AA03"
+ ],
+ "amfetamine": [
+  "N06BA01"
+ ],
+ "amifampridine": [
+  "N07XX05"
+ ],
+ "amifostine": [
+  "V03AF05"
+ ],
+ "amikacin": [
+  "D06AX12",
+  "J01GB06",
+  "S01AA21"
+ ],
+ "amiloride": [
+  "C03DB01"
+ ],
+ "amineptine": [
+  "N06AA19"
+ ],
+ "amino acids": [
+  "B05BA01"
+ ],
+ "amino(diphenylhydantoin) valeric acid": [
+  "N03AB03"
+ ],
+ "aminoacridine": [
+  "D08AA02"
+ ],
+ "aminobenzoate potassium": [
+  "D11AX23"
+ ],
+ "aminobenzoic acid": [
+  "D02BA01"
+ ],
+ "aminobutyric acid": [
+  "N03AG03"
+ ],
+ "aminocaproic acid": [
+  "B02AA01"
+ ],
+ "aminoglutethimide": [
+  "L02BG01"
+ ],
+ "aminohippuric acid": [
+  "V04CH30"
+ ],
+ "aminolevulinic acid": [
+  "L01XD04"
+ ],
+ "aminomethylbenzoic acid": [
+  "B02AA03"
+ ],
+ "aminophenazone": [
+  "N02BB03"
+ ],
+ "aminophenazone, combinations excl. psycholeptics": [
+  "N02BB53"
+ ],
+ "aminophenazone, combinations with psycholeptics": [
+  "N02BB73"
+ ],
+ "aminophylline": [
+  "R03DA05"
+ ],
+ "aminophylline and adrenergics": [
+  "R03DB05"
+ ],
+ "aminophylline, combinations": [
+  "R03DA55"
+ ],
+ "amiodarone": [
+  "C01BD01"
+ ],
+ "amisulpride": [
+  "N05AL05"
+ ],
+ "amitriptyline": [
+  "N06AA09"
+ ],
+ "amitriptyline and psycholeptics": [
+  "N06CA01"
+ ],
+ "amivantamab": [
+  "L01FX18"
+ ],
+ "amlexanox": [
+  "A01AD07",
+  "R03DX01"
+ ],
+ "amlodipine": [
+  "C08CA01"
+ ],
+ "amlodipine and celecoxib": [
+  "C08CA51"
+ ],
+ "amlodipine and diuretics": [
+  "C08GA02"
+ ],
+ "ammonia (13n)": [
+  "V09GX05"
+ ],
+ "ammonium chloride": [
+  "B05XA04",
+  "G04BA01"
+ ],
+ "amobarbital": [
+  "N05CA02"
+ ],
+ "amodiaquine": [
+  "P01BA06"
+ ],
+ "amorolfine": [
+  "D01AE16"
+ ],
+ "amoxapine": [
+  "N06AA17"
+ ],
+ "amoxicillin": [
+  "J01CA04"
+ ],
+ "amoxicillin and beta-lactamase inhibitor": [
+  "J01CR02"
+ ],
+ "amphotericin b": [
+  "A01AB04",
+  "A07AA07",
+  "G01AA03",
+  "J02AA01"
+ ],
+ "ampicillin": [
+  "J01CA01",
+  "S01AA19"
+ ],
+ "ampicillin and beta-lactamase inhibitor": [
+  "J01CR01"
+ ],
+ "ampicillin, combinations": [
+  "J01CA51"
+ ],
+ "amprenavir": [
+  "J05AE05"
+ ],
+ "amrinone": [
+  "C01CE01"
+ ],
+ "amrubicin": [
+  "L01DB10"
+ ],
+ "amsacrine": [
+  "L01XX01"
+ ],
+ "amyl nitrite": [
+  "V03AB22"
+ ],
+ "anagrelide": [
+  "L01XX35"
+ ],
+ "anakinra": [
+  "L04AC03"
+ ],
+ "anastrozole": [
+  "L02BG03"
+ ],
+ "ancestim": [
+  "L03AA12"
+ ],
+ "ancrod": [
+  "B01AD09"
+ ],
+ "andexanet alfa": [
+  "V03AB38"
+ ],
+ "androstanolone": [
+  "A14AA01",
+  "G03BB02"
+ ],
+ "anecortave": [
+  "S01LA02"
+ ],
+ "anethole trithione": [
+  "A16AX02"
+ ],
+ "angiotensin ii": [
+  "C01CX09"
+ ],
+ "angiotensinamide": [
+  "C01CX06"
+ ],
+ "anidulafungin": [
+  "J02AX06"
+ ],
+ "anifrolumab": [
+  "L04AG11"
+ ],
+ "anileridine": [
+  "N01AH05"
+ ],
+ "animals": [
+  "V01AA11"
+ ],
+ "aniracetam": [
+  "N06BX11"
+ ],
+ "anistreplase": [
+  "B01AD03"
+ ],
+ "ansuvimab": [
+  "J06BD04"
+ ],
+ "antazoline": [
+  "R01AC04",
+  "R06AX05"
+ ],
+ "anthrax antigen": [
+  "J07AC01"
+ ],
+ "anthrax immunoglobulin": [
+  "J06BB19"
+ ],
+ "anti-d (rh) immunoglobulin": [
+  "J06BB01"
+ ],
+ "antibiotics in combination with corticosteroids": [
+  "D01AA20"
+ ],
+ "antibiotics in combination with other drugs": [
+  "S01AA20"
+ ],
+ "antiinfectives, combinations": [
+  "S02AA30",
+  "S03AA30"
+ ],
+ "antilymphocyte immunoglobulin (horse)": [
+  "L04AA03"
+ ],
+ "antimony pentasulfide": [
+  "R05CA07"
+ ],
+ "antithrombin iii": [
+  "B01AB02"
+ ],
+ "antithymocyte immunoglobulin (rabbit)": [
+  "L04AA04"
+ ],
+ "apadamtase alfa and cinaxadamtase alfa": [
+  "B01AD13"
+ ],
+ "apalutamide": [
+  "L02BB05"
+ ],
+ "apixaban": [
+  "B01AF02"
+ ],
+ "apomorphine": [
+  "G04BE07",
+  "N04BC07"
+ ],
+ "apraclonidine": [
+  "S01EA03"
+ ],
+ "apremilast": [
+  "L04AA32"
+ ],
+ "aprepitant": [
+  "A04AD12"
+ ],
+ "aprindine": [
+  "C01BB04"
+ ],
+ "aprobarbital": [
+  "N05CA05"
+ ],
+ "aprocitentan": [
+  "C02KN01"
+ ],
+ "apronal": [
+  "N05CM12"
+ ],
+ "aprotinin": [
+  "B02AB01"
+ ],
+ "arbekacin": [
+  "J01GB12"
+ ],
+ "arbutamine": [
+  "C01CA22"
+ ],
+ "argatroban": [
+  "B01AE03"
+ ],
+ "arginine and lysine": [
+  "V03AF11"
+ ],
+ "arginine glutamate": [
+  "A05BA01"
+ ],
+ "arginine hydrochloride": [
+  "B05XB01"
+ ],
+ "arimoclomol": [
+  "N07XX17"
+ ],
+ "aripiprazole": [
+  "N05AX12"
+ ],
+ "armodafinil": [
+  "N06BA13"
+ ],
+ "arpraziquantel": [
+  "P02BA03"
+ ],
+ "arsenic trioxide": [
+  "L01XX27"
+ ],
+ "arsthinol": [
+  "P01AR01"
+ ],
+ "artemether": [
+  "P01BE02"
+ ],
+ "artemether and lumefantrine": [
+  "P01BF01"
+ ],
+ "artemisinin": [
+  "P01BE01"
+ ],
+ "artemisinin and naphthoquine": [
+  "P01BF08"
+ ],
+ "artemisinin and piperaquine": [
+  "P01BF07"
+ ],
+ "artemotil": [
+  "P01BE04"
+ ],
+ "artenimol": [
+  "P01BE05"
+ ],
+ "artenimol and piperaquine": [
+  "P01BF05"
+ ],
+ "arterolane and piperaquine": [
+  "P01BX02"
+ ],
+ "artesunate": [
+  "P01BE03"
+ ],
+ "artesunate and amodiaquine": [
+  "P01BF03"
+ ],
+ "artesunate and mefloquine": [
+  "P01BF02"
+ ],
+ "artesunate and pyronaridine": [
+  "P01BF06"
+ ],
+ "artesunate, sulfadoxine and pyrimethamine": [
+  "P01BF09"
+ ],
+ "artesunate, sulfalene and pyrimethamine": [
+  "P01BF04"
+ ],
+ "articaine": [
+  "N01BB08"
+ ],
+ "articaine, combinations": [
+  "N01BB58"
+ ],
+ "artificial tears and other indifferent preparations": [
+  "S01XA20"
+ ],
+ "asciminib": [
+  "L01EA06"
+ ],
+ "ascorbic acid": [
+  "G01AD03",
+  "S01XA15"
+ ],
+ "ascorbic acid (vit c)": [
+  "A11GA01"
+ ],
+ "ascorbic acid (vit c) and calcium": [
+  "A11GB01"
+ ],
+ "asenapine": [
+  "N05AH05"
+ ],
+ "asfotase alfa": [
+  "A16AB13"
+ ],
+ "asparaginase": [
+  "L01XX02"
+ ],
+ "aspoxicillin": [
+  "J01CA19"
+ ],
+ "astemizole": [
+  "R06AX11"
+ ],
+ "asunaprevir": [
+  "J05AP06"
+ ],
+ "ataluren": [
+  "M09AX03"
+ ],
+ "atazanavir": [
+  "J05AE08"
+ ],
+ "atazanavir and cobicistat": [
+  "J05AR15"
+ ],
+ "atazanavir and ritonavir": [
+  "J05AR23"
+ ],
+ "atenolol": [
+  "C07AB03"
+ ],
+ "atenolol and nifedipine": [
+  "C07FB03"
+ ],
+ "atenolol and other diuretics": [
+  "C07CB03"
+ ],
+ "atenolol and other diuretics, combinations": [
+  "C07CB53"
+ ],
+ "atenolol and thiazides": [
+  "C07BB03"
+ ],
+ "atenolol, thiazides and other diuretics": [
+  "C07DB01"
+ ],
+ "atezolizumab": [
+  "L01FF05"
+ ],
+ "atidarsagene autotemcel": [
+  "A16AB21"
+ ],
+ "atogepant": [
+  "N02CD07"
+ ],
+ "atomoxetine": [
+  "N06BA09"
+ ],
+ "atorvastatin": [
+  "C10AA05"
+ ],
+ "atorvastatin and acetylsalicylic acid": [
+  "C10BX08"
+ ],
+ "atorvastatin and amlodipine": [
+  "C10BX03"
+ ],
+ "atorvastatin and ezetimibe": [
+  "C10BA05"
+ ],
+ "atorvastatin and omega-3 fatty acids": [
+  "C10BA08"
+ ],
+ "atorvastatin and perindopril": [
+  "C10BX15"
+ ],
+ "atorvastatin, acetylsalicylic acid and perindopril": [
+  "C10BX12"
+ ],
+ "atorvastatin, acetylsalicylic acid and ramipril": [
+  "C10BX06"
+ ],
+ "atorvastatin, amlodipine and candesartan": [
+  "C10BX19"
+ ],
+ "atorvastatin, amlodipine and perindopril": [
+  "C10BX11"
+ ],
+ "atorvastatin, amlodipine and ramipril": [
+  "C10BX18"
+ ],
+ "atosiban": [
+  "G02CX01"
+ ],
+ "atovaquone": [
+  "P01AX06"
+ ],
+ "atracurium": [
+  "M03AC04"
+ ],
+ "atropine": [
+  "A03BA01",
+  "S01FA01"
+ ],
+ "atropine and psycholeptics": [
+  "A03CB03"
+ ],
+ "attapulgite": [
+  "A07BC04"
+ ],
+ "attapulgite, combinations": [
+  "A07BC54"
+ ],
+ "aumolertinib": [
+  "L01EB11"
+ ],
+ "auranofin": [
+  "M01CB03"
+ ],
+ "aurothioglucose": [
+  "M01CB04"
+ ],
+ "aurotioprol": [
+  "M01CB05"
+ ],
+ "avacincaptad pegol": [
+  "S01XA32"
+ ],
+ "avacopan": [
+  "L04AJ05"
+ ],
+ "avalglucosidase alfa": [
+  "A16AB22"
+ ],
+ "avanafil": [
+  "G04BE10"
+ ],
+ "avapritinib": [
+  "L01EX18"
+ ],
+ "avatrombopag": [
+  "B02BX08"
+ ],
+ "avelumab": [
+  "L01FF04"
+ ],
+ "avocado and soyabean oil, unsaponifiables": [
+  "M01AX26"
+ ],
+ "axicabtagene ciloleucel": [
+  "L01XL03"
+ ],
+ "axitinib": [
+  "L01EK01"
+ ],
+ "azacitidine": [
+  "L01BC07"
+ ],
+ "azanidazole": [
+  "G01AF13",
+  "P01AB04"
+ ],
+ "azapetine": [
+  "C04AX30"
+ ],
+ "azapropazone": [
+  "M01AX04"
+ ],
+ "azatadine": [
+  "R06AX09"
+ ],
+ "azathioprine": [
+  "L04AX01"
+ ],
+ "azelaic acid": [
+  "D10AX03"
+ ],
+ "azelastine": [
+  "R01AC03",
+  "R06AX19",
+  "S01GX07"
+ ],
+ "azidamfenicol": [
+  "S01AA25"
+ ],
+ "azidocillin": [
+  "J01CE04"
+ ],
+ "azilsartan medoxomil": [
+  "C09CA09"
+ ],
+ "azilsartan medoxomil and diuretics": [
+  "C09DA09"
+ ],
+ "azithromycin": [
+  "J01FA10",
+  "S01AA26"
+ ],
+ "azithromycin, fluconazole and secnidazole": [
+  "J01RA07"
+ ],
+ "azlocillin": [
+  "J01CA09"
+ ],
+ "aztreonam": [
+  "J01DF01"
+ ],
+ "aztreonam and beta-lactamase inhibitor": [
+  "J01DF51"
+ ],
+ "bacampicillin": [
+  "J01CA06"
+ ],
+ "bacitracin": [
+  "D06AX05",
+  "J01XX10",
+  "R02AB04",
+  "S01AA32"
+ ],
+ "baclofen": [
+  "M03BX01"
+ ],
+ "baloxavir marboxil": [
+  "J05AX25"
+ ],
+ "balsalazide": [
+  "A07EC04"
+ ],
+ "balugrastim": [
+  "L03AA15"
+ ],
+ "bambuterol": [
+  "R03CC12"
+ ],
+ "bamethan": [
+  "C04AA31"
+ ],
+ "bamifylline": [
+  "R03DA08"
+ ],
+ "bamipine": [
+  "D04AA15",
+  "R06AX01"
+ ],
+ "barbexaclone": [
+  "N03AA04"
+ ],
+ "barbital": [
+  "N05CA04"
+ ],
+ "barbiturates in combination with other drugs": [
+  "N05CB02"
+ ],
+ "baricitinib": [
+  "L04AF02"
+ ],
+ "barium sulfate with suspending agents": [
+  "V08BA01"
+ ],
+ "barium sulfate without suspending agents": [
+  "V08BA02"
+ ],
+ "barnidipine": [
+  "C08CA12"
+ ],
+ "basiliximab": [
+  "L04AC02"
+ ],
+ "batroxobin": [
+  "B02BX03"
+ ],
+ "bazedoxifene": [
+  "G03XC02"
+ ],
+ "bcg vaccine": [
+  "L03AX03"
+ ],
+ "becaplermin": [
+  "A01AD08",
+  "D03AX06"
+ ],
+ "beclamide": [
+  "N03AX30"
+ ],
+ "beclometasone": [
+  "A07EA07",
+  "D07AC15",
+  "R01AD01",
+  "R03BA01"
+ ],
+ "beclometasone and antibiotics": [
+  "D07CC04"
+ ],
+ "bedaquiline": [
+  "J04AK05"
+ ],
+ "befunolol": [
+  "S01ED06"
+ ],
+ "begelomab": [
+  "L04AG07"
+ ],
+ "beinaglutide": [
+  "A10BJ07"
+ ],
+ "bekanamycin": [
+  "J01GB13"
+ ],
+ "belantamab mafodotin": [
+  "L01FX15"
+ ],
+ "belatacept": [
+  "L04AA28"
+ ],
+ "belimumab": [
+  "L04AG04"
+ ],
+ "belinostat": [
+  "L01XH04"
+ ],
+ "belladonna total alkaloids": [
+  "A03BA04"
+ ],
+ "belladonna total alkaloids and psycholeptics": [
+  "A03CB02"
+ ],
+ "belotecan": [
+  "L01CE04"
+ ],
+ "belumosudil": [
+  "L04AA48"
+ ],
+ "belzutifan": [
+  "L01XX74"
+ ],
+ "bemegride": [
+  "R07AB05"
+ ],
+ "bemiparin": [
+  "B01AB12"
+ ],
+ "bempedoic acid": [
+  "C10AX15"
+ ],
+ "bempedoic acid and ezetimibe": [
+  "C10BA10"
+ ],
+ "benazepril": [
+  "C09AA07"
+ ],
+ "benazepril and amlodipine": [
+  "C09BB13"
+ ],
+ "benazepril and diuretics": [
+  "C09BA07"
+ ],
+ "bencyclane": [
+  "C04AX11"
+ ],
+ "bendamustine": [
+  "L01AA09"
+ ],
+ "bendazac": [
+  "M02AA11",
+  "S01BC07"
+ ],
+ "bendroflumethiazide": [
+  "C03AA01"
+ ],
+ "bendroflumethiazide and potassium": [
+  "C03AB01"
+ ],
+ "bendroflumethiazide and potassium-sparing agents": [
+  "C03EA13"
+ ],
+ "benfluorex": [
+  "A10BX06"
+ ],
+ "benfotiamine": [
+  "A11DA03"
+ ],
+ "benidipine": [
+  "C08CA15"
+ ],
+ "benorilate": [
+  "N02BA10"
+ ],
+ "benoxaprofen": [
+  "M01AE06"
+ ],
+ "benperidol": [
+  "N05AD07"
+ ],
+ "benproperine": [
+  "R05DB02"
+ ],
+ "benralizumab": [
+  "R03DX10"
+ ],
+ "bentazepam": [
+  "N05BA24"
+ ],
+ "bentiromide": [
+  "V04CK03"
+ ],
+ "benzalkonium": [
+  "D08AJ01",
+  "D09AA11",
+  "R02AA16"
+ ],
+ "benzathine benzylpenicillin": [
+  "J01CE08"
+ ],
+ "benzathine phenoxymethylpenicillin": [
+  "J01CE10"
+ ],
+ "benzatropine": [
+  "N04AC01"
+ ],
+ "benzbromarone": [
+  "M04AB03"
+ ],
+ "benzethonium": [
+  "R02AA09"
+ ],
+ "benzethonium chloride": [
+  "D08AJ08"
+ ],
+ "benzethonium chloride, combinations": [
+  "D08AJ58"
+ ],
+ "benzilone": [
+  "A03AB01"
+ ],
+ "benziodarone": [
+  "C01DX04"
+ ],
+ "benziodarone, combinations": [
+  "C01DX54"
+ ],
+ "benznidazole": [
+  "P01CA02"
+ ],
+ "benzocaine": [
+  "C05AD03",
+  "D04AB04",
+  "N01BA05",
+  "R02AD01"
+ ],
+ "benzoctamine": [
+  "N05BD01"
+ ],
+ "benzododecinium": [
+  "D09AA05"
+ ],
+ "benzonatate": [
+  "R05DB01"
+ ],
+ "benzoxonium chloride": [
+  "A01AB14",
+  "D08AJ05"
+ ],
+ "benzoyl peroxide": [
+  "D10AE01"
+ ],
+ "benzoyl peroxide, combinations": [
+  "D10AE51"
+ ],
+ "benzydamine": [
+  "A01AD02",
+  "G02CC03",
+  "M01AX07",
+  "M02AA05",
+  "R02AX03"
+ ],
+ "benzyl alcohol": [
+  "P03AX06"
+ ],
+ "benzyl benzoate": [
+  "P03AX01"
+ ],
+ "benzylpenicillin": [
+  "J01CE01",
+  "S01AA14"
+ ],
+ "benzylthiouracil": [
+  "H03BA03"
+ ],
+ "beperminogene perplasmid": [
+  "C05XX01"
+ ],
+ "bephenium": [
+  "P02CX02"
+ ],
+ "bepridil": [
+  "C08EA02"
+ ],
+ "beraprost": [
+  "B01AC19"
+ ],
+ "beremagene geperpavec": [
+  "D03AX16"
+ ],
+ "bergapten": [
+  "D05BA03"
+ ],
+ "bermekimab": [
+  "L01FX11"
+ ],
+ "berotralstat": [
+  "B06AC06"
+ ],
+ "besifloxacin": [
+  "S01AE08"
+ ],
+ "betacarotene": [
+  "A11CA02",
+  "D02BB01"
+ ],
+ "betahistine": [
+  "N07CA01"
+ ],
+ "betaine": [
+  "A16AA06"
+ ],
+ "betaine hydrochloride": [
+  "A09AB02"
+ ],
+ "betamethasone": [
+  "A07EA04",
+  "C05AA05",
+  "D07AC01",
+  "D07XC01",
+  "H02AB01",
+  "R01AD06",
+  "R03BA04",
+  "S01BA06",
+  "S01CB04",
+  "S02BA07",
+  "S03BA03"
+ ],
+ "betamethasone and antibiotics": [
+  "D07CC01"
+ ],
+ "betamethasone and antiinfectives": [
+  "S01CA05",
+  "S03CA06"
+ ],
+ "betamethasone and antiseptics": [
+  "D07BC01"
+ ],
+ "betamethasone and mydriatics": [
+  "S01BB04"
+ ],
+ "betanidine": [
+  "C02CC01"
+ ],
+ "betaxolol": [
+  "C07AB05",
+  "S01ED02"
+ ],
+ "betaxolol, combinations": [
+  "S01ED52"
+ ],
+ "betazole": [
+  "V04CG02"
+ ],
+ "bethanechol": [
+  "N07AB02"
+ ],
+ "betibeglogene autotemcel": [
+  "B06AX02"
+ ],
+ "betrixaban": [
+  "B01AF04"
+ ],
+ "betulae cortex": [
+  "D03AX13"
+ ],
+ "bevacizumab": [
+  "L01FG01",
+  "S01LA08"
+ ],
+ "bevantolol": [
+  "C07AB06"
+ ],
+ "bevantolol and thiazides": [
+  "C07BB06"
+ ],
+ "bevonium": [
+  "A03AB13"
+ ],
+ "bevonium and analgesics": [
+  "A03DA03"
+ ],
+ "bevonium and psycholeptics": [
+  "A03CA06"
+ ],
+ "bexagliflozin": [
+  "A10BK08"
+ ],
+ "bexarotene": [
+  "L01XF03"
+ ],
+ "bezafibrate": [
+  "C10AB02"
+ ],
+ "bezitramide": [
+  "N02AC05"
+ ],
+ "bezlotoxumab": [
+  "J06BC03"
+ ],
+ "biapenem": [
+  "J01DH05"
+ ],
+ "bibenzonium bromide": [
+  "R05DB12"
+ ],
+ "bibrocathol": [
+  "S01AX05"
+ ],
+ "bicalutamide": [
+  "L02BB03"
+ ],
+ "bietaserpine": [
+  "C02AA07"
+ ],
+ "bietaserpine and diuretics": [
+  "C02LA07"
+ ],
+ "bietaserpine, combinations": [
+  "C02AA57"
+ ],
+ "bifemelane": [
+  "N06AX08"
+ ],
+ "bifikafusp alfa and onfekafusp alfa": [
+  "L01XY04"
+ ],
+ "bifonazole": [
+  "D01AC10"
+ ],
+ "bifonazole, combinations": [
+  "D01AC60"
+ ],
+ "bilastine": [
+  "R06AX29",
+  "S01GX13"
+ ],
+ "bimatoprost": [
+  "S01EE03"
+ ],
+ "bimekizumab": [
+  "L04AC21"
+ ],
+ "binimetinib": [
+  "L01EE03"
+ ],
+ "bioallethrin": [
+  "P03AC02"
+ ],
+ "bioallethrin, combinations": [
+  "P03AC52"
+ ],
+ "biotin": [
+  "A11HA05"
+ ],
+ "biperiden": [
+  "N04AA02"
+ ],
+ "biphenylol": [
+  "D08AE06"
+ ],
+ "bisacodyl": [
+  "A06AB02",
+  "A06AG02"
+ ],
+ "bisacodyl, combinations": [
+  "A06AB52"
+ ],
+ "bismuth preparations, combinations": [
+  "C05AX02"
+ ],
+ "bismuth subcitrate": [
+  "A02BX05"
+ ],
+ "bismuth subcitrate, tetracycline and metronidazole": [
+  "A02BD08"
+ ],
+ "bismuth subnitrate": [
+  "A02BX12"
+ ],
+ "bisoprolol": [
+  "C07AB07"
+ ],
+ "bisoprolol and acetylsalicylic acid": [
+  "C07FX04"
+ ],
+ "bisoprolol and amlodipine": [
+  "C07FB07"
+ ],
+ "bisoprolol and thiazides": [
+  "C07BB07"
+ ],
+ "bisoxatin": [
+  "A06AB09"
+ ],
+ "bithionol": [
+  "D10AB01",
+  "P02BX01"
+ ],
+ "bitolterol": [
+  "R03AC17"
+ ],
+ "bivalirudin": [
+  "B01AE06"
+ ],
+ "bleomycin": [
+  "L01DC01"
+ ],
+ "blinatumomab": [
+  "L01FX07"
+ ],
+ "blood plasma": [
+  "B05AX03"
+ ],
+ "boceprevir": [
+  "J05AP03"
+ ],
+ "bopindolol": [
+  "C07AA17"
+ ],
+ "bopindolol and other diuretics": [
+  "C07CA17"
+ ],
+ "boric acid": [
+  "S02AA03"
+ ],
+ "bornaprine": [
+  "N04AA11"
+ ],
+ "bortezomib": [
+  "L01XG01"
+ ],
+ "bosentan": [
+  "C02KX01"
+ ],
+ "bosutinib": [
+  "L01EA04"
+ ],
+ "botulinum antitoxin": [
+  "J06AA04"
+ ],
+ "botulinum toxin": [
+  "M03AX01"
+ ],
+ "bremelanotide": [
+  "G02CX05"
+ ],
+ "brentuximab vedotin": [
+  "L01FX05"
+ ],
+ "bretylium tosilate": [
+  "C01BD02"
+ ],
+ "brexanolone": [
+  "N06AX29"
+ ],
+ "brexpiprazole": [
+  "N05AX16"
+ ],
+ "brexucabtagene autoleucel": [
+  "L01XL06"
+ ],
+ "briakinumab": [
+  "L04AC09"
+ ],
+ "brigatinib": [
+  "L01ED04"
+ ],
+ "brimonidine": [
+  "D11AX21",
+  "S01EA05",
+  "S01GA07"
+ ],
+ "brimonidine and ripasudil": [
+  "S01EA55"
+ ],
+ "brinase": [
+  "B01AD06"
+ ],
+ "brincidofovir": [
+  "J05AB17"
+ ],
+ "brinzolamide": [
+  "S01EC04"
+ ],
+ "brinzolamide, combinations": [
+  "S01EC54"
+ ],
+ "brivaracetam": [
+  "N03AX23"
+ ],
+ "brivudine": [
+  "J05AB15"
+ ],
+ "brodalumab": [
+  "L04AC12"
+ ],
+ "brodimoprim": [
+  "J01EA02"
+ ],
+ "brolucizumab": [
+  "S01LA06"
+ ],
+ "bromazepam": [
+  "N05BA08"
+ ],
+ "bromazine": [
+  "R06AA01"
+ ],
+ "bromelains": [
+  "D03BA03",
+  "M09AB03"
+ ],
+ "bromfenac": [
+  "S01BC11"
+ ],
+ "bromhexine": [
+  "R05CB02"
+ ],
+ "bromides": [
+  "N05CM11"
+ ],
+ "bromisoval": [
+  "N05CM03"
+ ],
+ "bromochlorosalicylanilide": [
+  "D01AE01"
+ ],
+ "bromocriptine": [
+  "G02CB01",
+  "N04BC01"
+ ],
+ "bromopride": [
+  "A03FA04"
+ ],
+ "bromperidol": [
+  "N05AD06"
+ ],
+ "brompheniramine": [
+  "R06AB01"
+ ],
+ "brompheniramine, combinations": [
+  "R06AB51"
+ ],
+ "brotizolam": [
+  "N05CD09"
+ ],
+ "broxyquinoline": [
+  "A07AX01",
+  "G01AC06",
+  "P01AA01"
+ ],
+ "brucella antigen": [
+  "J07AD01"
+ ],
+ "bucetin": [
+  "N02BE04"
+ ],
+ "bucetin, combinations excl. psycholeptics": [
+  "N02BE54"
+ ],
+ "bucetin, combinations with psycholeptics": [
+  "N02BE74"
+ ],
+ "bucillamine": [
+  "M01CC02"
+ ],
+ "bucladesine": [
+  "C01CE04"
+ ],
+ "buclizine": [
+  "R06AE01"
+ ],
+ "buclizine, combinations": [
+  "R06AE51"
+ ],
+ "budesonide": [
+  "A07EA06",
+  "D07AC09",
+  "R01AD05",
+  "R03BA02"
+ ],
+ "budipine": [
+  "N04BX03"
+ ],
+ "bufexamac": [
+  "M01AB17",
+  "M02AA09"
+ ],
+ "buflomedil": [
+  "C04AX20"
+ ],
+ "buformin": [
+  "A10BA03"
+ ],
+ "bufylline": [
+  "R03DA10"
+ ],
+ "bulevirtide": [
+  "J05AX28"
+ ],
+ "bumadizone": [
+  "M01AB07"
+ ],
+ "bumetanide": [
+  "C03CA02"
+ ],
+ "bumetanide and potassium": [
+  "C03CB02"
+ ],
+ "bumetanide and potassium-sparing agents": [
+  "C03EB02"
+ ],
+ "bunaftine": [
+  "C01BD03"
+ ],
+ "buphenine": [
+  "C04AA02",
+  "G02CA02"
+ ],
+ "bupivacaine": [
+  "N01BB01"
+ ],
+ "bupivacaine and meloxicam": [
+  "N01BB59"
+ ],
+ "bupivacaine, combinations": [
+  "N01BB51"
+ ],
+ "bupranolol": [
+  "C07AA19"
+ ],
+ "buprenorphine": [
+  "N02AE01",
+  "N07BC01"
+ ],
+ "buprenorphine, combinations": [
+  "N07BC51"
+ ],
+ "bupropion": [
+  "N06AX12"
+ ],
+ "bupropion and dextromethorphan": [
+  "N06AX62"
+ ],
+ "bupropion and naltrexone": [
+  "A08AA62"
+ ],
+ "burosumab": [
+  "M05BX05"
+ ],
+ "buserelin": [
+  "L02AE01"
+ ],
+ "buspirone": [
+  "N05BE01"
+ ],
+ "busulfan": [
+  "L01AB01"
+ ],
+ "butalamine": [
+  "C04AX23"
+ ],
+ "butamirate": [
+  "R05DB13"
+ ],
+ "butanilicaine": [
+  "N01BB05"
+ ],
+ "butaperazine": [
+  "N05AB09"
+ ],
+ "butenafine": [
+  "D01AE23"
+ ],
+ "butizide and potassium-sparing agents": [
+  "C03EA14"
+ ],
+ "butobarbital": [
+  "N05CA03"
+ ],
+ "butoconazole": [
+  "G01AF15"
+ ],
+ "butorphanol": [
+  "N02AF01"
+ ],
+ "butriptyline": [
+  "N06AA15"
+ ],
+ "butylscopolamine": [
+  "A03BB01"
+ ],
+ "butylscopolamine and analgesics": [
+  "A03DB04"
+ ],
+ "c1-inhibitor, plasma derived": [
+  "B06AC01"
+ ],
+ "cabazitaxel": [
+  "L01CD04"
+ ],
+ "cabergoline": [
+  "G02CB03",
+  "N04BC06"
+ ],
+ "cabotegravir": [
+  "J05AJ04"
+ ],
+ "cabozantinib": [
+  "L01EX07"
+ ],
+ "cadexomer iodine": [
+  "D03AX01"
+ ],
+ "cadmium compounds": [
+  "D11AC02"
+ ],
+ "cadralazine": [
+  "C02DB04"
+ ],
+ "cafedrine": [
+  "C01CA21"
+ ],
+ "caffeine": [
+  "D11AX26",
+  "N06BC01"
+ ],
+ "caffeine and sodium benzoate": [
+  "V04CG30"
+ ],
+ "calaspargase pegol": [
+  "L01XX86"
+ ],
+ "calcifediol": [
+  "A11CC06",
+  "H05BX05"
+ ],
+ "calcipotriol": [
+  "D05AX02"
+ ],
+ "calcipotriol, combinations": [
+  "D05AX52"
+ ],
+ "calcitonin (human synthetic)": [
+  "H05BA03"
+ ],
+ "calcitonin (pork natural)": [
+  "H05BA02"
+ ],
+ "calcitonin (salmon synthetic)": [
+  "H05BA01"
+ ],
+ "calcitriol": [
+  "A11CC04",
+  "D05AX03"
+ ],
+ "calcium (different salts in combination)": [
+  "A12AA20"
+ ],
+ "calcium acetate": [
+  "V03AE07"
+ ],
+ "calcium acetate and magnesium carbonate": [
+  "V03AE04"
+ ],
+ "calcium alginate": [
+  "B02BC08"
+ ],
+ "calcium aminosalicylate": [
+  "J04AA03"
+ ],
+ "calcium carbimide": [
+  "N07BB02"
+ ],
+ "calcium carbonate": [
+  "A02AC01",
+  "A12AA04"
+ ],
+ "calcium chloride": [
+  "A12AA07",
+  "B05XA07",
+  "G04BA03"
+ ],
+ "calcium citrate": [
+  "A12AA13"
+ ],
+ "calcium citrate lysine complex": [
+  "A12AA09"
+ ],
+ "calcium compounds": [
+  "A07XA03"
+ ],
+ "calcium dobesilate": [
+  "C05BX01"
+ ],
+ "calcium dobesilate, combinations": [
+  "C05BX51"
+ ],
+ "calcium folinate": [
+  "V03AF03"
+ ],
+ "calcium glubionate": [
+  "A12AA02"
+ ],
+ "calcium glucoheptonate": [
+  "A12AA10"
+ ],
+ "calcium gluconate": [
+  "A12AA03",
+  "B05XA19",
+  "D11AX03"
+ ],
+ "calcium glycerylphosphate": [
+  "A12AA08"
+ ],
+ "calcium hexamine thiocyanate": [
+  "R01AX01"
+ ],
+ "calcium iopodate": [
+  "V08AC10"
+ ],
+ "calcium lactate": [
+  "A12AA05"
+ ],
+ "calcium lactate gluconate": [
+  "A12AA06"
+ ],
+ "calcium laevulate": [
+  "A12AA30"
+ ],
+ "calcium levofolinate": [
+  "V03AF04"
+ ],
+ "calcium pangamate": [
+  "A12AA11"
+ ],
+ "calcium pantothenate": [
+  "A11HA31",
+  "D03AX04"
+ ],
+ "calcium phosphate": [
+  "A12AA01"
+ ],
+ "calcium silicate": [
+  "A02AC02"
+ ],
+ "camazepam": [
+  "N05BA15"
+ ],
+ "camostat": [
+  "B02AB04"
+ ],
+ "camphora": [
+  "C01EB02"
+ ],
+ "camylofin": [
+  "A03AA03"
+ ],
+ "camylofin and analgesics": [
+  "A03DA05"
+ ],
+ "canagliflozin": [
+  "A10BK02"
+ ],
+ "canakinumab": [
+  "L04AC08"
+ ],
+ "candesartan": [
+  "C09CA06"
+ ],
+ "candesartan and amlodipine": [
+  "C09DB07"
+ ],
+ "candesartan and diuretics": [
+  "C09DA06"
+ ],
+ "candesartan, amlodipine and hydrochlorothiazide": [
+  "C09DX06"
+ ],
+ "candicidin": [
+  "G01AA04"
+ ],
+ "cangrelor": [
+  "B01AC25"
+ ],
+ "cannabidiol": [
+  "N03AX24"
+ ],
+ "cannabinoids": [
+  "N02BG10"
+ ],
+ "canrenone": [
+  "C03DA03"
+ ],
+ "capecitabine": [
+  "L01BC06"
+ ],
+ "capivasertib": [
+  "L01EX27"
+ ],
+ "caplacizumab": [
+  "B01AX07"
+ ],
+ "capmatinib": [
+  "L01EX17"
+ ],
+ "capreomycin": [
+  "J04AB30"
+ ],
+ "capsaicin": [
+  "M02AB01",
+  "N01BX04"
+ ],
+ "captodiame": [
+  "N05BB02"
+ ],
+ "captopril": [
+  "C09AA01"
+ ],
+ "captopril and diuretics": [
+  "C09BA01"
+ ],
+ "carbachol": [
+  "N07AB01",
+  "S01EB02"
+ ],
+ "carbamazepine": [
+  "N03AF01"
+ ],
+ "carbamide": [
+  "B05BC02",
+  "D02AE01"
+ ],
+ "carbamide, combinations": [
+  "D02AE51"
+ ],
+ "carbasalate calcium": [
+  "B01AC08",
+  "N02BA15"
+ ],
+ "carbasalate calcium combinations excl. psycholeptics": [
+  "N02BA65"
+ ],
+ "carbazochrome": [
+  "B02BX02"
+ ],
+ "carbenicillin": [
+  "J01CA03"
+ ],
+ "carbenoxolone": [
+  "A02BX01"
+ ],
+ "carbenoxolone, combinations excl. psycholeptics": [
+  "A02BX51"
+ ],
+ "carbenoxolone, combinations with psycholeptics": [
+  "A02BX71"
+ ],
+ "carbetocin": [
+  "H01BB03"
+ ],
+ "carbimazole": [
+  "H03BB01"
+ ],
+ "carbinoxamine": [
+  "R06AA08"
+ ],
+ "carbocisteine": [
+  "R05CB03"
+ ],
+ "carbocromen": [
+  "C01DX05"
+ ],
+ "carbohydrates": [
+  "B05BA03"
+ ],
+ "carbon dioxide": [
+  "V03AN02"
+ ],
+ "carbon dioxide producing drugs": [
+  "A06AX02"
+ ],
+ "carbon monoxide": [
+  "V04CX08"
+ ],
+ "carboplatin": [
+  "L01XA02"
+ ],
+ "carboprost": [
+  "G02AD04"
+ ],
+ "carboquone": [
+  "L01AC03"
+ ],
+ "carbromal": [
+  "N05CM04"
+ ],
+ "carbutamide": [
+  "A10BB06"
+ ],
+ "carbuterol": [
+  "R03AC10",
+  "R03CC10"
+ ],
+ "cardioplegia solutions": [
+  "B05XA16"
+ ],
+ "carfecillin": [
+  "G01AA08"
+ ],
+ "carfilzomib": [
+  "L01XG02"
+ ],
+ "carfloglitazar": [
+  "A10BX17"
+ ],
+ "carglumic acid": [
+  "A16AA05"
+ ],
+ "carindacillin": [
+  "J01CA05"
+ ],
+ "cariprazine": [
+  "N05AX15"
+ ],
+ "carisbamate": [
+  "N03AX19"
+ ],
+ "carisoprodol": [
+  "M03BA02"
+ ],
+ "carisoprodol, combinations excl. psycholeptics": [
+  "M03BA52"
+ ],
+ "carisoprodol, combinations with psycholeptics": [
+  "M03BA72"
+ ],
+ "carmofur": [
+  "L01BC04"
+ ],
+ "carmustine": [
+  "L01AD01"
+ ],
+ "caroverine": [
+  "A03AX11"
+ ],
+ "carteolol": [
+  "C07AA15",
+  "S01ED05"
+ ],
+ "carteolol, combinations": [
+  "S01ED55"
+ ],
+ "carumonam": [
+  "J01DF02"
+ ],
+ "carvedilol": [
+  "C07AG02"
+ ],
+ "carvedilol and ivabradine": [
+  "C07FX06"
+ ],
+ "cascara": [
+  "A06AB07"
+ ],
+ "cascara, combinations": [
+  "A06AB57"
+ ],
+ "casimersen": [
+  "M09AX13"
+ ],
+ "casirivimab and imdevimab": [
+  "J06BD07"
+ ],
+ "casopitant": [
+  "A04AD13"
+ ],
+ "caspofungin": [
+  "J02AX04"
+ ],
+ "castor oil": [
+  "A06AB05"
+ ],
+ "cathine": [
+  "A08AA07"
+ ],
+ "cation exchange resins": [
+  "V04CG01"
+ ],
+ "catridecacog": [
+  "B02BD11"
+ ],
+ "catumaxomab": [
+  "L01FX03"
+ ],
+ "cediranib": [
+  "L01EK02"
+ ],
+ "cefacetrile": [
+  "J01DB10"
+ ],
+ "cefaclor": [
+  "J01DC04"
+ ],
+ "cefadroxil": [
+  "J01DB05"
+ ],
+ "cefalexin": [
+  "J01DB01"
+ ],
+ "cefaloridine": [
+  "J01DB02"
+ ],
+ "cefalotin": [
+  "J01DB03"
+ ],
+ "cefamandole": [
+  "J01DC03"
+ ],
+ "cefapirin": [
+  "J01DB08"
+ ],
+ "cefatrizine": [
+  "J01DB07"
+ ],
+ "cefazedone": [
+  "J01DB06"
+ ],
+ "cefazolin": [
+  "J01DB04"
+ ],
+ "cefbuperazone": [
+  "J01DC13"
+ ],
+ "cefcapene": [
+  "J01DD17"
+ ],
+ "cefdinir": [
+  "J01DD15"
+ ],
+ "cefditoren": [
+  "J01DD16"
+ ],
+ "cefepime": [
+  "J01DE01"
+ ],
+ "cefepime and amikacin": [
+  "J01RA06"
+ ],
+ "cefepime and beta-lactamase inhibitor": [
+  "J01DE51"
+ ],
+ "cefetamet": [
+  "J01DD10"
+ ],
+ "cefiderocol": [
+  "J01DI04"
+ ],
+ "cefixime": [
+  "J01DD08"
+ ],
+ "cefixime and azithromycin": [
+  "J01RA16"
+ ],
+ "cefixime and beta-lactamase inhibitor": [
+  "J01DD58"
+ ],
+ "cefixime and ornidazole": [
+  "J01RA15"
+ ],
+ "cefmenoxime": [
+  "J01DD05",
+  "S01AA31",
+  "S02AA18"
+ ],
+ "cefmetazole": [
+  "J01DC09"
+ ],
+ "cefminox": [
+  "J01DC12"
+ ],
+ "cefodizime": [
+  "J01DD09"
+ ],
+ "cefonicid": [
+  "J01DC06"
+ ],
+ "cefoperazone": [
+  "J01DD12"
+ ],
+ "cefoperazone and beta-lactamase inhibitor": [
+  "J01DD62"
+ ],
+ "ceforanide": [
+  "J01DC11"
+ ],
+ "cefotaxime": [
+  "J01DD01"
+ ],
+ "cefotaxime and beta-lactamase inhibitor": [
+  "J01DD51"
+ ],
+ "cefotetan": [
+  "J01DC05"
+ ],
+ "cefotiam": [
+  "J01DC07"
+ ],
+ "cefoxitin": [
+  "J01DC01"
+ ],
+ "cefozopran": [
+  "J01DE03"
+ ],
+ "cefpiramide": [
+  "J01DD11"
+ ],
+ "cefpirome": [
+  "J01DE02"
+ ],
+ "cefpodoxime": [
+  "J01DD13"
+ ],
+ "cefpodoxime and beta-lactamase inhibitor": [
+  "J01DD64"
+ ],
+ "cefprozil": [
+  "J01DC10"
+ ],
+ "cefradine": [
+  "J01DB09"
+ ],
+ "cefroxadine": [
+  "J01DB11"
+ ],
+ "cefsulodin": [
+  "J01DD03"
+ ],
+ "ceftaroline fosamil": [
+  "J01DI02"
+ ],
+ "ceftazidime": [
+  "J01DD02"
+ ],
+ "ceftazidime and beta-lactamase inhibitor": [
+  "J01DD52"
+ ],
+ "cefteram": [
+  "J01DD18"
+ ],
+ "ceftezole": [
+  "J01DB12"
+ ],
+ "ceftibuten": [
+  "J01DD14"
+ ],
+ "ceftizoxime": [
+  "J01DD07"
+ ],
+ "ceftobiprole medocaril": [
+  "J01DI01"
+ ],
+ "ceftolozane and beta-lactamase inhibitor": [
+  "J01DI54"
+ ],
+ "ceftriaxone": [
+  "J01DD04"
+ ],
+ "ceftriaxone and beta-lactamase inhibitor": [
+  "J01DD63"
+ ],
+ "ceftriaxone, combinations": [
+  "J01DD54"
+ ],
+ "cefuroxime": [
+  "J01DC02",
+  "S01AA27"
+ ],
+ "cefuroxime and beta-lactamase inhibitor": [
+  "J01DC52"
+ ],
+ "cefuroxime and metronidazole": [
+  "J01RA03"
+ ],
+ "celecoxib": [
+  "L01XX33",
+  "M01AH01"
+ ],
+ "celiprolol": [
+  "C07AB08"
+ ],
+ "cemiplimab": [
+  "L01FF06"
+ ],
+ "cenegermin": [
+  "S01XA24"
+ ],
+ "cenobamate": [
+  "N03AX25"
+ ],
+ "centella asiatica herba, incl. combinations": [
+  "D03AX14"
+ ],
+ "centhaquine": [
+  "C01CA28"
+ ],
+ "cepeginterferon alfa-2b": [
+  "L03AB14"
+ ],
+ "ceratonia": [
+  "A07XA02"
+ ],
+ "ceritinib": [
+  "L01ED02"
+ ],
+ "cerium oxalate": [
+  "A04AD02"
+ ],
+ "cerivastatin": [
+  "C10AA06"
+ ],
+ "cerliponase alfa": [
+  "A16AB17"
+ ],
+ "certolizumab pegol": [
+  "L04AB05"
+ ],
+ "ceruletide": [
+  "V04CC04"
+ ],
+ "cetiedil": [
+  "C04AX26"
+ ],
+ "cetirizine": [
+  "R06AE07",
+  "S01GX12"
+ ],
+ "cetrimide": [
+  "D08AJ04",
+  "D11AC01"
+ ],
+ "cetrimonium": [
+  "D08AJ02",
+  "R02AA17"
+ ],
+ "cetrorelix": [
+  "H01CC02"
+ ],
+ "cetuximab": [
+  "L01FE01"
+ ],
+ "cetylpyridinium": [
+  "B05CA01",
+  "D08AJ03",
+  "D09AA07",
+  "R02AA06"
+ ],
+ "cevimeline": [
+  "N07AX03"
+ ],
+ "chenodeoxycholic acid": [
+  "A05AA01"
+ ],
+ "chiniofon": [
+  "P01AX01"
+ ],
+ "chloral hydrate": [
+  "N05CC01"
+ ],
+ "chloralodol": [
+  "N05CC02"
+ ],
+ "chlorambucil": [
+  "L01AA02"
+ ],
+ "chloramphenicol": [
+  "D06AX02",
+  "D10AF03",
+  "G01AA05",
+  "J01BA01",
+  "S01AA01",
+  "S02AA01",
+  "S03AA08"
+ ],
+ "chlorbenzoxamine": [
+  "A03AX03"
+ ],
+ "chlorcyclizine": [
+  "R06AE04"
+ ],
+ "chlordiazepoxide": [
+  "N05BA02"
+ ],
+ "chlorhexidine": [
+  "A01AB03",
+  "B05CA02",
+  "D08AC02",
+  "D09AA12",
+  "R02AA05",
+  "S01AX09",
+  "S02AA09",
+  "S03AA04"
+ ],
+ "chlorhexidine and cetylpyridinium": [
+  "A01AB53"
+ ],
+ "chlorhexidine, combinations": [
+  "D08AC52"
+ ],
+ "chlormadinone": [
+  "G03DB06"
+ ],
+ "chlormadinone and estrogen": [
+  "G03FB03"
+ ],
+ "chlormadinone and ethinylestradiol": [
+  "G03AA15",
+  "G03AB07"
+ ],
+ "chlormethine": [
+  "L01AA05"
+ ],
+ "chlormezanone": [
+  "M03BB02"
+ ],
+ "chlormezanone, combinations excl. psycholeptics": [
+  "M03BB52"
+ ],
+ "chlormezanone, combinations with psycholeptics": [
+  "M03BB72"
+ ],
+ "chlormidazole": [
+  "D01AC04"
+ ],
+ "chlorobutanol": [
+  "A04AD04"
+ ],
+ "chlorobutanol, combinations": [
+  "A04AD54"
+ ],
+ "chloroform": [
+  "N01AB02"
+ ],
+ "chloroprednisone and antiinfectives": [
+  "S01CA09"
+ ],
+ "chloroprocaine": [
+  "N01BA04",
+  "S01HA08"
+ ],
+ "chloropyramine": [
+  "D04AA09",
+  "R06AC03"
+ ],
+ "chloropyramine, combinations": [
+  "R06AC53"
+ ],
+ "chloroquine": [
+  "P01BA01"
+ ],
+ "chloroquine and proguanil": [
+  "P01BB52"
+ ],
+ "chlorothiazide": [
+  "C03AA04"
+ ],
+ "chlorothiazide and potassium": [
+  "C03AB04"
+ ],
+ "chlorothiazide, combinations": [
+  "C03AH01"
+ ],
+ "chlorotrianisene": [
+  "G03CA06"
+ ],
+ "chloroxylenol": [
+  "D08AE05"
+ ],
+ "chlorphenamine": [
+  "R06AB04"
+ ],
+ "chlorphenamine, combinations": [
+  "R06AB54"
+ ],
+ "chlorphenesin": [
+  "D01AE07"
+ ],
+ "chlorphenoxamine": [
+  "D04AA34",
+  "R06AA06"
+ ],
+ "chlorphenoxamine, combinations": [
+  "R06AA56"
+ ],
+ "chlorproethazine": [
+  "N05AA07"
+ ],
+ "chlorpromazine": [
+  "N05AA01"
+ ],
+ "chlorpropamide": [
+  "A10BB02"
+ ],
+ "chlorprothixene": [
+  "N05AF03"
+ ],
+ "chlorquinaldol": [
+  "D08AH02",
+  "G01AC03",
+  "P01AA04",
+  "R02AA11"
+ ],
+ "chlortalidone": [
+  "C03BA04"
+ ],
+ "chlortalidone and potassium": [
+  "C03BB04"
+ ],
+ "chlortalidone and potassium-sparing agents": [
+  "C03EA06"
+ ],
+ "chlortetracycline": [
+  "A01AB21",
+  "D06AA02",
+  "J01AA03",
+  "S01AA02"
+ ],
+ "chlorzoxazone": [
+  "M03BB03"
+ ],
+ "chlorzoxazone, combinations excl. psycholeptics": [
+  "M03BB53"
+ ],
+ "chlorzoxazone, combinations with psycholeptics": [
+  "M03BB73"
+ ],
+ "cholera, combinations with typhoid vaccine, inactivated, whole cell": [
+  "J07AE51"
+ ],
+ "cholera, inactivated, whole cell": [
+  "J07AE01"
+ ],
+ "cholera, live attenuated": [
+  "J07AE02"
+ ],
+ "cholic acid": [
+  "A05AA03"
+ ],
+ "choline alfoscerate": [
+  "N07AX02"
+ ],
+ "choline fenofibrate": [
+  "C10AB11"
+ ],
+ "choline salicylate": [
+  "N02BA03"
+ ],
+ "choline theophyllinate": [
+  "R03DA02"
+ ],
+ "choline theophyllinate and adrenergics": [
+  "R03DB02"
+ ],
+ "cholinesterase": [
+  "V03AB29"
+ ],
+ "chondrocytes, autologous": [
+  "M09AX02"
+ ],
+ "chondroitin sulfate": [
+  "M01AX25"
+ ],
+ "chondroitin sulfate-iron complex": [
+  "B03AB07"
+ ],
+ "choriogonadotropin alfa": [
+  "G03GA08"
+ ],
+ "chorionic gonadotrophin": [
+  "G03GA01"
+ ],
+ "chromium (51cr) chromate labelled cells": [
+  "V09GX03"
+ ],
+ "chromium (51cr) edetate": [
+  "V09CX04"
+ ],
+ "chymopapain": [
+  "M09AB01"
+ ],
+ "chymotrypsin": [
+  "B06AA04",
+  "S01KX01"
+ ],
+ "cibenzoline": [
+  "C01BG07"
+ ],
+ "ciclesonide": [
+  "R01AD13",
+  "R03BA08"
+ ],
+ "cicletanine": [
+  "C03BX03"
+ ],
+ "ciclobendazole": [
+  "P02CA04"
+ ],
+ "ciclonicate": [
+  "C04AC07"
+ ],
+ "ciclonium and analgesics": [
+  "A03DA04"
+ ],
+ "ciclopirox": [
+  "D01AE14",
+  "G01AX12"
+ ],
+ "ciclosporin": [
+  "L04AD01",
+  "S01XA18"
+ ],
+ "cidofovir": [
+  "J05AB12"
+ ],
+ "cilansetron": [
+  "A03AE03"
+ ],
+ "cilazapril": [
+  "C09AA08"
+ ],
+ "cilazapril and diuretics": [
+  "C09BA08"
+ ],
+ "cilnidipine": [
+  "C08CA14"
+ ],
+ "cilostazol": [
+  "B01AC23"
+ ],
+ "ciltacabtagene autoleucel": [
+  "L01XL05"
+ ],
+ "cimetidine": [
+  "A02BA01"
+ ],
+ "cimetidine, combinations": [
+  "A02BA51"
+ ],
+ "cimetropium bromide": [
+  "A03BB05"
+ ],
+ "cimicifugae rhizoma": [
+  "G02CX04"
+ ],
+ "cinacalcet": [
+  "H05BX01"
+ ],
+ "cinchocaine": [
+  "C05AD04",
+  "D04AB02",
+  "N01BB06",
+  "S01HA06",
+  "S02DA04"
+ ],
+ "cinchophen": [
+  "M04AC02"
+ ],
+ "cineole": [
+  "R05CA13"
+ ],
+ "cinepazet": [
+  "C01DX14"
+ ],
+ "cinepazide": [
+  "C04AX27"
+ ],
+ "cinitapride": [
+  "A03FA08"
+ ],
+ "cinnarizine": [
+  "N07CA02"
+ ],
+ "cinnarizine, combinations": [
+  "N07CA52"
+ ],
+ "cinolazepam": [
+  "N05CD13"
+ ],
+ "cinoxacin": [
+  "J01MB06"
+ ],
+ "cipaglucosidase alfa": [
+  "A16AB23"
+ ],
+ "ciprofibrate": [
+  "C10AB08"
+ ],
+ "ciprofloxacin": [
+  "J01MA02",
+  "S01AE03",
+  "S02AA15",
+  "S03AA07"
+ ],
+ "ciprofloxacin and metronidazole": [
+  "J01RA10"
+ ],
+ "ciprofloxacin and ornidazole": [
+  "J01RA12"
+ ],
+ "ciprofloxacin and tinidazole": [
+  "J01RA11"
+ ],
+ "cisapride": [
+  "A03FA02"
+ ],
+ "cisatracurium": [
+  "M03AC11"
+ ],
+ "cisplatin": [
+  "L01XA01"
+ ],
+ "citalopram": [
+  "N06AB04"
+ ],
+ "citicoline": [
+  "N06BX06"
+ ],
+ "citiolone": [
+  "A05BA04"
+ ],
+ "citric acid": [
+  "A09AB04"
+ ],
+ "cladribine": [
+  "L01BB04",
+  "L04AA40"
+ ],
+ "clarithromycin": [
+  "J01FA09"
+ ],
+ "clascoterone": [
+  "D10AX06"
+ ],
+ "clazosentan": [
+  "C04AX33"
+ ],
+ "clebopride": [
+  "A03FA06"
+ ],
+ "clefamide": [
+  "P01AC02"
+ ],
+ "clemastine": [
+  "D04AA14",
+  "R06AA04"
+ ],
+ "clemastine, combinations": [
+  "R06AA54"
+ ],
+ "clenbuterol": [
+  "R03AC14",
+  "R03CC13"
+ ],
+ "clenbuterol and ambroxol": [
+  "R03CC63"
+ ],
+ "clevidipine": [
+  "C08CA16"
+ ],
+ "clevudine": [
+  "J05AF12"
+ ],
+ "clidinium and psycholeptics": [
+  "A03CA02"
+ ],
+ "clindamycin": [
+  "D10AF01",
+  "G01AA10",
+  "J01FF01"
+ ],
+ "clindamycin, combinations": [
+  "D10AF51"
+ ],
+ "clioquinol": [
+  "D08AH30",
+  "D09AA10",
+  "G01AC02",
+  "P01AA02",
+  "S02AA05"
+ ],
+ "clioquinol, combinations": [
+  "P01AA52"
+ ],
+ "clobazam": [
+  "N05BA09"
+ ],
+ "clobenzorex": [
+  "A08AA08"
+ ],
+ "clobetasol": [
+  "D07AD01"
+ ],
+ "clobetasol and antibiotics": [
+  "D07CD01"
+ ],
+ "clobetasone": [
+  "D07AB01",
+  "S01BA09"
+ ],
+ "clobetasone and antiinfectives": [
+  "S01CA11"
+ ],
+ "clobutinol": [
+  "R05DB03"
+ ],
+ "clocortolone": [
+  "D07AB21"
+ ],
+ "clodantoin": [
+  "G01AX01"
+ ],
+ "clodronic acid": [
+  "M05BA02"
+ ],
+ "clofarabine": [
+  "L01BB06"
+ ],
+ "clofazimine": [
+  "J04BA01"
+ ],
+ "clofedanol": [
+  "R05DB10"
+ ],
+ "clofenamide": [
+  "C03BA07"
+ ],
+ "clofenamide and potassium": [
+  "C03BB07"
+ ],
+ "clofenotane": [
+  "P03AB01"
+ ],
+ "clofenotane, combinations": [
+  "P03AB51"
+ ],
+ "clofezone": [
+  "M01AA05",
+  "M02AA03"
+ ],
+ "clofibrate": [
+  "C10AB01"
+ ],
+ "clofibride": [
+  "C10AB10"
+ ],
+ "clofoctol": [
+  "J01XX03"
+ ],
+ "clomethiazole": [
+  "N05CM02"
+ ],
+ "clomethiazole, combinations": [
+  "N05CX04"
+ ],
+ "clometocillin": [
+  "J01CE07"
+ ],
+ "clomifene": [
+  "G03GB02"
+ ],
+ "clomipramine": [
+  "N06AA04"
+ ],
+ "clomocycline": [
+  "J01AA11"
+ ],
+ "clonazepam": [
+  "N03AE01"
+ ],
+ "clonidine": [
+  "C02AC01",
+  "N02CX02",
+  "S01EA04"
+ ],
+ "clonidine and diuretics": [
+  "C02LC01"
+ ],
+ "clonidine and diuretics, combinations with other drugs": [
+  "C02LC51"
+ ],
+ "clopamide": [
+  "C03BA03"
+ ],
+ "clopamide and potassium": [
+  "C03BB03"
+ ],
+ "clopenthixol": [
+  "N05AF02"
+ ],
+ "cloperastine": [
+  "R05DB21"
+ ],
+ "clopidogrel": [
+  "B01AC04"
+ ],
+ "cloprednol": [
+  "H02AB14"
+ ],
+ "cloranolol": [
+  "C07AA27"
+ ],
+ "clorexolone": [
+  "C03BA12"
+ ],
+ "clorexolone, combinations with psycholeptics": [
+  "C03BA82"
+ ],
+ "cloricromen": [
+  "B01AC02"
+ ],
+ "cloridarol": [
+  "C01DX15"
+ ],
+ "clorindione": [
+  "B01AA09"
+ ],
+ "clotiapine": [
+  "N05AH06"
+ ],
+ "clotiazepam": [
+  "N05BA21"
+ ],
+ "clotrimazole": [
+  "A01AB18",
+  "D01AC01",
+  "G01AF02"
+ ],
+ "cloxacillin": [
+  "J01CF02"
+ ],
+ "cloxazolam": [
+  "N05BA22"
+ ],
+ "clozapine": [
+  "N05AH02"
+ ],
+ "coagulation factor ix": [
+  "B02BD04"
+ ],
+ "coagulation factor ix, ii, vii and x in combination": [
+  "B02BD01"
+ ],
+ "coagulation factor vii": [
+  "B02BD05"
+ ],
+ "coagulation factor viia": [
+  "B02BD08"
+ ],
+ "coagulation factor viii": [
+  "B02BD02"
+ ],
+ "coagulation factor x": [
+  "B02BD13"
+ ],
+ "coagulation factor xiii": [
+  "B02BD07"
+ ],
+ "cobalt (57co) cyanocobalamine": [
+  "V09XX01"
+ ],
+ "cobalt (58co) cyanocobalamine": [
+  "V09XX02"
+ ],
+ "cobamamide": [
+  "B03BA04"
+ ],
+ "cobicistat": [
+  "V03AX03"
+ ],
+ "cobimetinib": [
+  "L01EE02"
+ ],
+ "coblopasvir": [
+  "J05AP12"
+ ],
+ "cocaine": [
+  "N01BC01",
+  "R02AD03",
+  "S01HA01",
+  "S02DA02"
+ ],
+ "codeine": [
+  "R05DA04"
+ ],
+ "codeine and acetylsalicylic acid": [
+  "N02AJ07"
+ ],
+ "codeine and ibuprofen": [
+  "N02AJ08"
+ ],
+ "codeine and other non-opioid analgesics": [
+  "N02AJ09"
+ ],
+ "codeine and paracetamol": [
+  "N02AJ06"
+ ],
+ "codeine, combinations excl. psycholeptics": [
+  "N02AA59"
+ ],
+ "codeine, combinations with psycholeptics": [
+  "N02AA79"
+ ],
+ "colchicine": [
+  "M04AC01"
+ ],
+ "colchicine and probenecid": [
+  "M04AC51"
+ ],
+ "colecalciferol": [
+  "A11CC05"
+ ],
+ "colecalciferol, combinations": [
+  "A11CC55"
+ ],
+ "colesevelam": [
+  "C10AC04"
+ ],
+ "colestilan": [
+  "V03AE06"
+ ],
+ "colestipol": [
+  "C10AC02"
+ ],
+ "colestyramine": [
+  "C10AC01"
+ ],
+ "colextran": [
+  "C10AC03"
+ ],
+ "colfosceril palmitate": [
+  "R07AA01"
+ ],
+ "colistin": [
+  "A07AA10",
+  "J01XB01"
+ ],
+ "collagen": [
+  "B02BC07",
+  "G04BX11"
+ ],
+ "collagen, combinations": [
+  "D11AX57"
+ ],
+ "collagenase": [
+  "D03BA02"
+ ],
+ "collagenase clostridium histolyticum": [
+  "M09AB02"
+ ],
+ "collagenase, combinations": [
+  "D03BA52"
+ ],
+ "combination of rauwolfia alkaloids and diuretics incl. other combinations": [
+  "C02LA50"
+ ],
+ "combinations": [
+  "A01AA30",
+  "A02AA10",
+  "A02AB10",
+  "A02AC10",
+  "A06AG20",
+  "A07BC30",
+  "A10AB30",
+  "A10AC30",
+  "A10AD30",
+  "A10AE30",
+  "A11CC20",
+  "B01AC30",
+  "B02BC30",
+  "B05BA10",
+  "B05CA10",
+  "B05CB10",
+  "B05CX10",
+  "C01CA30",
+  "D01AE20",
+  "G03GA30",
+  "G04BE30",
+  "J01CA20",
+  "J01CE30",
+  "J01EB20",
+  "J01EC20",
+  "J01ED20",
+  "J06BB30",
+  "J07BC20",
+  "N01BB20",
+  "N06DX30",
+  "R01AX30",
+  "R05CA10",
+  "R05CB10",
+  "R05DA20",
+  "R05DB20",
+  "R07AA30",
+  "S01HA30",
+  "S02DA30"
+ ],
+ "combinations of barbiturates": [
+  "N05CB01"
+ ],
+ "combinations of corticosteroids": [
+  "D07AB30",
+  "D07XB30"
+ ],
+ "combinations of different antibiotics": [
+  "S01AA30"
+ ],
+ "combinations of electrolytes": [
+  "B05XA30"
+ ],
+ "combinations of imidazole derivatives": [
+  "G01AF20"
+ ],
+ "combinations of levothyroxine and liothyronine": [
+  "H03AA03"
+ ],
+ "combinations of penicillins": [
+  "J01CR50"
+ ],
+ "combinations of rauwolfia alkaloids": [
+  "C02AA03"
+ ],
+ "combinations of rauwolfia alkoloids, combinations": [
+  "C02AA53"
+ ],
+ "combinations of sulfonamides": [
+  "G01AE10"
+ ],
+ "combinations of tetracyclines": [
+  "J01AA20"
+ ],
+ "combinations of xanthines": [
+  "R03DA20"
+ ],
+ "concizumab": [
+  "B02BX10"
+ ],
+ "conestat alfa": [
+  "B06AC04"
+ ],
+ "conivaptan": [
+  "C03XA02"
+ ],
+ "conjugated estrogens": [
+  "G03CA57"
+ ],
+ "conjugated estrogens and bazedoxifene": [
+  "G03CC07"
+ ],
+ "contact laxatives in combination": [
+  "A06AB20"
+ ],
+ "contact laxatives in combination with belladonna alkaloids": [
+  "A06AB30"
+ ],
+ "copanlisib": [
+  "L01EM02"
+ ],
+ "copper (64cu) dotatate": [
+  "V09IX15"
+ ],
+ "copper oleinate": [
+  "P03AX02"
+ ],
+ "copper sulfate": [
+  "V03AB20"
+ ],
+ "copper usnate": [
+  "G01AX15"
+ ],
+ "corifollitropin alfa": [
+  "G03GA09"
+ ],
+ "corticorelin": [
+  "V04CD04"
+ ],
+ "corticotropin": [
+  "H01AA01"
+ ],
+ "cortisone": [
+  "H02AB10",
+  "S01BA03"
+ ],
+ "cortivazol": [
+  "H02AB17"
+ ],
+ "cough suppressants and expectorants": [
+  "R05FB02"
+ ],
+ "cough suppressants and mucolytics": [
+  "R05FB01"
+ ],
+ "covid-19, inactivated virus": [
+  "J07BN03"
+ ],
+ "covid-19, protein subunit": [
+  "J07BN04"
+ ],
+ "covid-19, rna-based vaccine": [
+  "J07BN01"
+ ],
+ "covid-19, viral vector, non-replicating": [
+  "J07BN02"
+ ],
+ "covid-19, virus-like particles": [
+  "J07BN05"
+ ],
+ "crataegus glycosides": [
+  "C01EB04"
+ ],
+ "creatinolfosfate": [
+  "C01EB05"
+ ],
+ "creosote": [
+  "R05CA08"
+ ],
+ "cridanimod": [
+  "L03AX18"
+ ],
+ "crilanomer": [
+  "D03AX09"
+ ],
+ "crisaborole": [
+  "D11AH06"
+ ],
+ "crizanlizumab": [
+  "B06AX01"
+ ],
+ "crizotinib": [
+  "L01ED01"
+ ],
+ "crofelemer": [
+  "A07XA06"
+ ],
+ "cromoglicic acid": [
+  "A07EB01",
+  "D11AH03",
+  "R01AC01",
+  "R03BC01",
+  "S01GX01"
+ ],
+ "cromoglicic acid, combinations": [
+  "R01AC51",
+  "S01GX51"
+ ],
+ "crospovidone": [
+  "A07BC03"
+ ],
+ "crovalimab": [
+  "L04AJ07"
+ ],
+ "cyamemazine": [
+  "N05AA06"
+ ],
+ "cyanocobalamin": [
+  "B03BA01"
+ ],
+ "cyanocobalamin tannin complex": [
+  "B03BA02"
+ ],
+ "cyanocobalamin, combinations": [
+  "B03BA51"
+ ],
+ "cyclandelate": [
+  "C04AX01"
+ ],
+ "cyclizine": [
+  "R06AE03"
+ ],
+ "cyclizine, combinations": [
+  "R06AE53"
+ ],
+ "cyclobarbital": [
+  "N05CA10"
+ ],
+ "cyclobenzaprine": [
+  "M03BX08"
+ ],
+ "cyclobutyrol": [
+  "A05AX03"
+ ],
+ "cyclofenil": [
+  "G03GB01"
+ ],
+ "cycloguanil embonate": [
+  "P01BB02"
+ ],
+ "cyclopentamine": [
+  "R01AA02"
+ ],
+ "cyclopenthiazide": [
+  "C03AA07"
+ ],
+ "cyclopenthiazide and potassium": [
+  "C03AB07"
+ ],
+ "cyclopenthiazide and potassium-sparing agents": [
+  "C03EA07"
+ ],
+ "cyclopentolate": [
+  "S01FA04"
+ ],
+ "cyclopentolate, combinations": [
+  "S01FA54"
+ ],
+ "cyclophosphamide": [
+  "L01AA01"
+ ],
+ "cycloserine": [
+  "J04AB01"
+ ],
+ "cyclothiazide": [
+  "C03AA09"
+ ],
+ "cyclothiazide and potassium": [
+  "C03AB09"
+ ],
+ "cyfluthrin": [
+  "P03BA01"
+ ],
+ "cymarin": [
+  "C01AC03"
+ ],
+ "cypermethrin": [
+  "P03BA02"
+ ],
+ "cyproheptadine": [
+  "R06AX02"
+ ],
+ "cyproterone": [
+  "G03HA01"
+ ],
+ "cyproterone and estrogen": [
+  "G03HB01"
+ ],
+ "cytarabine": [
+  "L01BC01"
+ ],
+ "cytarabine and daunorubicin": [
+  "L01XY01"
+ ],
+ "cytisine": [
+  "N07BA04"
+ ],
+ "cytomegalovirus immunoglobulin": [
+  "J06BB09"
+ ],
+ "dabigatran etexilate": [
+  "B01AE07"
+ ],
+ "dabrafenib": [
+  "L01EC02"
+ ],
+ "dacarbazine": [
+  "L01AX04"
+ ],
+ "daclatasvir": [
+  "J05AP07"
+ ],
+ "daclatasvir, asunaprevir and beclabuvir": [
+  "J05AP58"
+ ],
+ "daclizumab": [
+  "L04AC01"
+ ],
+ "dacomitinib": [
+  "L01EB07"
+ ],
+ "dactinomycin": [
+  "L01DA01"
+ ],
+ "dalbavancin": [
+  "J01XA04"
+ ],
+ "dalteparin": [
+  "B01AB04"
+ ],
+ "danaparoid": [
+  "B01AB09"
+ ],
+ "danazol": [
+  "G03XA01"
+ ],
+ "danicopan": [
+  "L04AJ09"
+ ],
+ "dantrolene": [
+  "M03CA01"
+ ],
+ "dantron": [
+  "A06AB03"
+ ],
+ "dantron, combinations": [
+  "A06AB53"
+ ],
+ "dantron, incl. combinations": [
+  "A06AG03"
+ ],
+ "dapagliflozin": [
+  "A10BK01"
+ ],
+ "dapiprazole": [
+  "S01EX02"
+ ],
+ "dapivirine": [
+  "G01AX17"
+ ],
+ "dapoxetine": [
+  "G04BX14"
+ ],
+ "daprodustat": [
+  "B03XA07"
+ ],
+ "dapsone": [
+  "D10AX05",
+  "J04BA02"
+ ],
+ "dapsone and rifampicin": [
+  "J04BA50"
+ ],
+ "dapsone, rifampicin and clofazimine": [
+  "J04BA51"
+ ],
+ "daptomycin": [
+  "J01XX09"
+ ],
+ "daratumumab": [
+  "L01FC01"
+ ],
+ "darbepoetin alfa": [
+  "B03XA02"
+ ],
+ "daridorexant": [
+  "N05CJ03"
+ ],
+ "darifenacin": [
+  "G04BD10"
+ ],
+ "darinaparsin": [
+  "L01XX82"
+ ],
+ "darolutamide": [
+  "L02BB06"
+ ],
+ "darunavir": [
+  "J05AE10"
+ ],
+ "darunavir and cobicistat": [
+  "J05AR14"
+ ],
+ "darunavir and ritonavir": [
+  "J05AR26"
+ ],
+ "darvadstrocel": [
+  "L04AX08"
+ ],
+ "dasabuvir": [
+  "J05AP09"
+ ],
+ "dasabuvir, ombitasvir, paritaprevir and ritonavir": [
+  "J05AP52"
+ ],
+ "dasatinib": [
+  "L01EA02"
+ ],
+ "dasiglucagon": [
+  "H04AA02"
+ ],
+ "dasiprotimut-t": [
+  "L03AX19"
+ ],
+ "datopotamab deruxtecan": [
+  "L01FX35"
+ ],
+ "daunorubicin": [
+  "L01DB02"
+ ],
+ "deanol": [
+  "N06BX04"
+ ],
+ "debrisoquine": [
+  "C02CC04"
+ ],
+ "decamethoxine": [
+  "D08AJ10"
+ ],
+ "decamethrin": [
+  "P03BA03"
+ ],
+ "decitabine": [
+  "L01BC08"
+ ],
+ "decitabine, combinations": [
+  "L01BC58"
+ ],
+ "deferasirox": [
+  "V03AC03"
+ ],
+ "deferiprone": [
+  "V03AC02"
+ ],
+ "deferoxamine": [
+  "V03AC01"
+ ],
+ "defibrotide": [
+  "B01AX01"
+ ],
+ "deflazacort": [
+  "H02AB13"
+ ],
+ "degarelix": [
+  "L02BX02"
+ ],
+ "dehydroemetine": [
+  "P01AX09"
+ ],
+ "delafloxacin": [
+  "J01MA23"
+ ],
+ "delamanid": [
+  "J04AK06"
+ ],
+ "delandistrogene moxeparvovec": [
+  "M09AX15"
+ ],
+ "delapril": [
+  "C09AA12"
+ ],
+ "delapril and diuretics": [
+  "C09BA12"
+ ],
+ "delapril and manidipine": [
+  "C09BB12"
+ ],
+ "delavirdine": [
+  "J05AG02"
+ ],
+ "delgocitinib": [
+  "D11AH11"
+ ],
+ "demecarium": [
+  "S01EB04"
+ ],
+ "demeclocycline": [
+  "D06AA01",
+  "J01AA01"
+ ],
+ "demecolcine": [
+  "L01CC01"
+ ],
+ "demegestone": [
+  "G03DB05"
+ ],
+ "demoxytocin": [
+  "H01BB01"
+ ],
+ "dengue virus vaccines": [
+  "J07BX04"
+ ],
+ "denileukin diftitox": [
+  "L01XX29"
+ ],
+ "denosumab": [
+  "M05BX04"
+ ],
+ "deoxycholic acid": [
+  "D11AX24"
+ ],
+ "deptropine": [
+  "R06AX16"
+ ],
+ "dequalinium": [
+  "D08AH01",
+  "G01AC05",
+  "R02AA02"
+ ],
+ "dermatan sulfate": [
+  "B01AX04"
+ ],
+ "desaspidin": [
+  "P02DX01"
+ ],
+ "deserpidine": [
+  "C02AA05"
+ ],
+ "deserpidine and diuretics": [
+  "C02LA03"
+ ],
+ "desfesoterodine": [
+  "G04BD13"
+ ],
+ "desflurane": [
+  "N01AB07"
+ ],
+ "desipramine": [
+  "N06AA01"
+ ],
+ "desirudin": [
+  "B01AE01"
+ ],
+ "deslanoside": [
+  "C01AA07"
+ ],
+ "desloratadine": [
+  "R06AX27"
+ ],
+ "desmopressin": [
+  "H01BA02"
+ ],
+ "desogestrel": [
+  "G03AC09"
+ ],
+ "desogestrel and estrogen": [
+  "G03FB10"
+ ],
+ "desogestrel and ethinylestradiol": [
+  "G03AA09",
+  "G03AB05"
+ ],
+ "desonide": [
+  "D07AB08",
+  "S01BA11"
+ ],
+ "desonide and antiseptics": [
+  "D07BB02"
+ ],
+ "desoximetasone": [
+  "D07AC03",
+  "D07XC02"
+ ],
+ "desoxycortone": [
+  "H02AA03"
+ ],
+ "desoxyribonuclease": [
+  "B06AA10"
+ ],
+ "desvenlafaxine": [
+  "N06AX23"
+ ],
+ "deucravacitinib": [
+  "L04AF07"
+ ],
+ "deutetrabenazine": [
+  "N07XX16"
+ ],
+ "deutivacaftor, tezacaftor and vanzacaftor": [
+  "R07AX33"
+ ],
+ "dexamethasone": [
+  "A01AC02",
+  "C05AA09",
+  "D07AB19",
+  "D07XB05",
+  "D10AA03",
+  "H02AB02",
+  "R01AD03",
+  "S01BA01",
+  "S01CB01",
+  "S02BA06",
+  "S03BA01"
+ ],
+ "dexamethasone and antibiotics": [
+  "D07CB04"
+ ],
+ "dexamethasone and antiinfectives": [
+  "S01CA01",
+  "S02CA06",
+  "S03CA01"
+ ],
+ "dexamethasone, combinations": [
+  "R01AD53"
+ ],
+ "dexamfetamine": [
+  "N06BA02"
+ ],
+ "dexbrompheniramine": [
+  "R06AB06"
+ ],
+ "dexbrompheniramine, combinations": [
+  "R06AB56"
+ ],
+ "dexchlorpheniramine": [
+  "R06AB02"
+ ],
+ "dexchlorpheniramine, combinations": [
+  "R06AB52"
+ ],
+ "dexetimide": [
+  "N04AA08"
+ ],
+ "dexfenfluramine": [
+  "A08AA04"
+ ],
+ "dexibuprofen": [
+  "M01AE14"
+ ],
+ "dexketoprofen": [
+  "M01AE17",
+  "M02AA27"
+ ],
+ "dexlansoprazole": [
+  "A02BC06"
+ ],
+ "dexmedetomidine": [
+  "N05CM18"
+ ],
+ "dexmethylphenidate": [
+  "N06BA11"
+ ],
+ "dexmethylphenidate and serdexmethylphenidate": [
+  "N06BA15"
+ ],
+ "dexpanthenol": [
+  "A11HA30",
+  "D03AX03",
+  "S01XA12"
+ ],
+ "dexrabeprazole": [
+  "A02BC07"
+ ],
+ "dexrazoxane": [
+  "V03AF02"
+ ],
+ "dextran": [
+  "B05AA05"
+ ],
+ "dextranomer": [
+  "D03AX02"
+ ],
+ "dextromethorphan": [
+  "R05DA09"
+ ],
+ "dextromethorphan, combinations": [
+  "N07XX59"
+ ],
+ "dextromoramide": [
+  "N02AC01"
+ ],
+ "dextropropoxyphene": [
+  "N02AC04"
+ ],
+ "dextropropoxyphene, combinations excl. psycholeptics": [
+  "N02AC54"
+ ],
+ "dextropropoxyphene, combinations with psycholeptics": [
+  "N02AC74"
+ ],
+ "dextrothyroxine": [
+  "C10AX01"
+ ],
+ "dezocine": [
+  "N02AX03"
+ ],
+ "diacerein": [
+  "M01AX21"
+ ],
+ "diamorphine": [
+  "N07BC06"
+ ],
+ "diastase": [
+  "A09AA01"
+ ],
+ "diatrizoic acid": [
+  "V08AA01"
+ ],
+ "diazepam": [
+  "N05BA01"
+ ],
+ "diazoxide": [
+  "C02DA01",
+  "V03AH01"
+ ],
+ "dibekacin": [
+  "J01GB09",
+  "S01AA29"
+ ],
+ "dibenzepin": [
+  "N06AA08"
+ ],
+ "dibotermin alfa": [
+  "M05BC01"
+ ],
+ "dibromotyrosine": [
+  "H03BX02"
+ ],
+ "dibrompropamidine": [
+  "D08AC01",
+  "S01AX14"
+ ],
+ "dibunate": [
+  "R05DB16"
+ ],
+ "dibutylphthalate": [
+  "P03BX03"
+ ],
+ "dibutylsuccinate": [
+  "P03BX04"
+ ],
+ "dichloralphenazone": [
+  "N05CC04"
+ ],
+ "dichlorobenzyl alcohol": [
+  "R02AA03"
+ ],
+ "dichlorophen": [
+  "P02DX02"
+ ],
+ "diclofenac": [
+  "D11AX18",
+  "M01AB05",
+  "M02AA15",
+  "S01BC03"
+ ],
+ "diclofenac and antiinfectives": [
+  "S01CC01"
+ ],
+ "diclofenac, combinations": [
+  "M01AB55"
+ ],
+ "diclofenamide": [
+  "S01EC02"
+ ],
+ "dicloxacillin": [
+  "J01CF01"
+ ],
+ "dicoumarol": [
+  "B01AA01"
+ ],
+ "dicycloverine": [
+  "A03AA07"
+ ],
+ "didanosine": [
+  "J05AF02"
+ ],
+ "didecyldimethylammonium chloride": [
+  "D08AJ06"
+ ],
+ "dienestrol": [
+  "G03CB01",
+  "G03CC02"
+ ],
+ "dienogest": [
+  "G03DB08"
+ ],
+ "dienogest and estradiol": [
+  "G03AB08"
+ ],
+ "dienogest and estrogen": [
+  "G03FA15"
+ ],
+ "dienogest and ethinylestradiol": [
+  "G03AA16"
+ ],
+ "diethyl ether": [
+  "N01AA01"
+ ],
+ "diethylcarbamazine": [
+  "P02CB02"
+ ],
+ "diethylstilbestrol": [
+  "G03CB02",
+  "G03CC05",
+  "L02AA01"
+ ],
+ "diethyltoluamide": [
+  "P03BX01"
+ ],
+ "difelikefalin": [
+  "V03AX04"
+ ],
+ "difemerine": [
+  "A03AA09"
+ ],
+ "difenoxin": [
+  "A07DA04"
+ ],
+ "difenpiramide": [
+  "M01AB12"
+ ],
+ "difetarsone": [
+  "P01AR02"
+ ],
+ "diflorasone": [
+  "D07AC10"
+ ],
+ "diflucortolone": [
+  "D07AC06",
+  "D07XC04"
+ ],
+ "diflucortolone and antiseptics": [
+  "D07BC04"
+ ],
+ "diflunisal": [
+  "N02BA11"
+ ],
+ "difluprednate": [
+  "D07AC19",
+  "S01BA16"
+ ],
+ "digitalis antitoxin": [
+  "V03AB24"
+ ],
+ "digitalis leaves": [
+  "C01AA03"
+ ],
+ "digitoxin": [
+  "C01AA04"
+ ],
+ "digoxin": [
+  "C01AA05"
+ ],
+ "dihexyverine": [
+  "A03AA08"
+ ],
+ "dihydralazine": [
+  "C02DB01"
+ ],
+ "dihydralazine and diuretics": [
+  "C02LG01"
+ ],
+ "dihydralazine and diuretics, combinations with other drugs": [
+  "C02LG51"
+ ],
+ "dihydrocodeine": [
+  "N02AA08"
+ ],
+ "dihydrocodeine and acetylsalicylic acid": [
+  "N02AJ02"
+ ],
+ "dihydrocodeine and other non-opioid analgesics": [
+  "N02AJ03"
+ ],
+ "dihydrocodeine and paracetamol": [
+  "N02AJ01"
+ ],
+ "dihydrocodeine, combinations": [
+  "N02AA58"
+ ],
+ "dihydroergocristine": [
+  "C04AE04"
+ ],
+ "dihydroergocristine, combinations": [
+  "C04AE54"
+ ],
+ "dihydroergocryptine mesylate": [
+  "N04BC03"
+ ],
+ "dihydroergotamine": [
+  "N02CA01"
+ ],
+ "dihydroergotamine, combinations": [
+  "N02CA51"
+ ],
+ "dihydrostreptomycin": [
+  "S01AA15"
+ ],
+ "dihydrotachysterol": [
+  "A11CC02"
+ ],
+ "dihydroxialumini sodium carbonate": [
+  "A02AB04"
+ ],
+ "diiodohydroxypropane": [
+  "D08AG04"
+ ],
+ "diiodohydroxyquinoline": [
+  "G01AC01"
+ ],
+ "diiodotyrosine": [
+  "H03BX01"
+ ],
+ "diisopromine": [
+  "A03AX02"
+ ],
+ "dilazep": [
+  "C01DX10"
+ ],
+ "diloxanide": [
+  "P01AC01"
+ ],
+ "diltiazem": [
+  "C05AE03",
+  "C08DB01"
+ ],
+ "dimazole": [
+  "D01AE17"
+ ],
+ "dimefline": [
+  "R07AB08"
+ ],
+ "dimemorfan": [
+  "R05DA11"
+ ],
+ "dimenhydrinate": [
+  "R06AA11"
+ ],
+ "dimenhydrinate, combinations": [
+  "R06AA61"
+ ],
+ "dimercaprol": [
+  "V03AB09"
+ ],
+ "dimetacrine": [
+  "N06AA18"
+ ],
+ "dimethoxanate": [
+  "R05DB28"
+ ],
+ "dimethyl fumarate": [
+  "L04AX07"
+ ],
+ "dimethyl sulfoxide": [
+  "G04BX13",
+  "M02AX03"
+ ],
+ "dimethylaminopropionylphenothiazine": [
+  "A03AC02"
+ ],
+ "dimethylcarbate": [
+  "P03BX05"
+ ],
+ "dimethylphthalate": [
+  "P03BX02"
+ ],
+ "dimethyltubocurarine": [
+  "M03AA04"
+ ],
+ "dimeticone": [
+  "P03AX05"
+ ],
+ "dimetindene": [
+  "D04AA13",
+  "R06AB03"
+ ],
+ "dimetofrine": [
+  "C01CA12"
+ ],
+ "dimetotiazine": [
+  "N02CX05"
+ ],
+ "dinoprost": [
+  "G02AD01"
+ ],
+ "dinoprostone": [
+  "G02AD02"
+ ],
+ "dinutuximab beta": [
+  "L01FX06"
+ ],
+ "diodone": [
+  "V08AA10"
+ ],
+ "diosmectite": [
+  "A07BC05"
+ ],
+ "diosmin": [
+  "C05CA03"
+ ],
+ "diosmin, combinations": [
+  "C05CA53"
+ ],
+ "diphemanil": [
+  "A03AB15"
+ ],
+ "diphemanil and psycholeptics": [
+  "A03CA08"
+ ],
+ "diphenadione": [
+  "B01AA10"
+ ],
+ "diphenhydramine": [
+  "D04AA32",
+  "R06AA02"
+ ],
+ "diphenhydramine methylbromide": [
+  "D04AA33"
+ ],
+ "diphenhydramine, combinations": [
+  "R06AA52"
+ ],
+ "diphenoxylate": [
+  "A07DA01"
+ ],
+ "diphenylpyraline": [
+  "R06AA07"
+ ],
+ "diphenylpyraline, combinations": [
+  "R06AA57"
+ ],
+ "diphtheria antitoxin": [
+  "J06AA01"
+ ],
+ "diphtheria immunoglobulin": [
+  "J06BB10"
+ ],
+ "diphtheria toxoid": [
+  "J07AF01"
+ ],
+ "diphtheria-hemophilus influenzae b-pertussis-poliomyelitis-tetanus": [
+  "J07CA06"
+ ],
+ "diphtheria-hemophilus influenzae b-pertussis-poliomyelitis-tetanus-hepatitis b": [
+  "J07CA09"
+ ],
+ "diphtheria-hemophilus influenzae b-pertussis-tetanus-hepatitis b": [
+  "J07CA11"
+ ],
+ "diphtheria-hemophilus influenzae b-pertussis-tetanus-hepatitis b-meningococcus a + c": [
+  "J07CA13"
+ ],
+ "diphtheria-hepatitis b-pertussis-tetanus": [
+  "J07CA05"
+ ],
+ "diphtheria-hepatitis b-tetanus": [
+  "J07CA07"
+ ],
+ "diphtheria-pertussis-poliomyelitis-tetanus": [
+  "J07CA02"
+ ],
+ "diphtheria-pertussis-poliomyelitis-tetanus-hepatitis b": [
+  "J07CA12"
+ ],
+ "diphtheria-poliomyelitis-tetanus": [
+  "J07CA01"
+ ],
+ "diphtheria-rubella-tetanus": [
+  "J07CA03"
+ ],
+ "dipiperonylaminoethanol, combinations": [
+  "N05CX06"
+ ],
+ "dipivefrine": [
+  "S01EA02"
+ ],
+ "diprophylline": [
+  "R03DA01"
+ ],
+ "diprophylline and adrenergics": [
+  "R03DB01"
+ ],
+ "diprophylline, combinations": [
+  "R03DA51"
+ ],
+ "dipyridamole": [
+  "B01AC07"
+ ],
+ "dipyrocetyl": [
+  "N02BA09"
+ ],
+ "dipyrocetyl and corticosteroids": [
+  "M01BA02"
+ ],
+ "dipyrocetyl, combinations excl. psycholeptics": [
+  "N02BA59"
+ ],
+ "dipyrocetyl, combinations with psycholeptics": [
+  "N02BA79"
+ ],
+ "diquafosol": [
+  "S01XA33"
+ ],
+ "dirithromycin": [
+  "J01FA13"
+ ],
+ "diroximel fumarate": [
+  "L04AX09"
+ ],
+ "disopyramide": [
+  "C01BA03"
+ ],
+ "distigmine": [
+  "N07AA03"
+ ],
+ "disulfiram": [
+  "N07BB01",
+  "P03AA04"
+ ],
+ "disulfiram, combinations": [
+  "P03AA54"
+ ],
+ "ditazole": [
+  "B01AC01"
+ ],
+ "dithranol": [
+  "D05AC01"
+ ],
+ "dithranol, combinations": [
+  "D05AC51"
+ ],
+ "divozilimab": [
+  "L04AG15"
+ ],
+ "dixanthogen": [
+  "P03AA01"
+ ],
+ "dixyrazine": [
+  "N05AB01"
+ ],
+ "dobutamine": [
+  "C01CA07"
+ ],
+ "docetaxel": [
+  "L01CD02"
+ ],
+ "docosanol": [
+  "D06BB11"
+ ],
+ "docusate sodium": [
+  "A06AA02"
+ ],
+ "docusate sodium, incl. combinations": [
+  "A06AG10"
+ ],
+ "dodeclonium bromide, combinations": [
+  "D08AJ59"
+ ],
+ "dofetilide": [
+  "C01BD04"
+ ],
+ "dolasetron": [
+  "A04AA04"
+ ],
+ "dolutegravir": [
+  "J05AJ03"
+ ],
+ "dolutegravir and rilpivirine": [
+  "J05AR21"
+ ],
+ "domiodol": [
+  "R05CB08"
+ ],
+ "domiphen": [
+  "A01AB06"
+ ],
+ "domperidone": [
+  "A03FA03"
+ ],
+ "donanemab": [
+  "N06DX05"
+ ],
+ "donepezil": [
+  "N06DA02"
+ ],
+ "donepezil and memantine": [
+  "N06DA52"
+ ],
+ "donepezil, memantine and ginkgo folium": [
+  "N06DA53"
+ ],
+ "donislecel": [
+  "A10XX02"
+ ],
+ "dopamine": [
+  "C01CA04"
+ ],
+ "dopexamine": [
+  "C01CA14"
+ ],
+ "doravirine": [
+  "J05AG06"
+ ],
+ "doripenem": [
+  "J01DH04"
+ ],
+ "dornase alfa (desoxyribonuclease)": [
+  "R05CB13"
+ ],
+ "dorzagliatin": [
+  "A10BX18"
+ ],
+ "dorzolamide": [
+  "S01EC03"
+ ],
+ "dostarlimab": [
+  "L01FF07"
+ ],
+ "dosulepin": [
+  "N06AA16"
+ ],
+ "doxacurium chloride": [
+  "M03AC07"
+ ],
+ "doxapram": [
+  "R07AB01"
+ ],
+ "doxazosin": [
+  "C02CA04"
+ ],
+ "doxazosin and finasteride": [
+  "G04CA55"
+ ],
+ "doxefazepam": [
+  "N05CD12"
+ ],
+ "doxepin": [
+  "D04AX01",
+  "N06AA12"
+ ],
+ "doxercalciferol": [
+  "H05BX03"
+ ],
+ "doxofylline": [
+  "R03DA11"
+ ],
+ "doxorubicin": [
+  "L01DB01"
+ ],
+ "doxycycline": [
+  "A01AB22",
+  "J01AA02"
+ ],
+ "doxylamine": [
+  "R06AA09"
+ ],
+ "doxylamine, combinations": [
+  "R06AA59"
+ ],
+ "drisapersen": [
+  "M09AX04"
+ ],
+ "dronabinol": [
+  "A04AD10"
+ ],
+ "dronedarone": [
+  "C01BD07"
+ ],
+ "droperidol": [
+  "N05AD08"
+ ],
+ "dropropizine": [
+  "R05DB19"
+ ],
+ "drospirenone": [
+  "G03AC10"
+ ],
+ "drospirenone and estetrol": [
+  "G03AA18"
+ ],
+ "drospirenone and estrogen": [
+  "G03FA17"
+ ],
+ "drospirenone and ethinylestradiol": [
+  "G03AA12"
+ ],
+ "drotaverine": [
+  "A03AD02"
+ ],
+ "drotrecogin alfa (activated)": [
+  "B01AD10"
+ ],
+ "droxicam": [
+  "M01AC04"
+ ],
+ "droxidopa": [
+  "C01CA27"
+ ],
+ "droxypropine": [
+  "R05DB17"
+ ],
+ "dulaglutide": [
+  "A10BJ05"
+ ],
+ "duloxetine": [
+  "N06AX21"
+ ],
+ "dupilumab": [
+  "D11AH05"
+ ],
+ "durvalumab": [
+  "L01FF03"
+ ],
+ "dutasteride": [
+  "G04CB02"
+ ],
+ "duvelisib": [
+  "L01EM04"
+ ],
+ "dyclonine": [
+  "N01BX02",
+  "R02AD04"
+ ],
+ "dydrogesterone": [
+  "G03DB01"
+ ],
+ "dydrogesterone and estrogen": [
+  "G03FA14",
+  "G03FB08"
+ ],
+ "dysprosium (165dy) colloid": [
+  "V10AX03"
+ ],
+ "ebastine": [
+  "R06AX22"
+ ],
+ "eberconazole": [
+  "D01AC17"
+ ],
+ "ebola vaccines": [
+  "J07BX02"
+ ],
+ "ecallantide": [
+  "B06AC03"
+ ],
+ "econazole": [
+  "D01AC03",
+  "G01AF05"
+ ],
+ "econazole, combinations": [
+  "G01AF55"
+ ],
+ "ecothiopate": [
+  "S01EB03"
+ ],
+ "eculizumab": [
+  "L04AJ01"
+ ],
+ "edaravone": [
+  "N07XX14"
+ ],
+ "edetates": [
+  "V03AB03"
+ ],
+ "edoxaban": [
+  "B01AF03"
+ ],
+ "edoxudine": [
+  "D06BB09"
+ ],
+ "edrecolomab": [
+  "L01FX01"
+ ],
+ "edrophonium": [
+  "V04CX07"
+ ],
+ "efalizumab": [
+  "L04AG02"
+ ],
+ "efaproxiral": [
+  "L01XD06"
+ ],
+ "efavirenz": [
+  "J05AG03"
+ ],
+ "efbemalenograstim alfa": [
+  "L03AA18"
+ ],
+ "efepoetin alfa": [
+  "B03XA10"
+ ],
+ "efgartigimod alfa": [
+  "L04AA58"
+ ],
+ "efinaconazole": [
+  "D01AC19"
+ ],
+ "eflapegrastim": [
+  "L03AA19"
+ ],
+ "eflornithine": [
+  "D11AX16",
+  "L01XX79",
+  "P01CX03"
+ ],
+ "efloxate": [
+  "C01DX13"
+ ],
+ "elacestrant": [
+  "L02BA04"
+ ],
+ "eladocagene exuparvovec": [
+  "A16AB26"
+ ],
+ "elafibranor": [
+  "A05AX06"
+ ],
+ "elagolix": [
+  "H01CC03"
+ ],
+ "elagolix, estradiol and norethisterone": [
+  "H01CC53"
+ ],
+ "elapegademase": [
+  "L03AX21"
+ ],
+ "elbasvir": [
+  "J05AP10"
+ ],
+ "elbasvir and grazoprevir": [
+  "J05AP54"
+ ],
+ "elcatonin": [
+  "H05BA04"
+ ],
+ "electrolytes": [
+  "B05BB01"
+ ],
+ "electrolytes in combination with other drugs": [
+  "B05BB04",
+  "B05XA31"
+ ],
+ "electrolytes with carbohydrates": [
+  "B05BB02"
+ ],
+ "eletriptan": [
+  "N02CC06"
+ ],
+ "eliglustat": [
+  "A16AX10"
+ ],
+ "elivaldogene autotemcel": [
+  "A16AX21"
+ ],
+ "elobixibat": [
+  "A06AX09"
+ ],
+ "elosulfase alfa": [
+  "A16AB12"
+ ],
+ "elotuzumab": [
+  "L01FX08"
+ ],
+ "elranatamab": [
+  "L01FX32"
+ ],
+ "elsulfavirine": [
+  "J05AG07"
+ ],
+ "eltrombopag": [
+  "B02BX05"
+ ],
+ "eluxadoline": [
+  "A07DA06"
+ ],
+ "elvitegravir": [
+  "J05AJ02"
+ ],
+ "emapalumab": [
+  "L04AG09"
+ ],
+ "emedastine": [
+  "S01GX06"
+ ],
+ "emepronium": [
+  "G04BD01"
+ ],
+ "emepronium and psycholeptics": [
+  "A03CA30"
+ ],
+ "emepronium, combinations": [
+  "N05CX05"
+ ],
+ "emetine": [
+  "P01AX02"
+ ],
+ "emetine, combinations": [
+  "P01AX52"
+ ],
+ "emicizumab": [
+  "B02BX06"
+ ],
+ "empagliflozin": [
+  "A10BK03"
+ ],
+ "empegfilgrastim": [
+  "L03AA16"
+ ],
+ "emtricitabine": [
+  "J05AF09"
+ ],
+ "emtricitabine and tenofovir alafenamide": [
+  "J05AR17"
+ ],
+ "emtricitabine, tenofovir alafenamide and bictegravir": [
+  "J05AR20"
+ ],
+ "emtricitabine, tenofovir alafenamide and dolutegravir": [
+  "J05AR29"
+ ],
+ "emtricitabine, tenofovir alafenamide and rilpivirine": [
+  "J05AR19"
+ ],
+ "emtricitabine, tenofovir alafenamide, darunavir and cobicistat": [
+  "J05AR22"
+ ],
+ "emtricitabine, tenofovir alafenamide, elvitegravir and cobicistat": [
+  "J05AR18"
+ ],
+ "emtricitabine, tenofovir disoproxil and efavirenz": [
+  "J05AR06"
+ ],
+ "emtricitabine, tenofovir disoproxil and rilpivirine": [
+  "J05AR08"
+ ],
+ "emtricitabine, tenofovir disoproxil, elvitegravir and cobicistat": [
+  "J05AR09"
+ ],
+ "emylcamate": [
+  "N05BC03"
+ ],
+ "enalapril": [
+  "C09AA02"
+ ],
+ "enalapril and diuretics": [
+  "C09BA02"
+ ],
+ "enalapril and lercanidipine": [
+  "C09BB02"
+ ],
+ "enalapril and nitrendipine": [
+  "C09BB06"
+ ],
+ "enasidenib": [
+  "L01XM01"
+ ],
+ "enavogliflozin": [
+  "A10BK09"
+ ],
+ "encainide": [
+  "C01BC08"
+ ],
+ "encephalitis, japanese, inactivated, whole virus": [
+  "J07BA02"
+ ],
+ "encephalitis, japanese, live attenuated": [
+  "J07BA03"
+ ],
+ "encephalitis, tick borne immunoglobulin": [
+  "J06BB12"
+ ],
+ "encephalitis, tick borne, inactivated, whole virus": [
+  "J07BA01"
+ ],
+ "encorafenib": [
+  "L01EC03"
+ ],
+ "endralazine": [
+  "C02DB03"
+ ],
+ "enflurane": [
+  "N01AB04"
+ ],
+ "enfortumab vedotin": [
+  "L01FX13"
+ ],
+ "enfuvirtide": [
+  "J05AX07"
+ ],
+ "enisamium iodide": [
+  "J05AX17"
+ ],
+ "enoxacin": [
+  "J01MA04"
+ ],
+ "enoxaparin": [
+  "B01AB05"
+ ],
+ "enoximone": [
+  "C01CE03"
+ ],
+ "enoxolone": [
+  "D03AX10"
+ ],
+ "enprostil": [
+  "A02BB02"
+ ],
+ "ensitrelvir": [
+  "J05AE16"
+ ],
+ "entacapone": [
+  "N04BX02"
+ ],
+ "entecavir": [
+  "J05AF10"
+ ],
+ "enterovirus 71 vaccines": [
+  "J07BX06"
+ ],
+ "entinostat": [
+  "L01XH05"
+ ],
+ "entrectinib": [
+  "L01EX14"
+ ],
+ "enviomycin": [
+  "J04AB06"
+ ],
+ "enzalutamide": [
+  "L02BB04"
+ ],
+ "eosin": [
+  "D08AX02"
+ ],
+ "epacadostat": [
+  "L01XX58"
+ ],
+ "epanolol": [
+  "C07AB10"
+ ],
+ "epcoritamab": [
+  "L01FX27"
+ ],
+ "eperisone": [
+  "M03BX09"
+ ],
+ "ephedrine": [
+  "C01CA26",
+  "R01AA03",
+  "R01AB05",
+  "S01FB02"
+ ],
+ "ephedrine, combinations": [
+  "A08AA56"
+ ],
+ "epicillin": [
+  "J01CA07"
+ ],
+ "epimestrol": [
+  "G03GB03"
+ ],
+ "epinastine": [
+  "R06AX24",
+  "S01GX10"
+ ],
+ "epinephrine": [
+  "A01AD01",
+  "B02BC09",
+  "C01CA24",
+  "R01AA14",
+  "R03AA01",
+  "S01EA01"
+ ],
+ "epinephrine and other drugs for obstructive airway diseases": [
+  "R03AK01"
+ ],
+ "epinephrine, combinations": [
+  "S01EA51"
+ ],
+ "epirubicin": [
+  "L01DB03"
+ ],
+ "epitizide and potassium-sparing agents": [
+  "C03EA03"
+ ],
+ "eplerenone": [
+  "C03DA04"
+ ],
+ "eplontersen": [
+  "N07XX21"
+ ],
+ "epomediol": [
+  "A05BA05"
+ ],
+ "epoprostenol": [
+  "B01AC09"
+ ],
+ "eprazinone": [
+  "R05CB04"
+ ],
+ "eprosartan": [
+  "C09CA02"
+ ],
+ "eprosartan and diuretics": [
+  "C09DA02"
+ ],
+ "eprozinol": [
+  "R03DX02"
+ ],
+ "eptifibatide": [
+  "B01AC16"
+ ],
+ "eptinezumab": [
+  "N02CD05"
+ ],
+ "eptotermin alfa": [
+  "M05BC02"
+ ],
+ "eravacycline": [
+  "J01AA13"
+ ],
+ "erbium (169er) citrate colloid": [
+  "V10AX04"
+ ],
+ "erdafitinib": [
+  "L01EN01"
+ ],
+ "erdosteine": [
+  "R05CB15"
+ ],
+ "erenumab": [
+  "N02CD01"
+ ],
+ "ergocalciferol": [
+  "A11CC01"
+ ],
+ "ergoloid mesylates": [
+  "C04AE01"
+ ],
+ "ergoloid mesylates, combinations": [
+  "C04AE51"
+ ],
+ "ergometrine": [
+  "G02AB03"
+ ],
+ "ergot alkaloids": [
+  "G02AB02"
+ ],
+ "ergotamine": [
+  "N02CA02"
+ ],
+ "ergotamine, combinations excl. psycholeptics": [
+  "N02CA52"
+ ],
+ "ergotamine, combinations with psycholeptics": [
+  "N02CA72"
+ ],
+ "eribulin": [
+  "L01XX41"
+ ],
+ "eritrityl tetranitrate": [
+  "C01DA13"
+ ],
+ "eritrityl tetranitrate, combinations": [
+  "C01DA63"
+ ],
+ "erlotinib": [
+  "L01EB02"
+ ],
+ "ertapenem": [
+  "J01DH03"
+ ],
+ "ertugliflozin": [
+  "A10BK04"
+ ],
+ "erythrocytes": [
+  "B05AX01"
+ ],
+ "erythromycin": [
+  "D10AF02",
+  "J01FA01",
+  "S01AA17"
+ ],
+ "erythromycin, combinations": [
+  "D10AF52"
+ ],
+ "erythropoietin": [
+  "B03XA01"
+ ],
+ "escherichia coli": [
+  "A07FA03"
+ ],
+ "escitalopram": [
+  "N06AB10"
+ ],
+ "esflurbiprofen": [
+  "M02AA29"
+ ],
+ "esketamine": [
+  "N01AX14",
+  "N06AX27"
+ ],
+ "eslicarbazepine": [
+  "N03AF04"
+ ],
+ "esmolol": [
+  "C07AB09"
+ ],
+ "esomeprazole": [
+  "A02BC05"
+ ],
+ "esomeprazole, amoxicillin and clarithromycin": [
+  "A02BD06"
+ ],
+ "estazolam": [
+  "N05CD04"
+ ],
+ "estradiol": [
+  "G03CA03"
+ ],
+ "estradiol, combinations": [
+  "G03CA53"
+ ],
+ "estramustine": [
+  "L01XX11"
+ ],
+ "estriol": [
+  "G03CA04",
+  "G03CC06"
+ ],
+ "estrone": [
+  "G03CA07",
+  "G03CC04"
+ ],
+ "eszopiclone": [
+  "N05CF04"
+ ],
+ "etacrynic acid": [
+  "C03CC01"
+ ],
+ "etafenone": [
+  "C01DX07"
+ ],
+ "etallobarbital": [
+  "N05CA20"
+ ],
+ "etamiphylline": [
+  "R03DA06"
+ ],
+ "etamiphylline and adrenergics": [
+  "R03DB06"
+ ],
+ "etamivan": [
+  "R07AB04"
+ ],
+ "etamsylate": [
+  "B02BX01"
+ ],
+ "etanautine": [
+  "N04AB01"
+ ],
+ "etanercept": [
+  "L04AB01"
+ ],
+ "etelcalcetide": [
+  "H05BX04"
+ ],
+ "eteplirsen": [
+  "M09AX06"
+ ],
+ "ethacizine": [
+  "C01BC09"
+ ],
+ "ethacridine lactate": [
+  "B05CA08",
+  "D08AA01"
+ ],
+ "ethadione": [
+  "N03AC03"
+ ],
+ "ethambutol": [
+  "J04AK02"
+ ],
+ "ethambutol and isoniazid": [
+  "J04AM03"
+ ],
+ "ethanol": [
+  "D08AX08",
+  "V03AB16",
+  "V03AZ01"
+ ],
+ "ethchlorvynol": [
+  "N05CM08"
+ ],
+ "ethenzamide": [
+  "N02BA07"
+ ],
+ "ethenzamide, combinations excl. psycholeptics": [
+  "N02BA57"
+ ],
+ "ethenzamide, combinations with psycholeptics": [
+  "N02BA77"
+ ],
+ "ethinylestradiol": [
+  "G03CA01",
+  "L02AA03"
+ ],
+ "ethionamide": [
+  "J04AD03"
+ ],
+ "ethisterone": [
+  "G03DC04"
+ ],
+ "ethisterone and estrogen": [
+  "G03FA03"
+ ],
+ "ethosuximide": [
+  "N03AD01"
+ ],
+ "ethosuximide, combinations": [
+  "N03AD51"
+ ],
+ "ethotoin": [
+  "N03AB01"
+ ],
+ "ethulose": [
+  "A06AC02"
+ ],
+ "ethyl biscoumacetate": [
+  "B01AA08"
+ ],
+ "ethyl chloride": [
+  "N01BX01"
+ ],
+ "ethyl esters of iodised fatty acids": [
+  "V08AD01"
+ ],
+ "ethyl hydroxybenzoate": [
+  "D01AE10"
+ ],
+ "ethyl loflazepate": [
+  "N05BA18"
+ ],
+ "ethylestrenol": [
+  "A14AB02"
+ ],
+ "ethylmorphine": [
+  "R05DA01",
+  "S01XA06"
+ ],
+ "etidocaine": [
+  "N01BB07"
+ ],
+ "etidocaine, combinations": [
+  "N01BB57"
+ ],
+ "etidronic acid": [
+  "M05BA01"
+ ],
+ "etidronic acid and calcium, sequential": [
+  "M05BB01"
+ ],
+ "etifoxine": [
+  "N05BX03"
+ ],
+ "etilamfetamine": [
+  "A08AA06"
+ ],
+ "etilefrine": [
+  "C01CA01"
+ ],
+ "etilefrine, combinations": [
+  "C01CA51"
+ ],
+ "etilevodopa and decarboxylase inhibitor": [
+  "N04BA06"
+ ],
+ "etirinotecan pegol": [
+  "L01CE03"
+ ],
+ "etizolam": [
+  "N05BA19"
+ ],
+ "etodolac": [
+  "M01AB08"
+ ],
+ "etofamide": [
+  "P01AC03"
+ ],
+ "etofenamate": [
+  "M02AA06"
+ ],
+ "etofibrate": [
+  "C10AB09"
+ ],
+ "etofylline nicotinate": [
+  "C04AD04"
+ ],
+ "etoglucid": [
+  "L01AG01"
+ ],
+ "etohexadiol": [
+  "P03BX06"
+ ],
+ "etomidate": [
+  "N01AX07"
+ ],
+ "etonogestrel": [
+  "G03AC08"
+ ],
+ "etoperidone": [
+  "N06AB09"
+ ],
+ "etoposide": [
+  "L01CB01"
+ ],
+ "etoricoxib": [
+  "M01AH05"
+ ],
+ "etozolin": [
+  "C03CX01"
+ ],
+ "etranacogene dezaparvovec": [
+  "B02BD16"
+ ],
+ "etrasimod": [
+  "L04AE05"
+ ],
+ "etravirine": [
+  "J05AG04"
+ ],
+ "etretinate": [
+  "D05BB01"
+ ],
+ "etripamil": [
+  "C08DA03"
+ ],
+ "etybenzatropine": [
+  "N04AC30"
+ ],
+ "etynodiol": [
+  "G03DC06"
+ ],
+ "etynodiol and estrogen": [
+  "G03FA06"
+ ],
+ "etynodiol and ethinylestradiol": [
+  "G03AA01"
+ ],
+ "euflavine": [
+  "D08AA03"
+ ],
+ "everolimus": [
+  "L01EG02",
+  "L04AH02"
+ ],
+ "evinacumab": [
+  "C10AX17"
+ ],
+ "evocalcet": [
+  "H05BX06"
+ ],
+ "evogliptin": [
+  "A10BH07"
+ ],
+ "evolocumab": [
+  "C10AX13"
+ ],
+ "exagamglogene autotemcel": [
+  "B06AX05"
+ ],
+ "exemestane": [
+  "L02BG06"
+ ],
+ "exenatide": [
+  "A10BJ01"
+ ],
+ "ezetimibe": [
+  "C10AX09"
+ ],
+ "fabomotizole": [
+  "N05BX04"
+ ],
+ "factor viii inhibitor bypassing activity": [
+  "B02BD03"
+ ],
+ "faldaprevir": [
+  "J05AP04"
+ ],
+ "famciclovir": [
+  "J05AB09",
+  "S01AD07"
+ ],
+ "famotidine": [
+  "A02BA03"
+ ],
+ "famotidine, combinations": [
+  "A02BA53"
+ ],
+ "fampridine": [
+  "N07XX07"
+ ],
+ "faricimab": [
+  "S01LA09"
+ ],
+ "faropenem": [
+  "J01DI03"
+ ],
+ "fasudil": [
+  "C04AX32"
+ ],
+ "fat emulsions": [
+  "B05BA02"
+ ],
+ "favipiravir": [
+  "J05AX27"
+ ],
+ "fazadinium bromide": [
+  "M03AC08"
+ ],
+ "feather": [
+  "V01AA01"
+ ],
+ "febarbamate": [
+  "M03BA05"
+ ],
+ "febuxostat": [
+  "M04AA03"
+ ],
+ "fedratinib": [
+  "L01EJ02"
+ ],
+ "fedrilate": [
+  "R05DB14"
+ ],
+ "felbamate": [
+  "N03AX10"
+ ],
+ "felbinac": [
+  "M02AA08"
+ ],
+ "felodipine": [
+  "C08CA02"
+ ],
+ "fenbendazole": [
+  "P02CA06"
+ ],
+ "fenbufen": [
+  "M01AE05"
+ ],
+ "fencamfamin": [
+  "N06BA06"
+ ],
+ "fendiline": [
+  "C08EA01"
+ ],
+ "fenetylline": [
+  "N06BA10"
+ ],
+ "fenfluramine": [
+  "A08AA02",
+  "N03AX26"
+ ],
+ "fenofibrate": [
+  "C10AB05"
+ ],
+ "fenoldopam": [
+  "C01CA19"
+ ],
+ "fenoprofen": [
+  "M01AE04"
+ ],
+ "fenoterol": [
+  "G02CA03",
+  "R03AC04",
+  "R03CC04"
+ ],
+ "fenoterol and ipratropium bromide": [
+  "R03AL01"
+ ],
+ "fenoverine": [
+  "A03AX05"
+ ],
+ "fenoxazoline": [
+  "R01AA12"
+ ],
+ "fenozolone": [
+  "N06BA08"
+ ],
+ "fenpiprane": [
+  "A03AX01"
+ ],
+ "fenpiverinium": [
+  "A03AB21"
+ ],
+ "fenquizone": [
+  "C03BA13"
+ ],
+ "fenspiride": [
+  "R03BX01",
+  "R03DX03"
+ ],
+ "fentanyl": [
+  "N01AH01",
+  "N02AB03"
+ ],
+ "fentanyl, combinations": [
+  "N01AH51"
+ ],
+ "fentiazac": [
+  "M01AB10",
+  "M02AA14"
+ ],
+ "fenticonazole": [
+  "D01AC12",
+  "G01AF12"
+ ],
+ "fentonium": [
+  "A03BB04"
+ ],
+ "fenyramidol": [
+  "M03BX30"
+ ],
+ "feprazone": [
+  "M01AX18",
+  "M02AA16"
+ ],
+ "feprazone, combinations": [
+  "M01AX68"
+ ],
+ "ferric (59fe) citrate": [
+  "V09XX04"
+ ],
+ "ferric acetyl transferrin": [
+  "B03AB08"
+ ],
+ "ferric ammonium citrate": [
+  "V08CA07"
+ ],
+ "ferric citrate": [
+  "V03AE08"
+ ],
+ "ferric hydroxide": [
+  "B03AB04"
+ ],
+ "ferric maltol": [
+  "B03AB10"
+ ],
+ "ferric oxide polymaltose complexes": [
+  "B03AB05"
+ ],
+ "ferric oxide polymaltose complexes and folic acid": [
+  "B03AD04"
+ ],
+ "ferric proteinsuccinylate": [
+  "B03AB09"
+ ],
+ "ferric sodium citrate": [
+  "B03AB01"
+ ],
+ "ferristene": [
+  "V08CB02"
+ ],
+ "ferrous amino acid complex and folic acid": [
+  "B03AD01"
+ ],
+ "ferrous ascorbate": [
+  "B03AA10"
+ ],
+ "ferrous aspartate": [
+  "B03AA09"
+ ],
+ "ferrous carbonate": [
+  "B03AA04"
+ ],
+ "ferrous chloride": [
+  "B03AA05"
+ ],
+ "ferrous fumarate": [
+  "B03AA02"
+ ],
+ "ferrous fumarate and folic acid": [
+  "B03AD02"
+ ],
+ "ferrous gluconate": [
+  "B03AA03"
+ ],
+ "ferrous gluconate and folic acid": [
+  "B03AD05"
+ ],
+ "ferrous glycine sulfate": [
+  "B03AA01"
+ ],
+ "ferrous iodine": [
+  "B03AA11"
+ ],
+ "ferrous sodium citrate": [
+  "B03AA12"
+ ],
+ "ferrous succinate": [
+  "B03AA06"
+ ],
+ "ferrous sulfate": [
+  "B03AA07"
+ ],
+ "ferrous sulfate and folic acid": [
+  "B03AD03"
+ ],
+ "ferrous tartrate": [
+  "B03AA08"
+ ],
+ "ferumoxsil": [
+  "V08CB01"
+ ],
+ "fesoterodine": [
+  "G04BD11"
+ ],
+ "fexapotide": [
+  "G04CX04"
+ ],
+ "fexinidazole": [
+  "P01CA03"
+ ],
+ "fexofenadine": [
+  "R06AX26"
+ ],
+ "fexuprazan": [
+  "A02BC10"
+ ],
+ "fezolinetant": [
+  "G02CX06"
+ ],
+ "fibrinogen (125i)": [
+  "V09GB01"
+ ],
+ "fibrinogen, human": [
+  "B02BB01"
+ ],
+ "fibrinolysin": [
+  "B01AD05"
+ ],
+ "fibrinolysin and desoxyribonuclease": [
+  "B06AA02"
+ ],
+ "fidanacogene elaparvovec": [
+  "B02BD17"
+ ],
+ "fidaxomicin": [
+  "A07AA12"
+ ],
+ "filgotinib": [
+  "L04AF04"
+ ],
+ "filgrastim": [
+  "L03AA02"
+ ],
+ "fimasartan": [
+  "C09CA10"
+ ],
+ "fimasartan and amlodipine": [
+  "C09DB09"
+ ],
+ "fimasartan and diuretics": [
+  "C09DA10"
+ ],
+ "finasteride": [
+  "D11AX10",
+  "G04CB01"
+ ],
+ "finasteride and tadalafil": [
+  "G04CB51"
+ ],
+ "finerenone": [
+  "C03DA05"
+ ],
+ "fingolimod": [
+  "L04AE01"
+ ],
+ "fipexide": [
+  "N06BX05"
+ ],
+ "flavoxate": [
+  "G04BD02"
+ ],
+ "flecainide": [
+  "C01BC04"
+ ],
+ "fleroxacin": [
+  "J01MA08"
+ ],
+ "flibanserin": [
+  "G02CX02"
+ ],
+ "floctafenine": [
+  "N02BG04"
+ ],
+ "flomoxef": [
+  "J01DC14"
+ ],
+ "florbetaben (18f)": [
+  "V09AX06"
+ ],
+ "florbetapir (18f)": [
+  "V09AX05"
+ ],
+ "flortaucipir (18f)": [
+  "V09AX07"
+ ],
+ "flosequinan": [
+  "C01DB01"
+ ],
+ "flotufolastat (18f)": [
+  "V09IX18"
+ ],
+ "flowers": [
+  "V01AA10"
+ ],
+ "floxuridine": [
+  "L01BC09"
+ ],
+ "fluanisone": [
+  "N05AD09"
+ ],
+ "flubendazole": [
+  "P02CA05"
+ ],
+ "fluciclovine (18f)": [
+  "V09IX12"
+ ],
+ "fluclorolone": [
+  "D07AC02"
+ ],
+ "flucloxacillin": [
+  "J01CF05"
+ ],
+ "fluconazole": [
+  "D01AC15",
+  "J02AC01"
+ ],
+ "flucytosine": [
+  "D01AE21",
+  "J02AX01"
+ ],
+ "fludarabine": [
+  "L01BB05"
+ ],
+ "fludeoxyglucose (18f)": [
+  "V09IX04"
+ ],
+ "fludiazepam": [
+  "N05BA17"
+ ],
+ "fludrocortisone": [
+  "H02AA02"
+ ],
+ "fludrocortisone and antiinfectives": [
+  "S01CA06",
+  "S02CA07",
+  "S03CA05"
+ ],
+ "fludroxycortide": [
+  "D07AC07"
+ ],
+ "fludroxycortide and antibiotics": [
+  "D07CC03"
+ ],
+ "flufenamic acid": [
+  "M01AG03"
+ ],
+ "fluindione": [
+  "B01AA12"
+ ],
+ "flumazenil": [
+  "V03AB25"
+ ],
+ "flumedroxone": [
+  "N02CB01"
+ ],
+ "flumequine": [
+  "J01MB07"
+ ],
+ "flumetasone": [
+  "D07AB03",
+  "D07XB01"
+ ],
+ "flumetasone and antibiotics": [
+  "D07CB05"
+ ],
+ "flumetasone and antiinfectives": [
+  "S02CA02"
+ ],
+ "flumetasone and antiseptics": [
+  "D07BB01"
+ ],
+ "flunarizine": [
+  "N07CA03"
+ ],
+ "flunisolide": [
+  "R01AD04",
+  "R03BA03"
+ ],
+ "flunitrazepam": [
+  "N05CD03"
+ ],
+ "flunoxaprofen": [
+  "G02CC04",
+  "M01AE15"
+ ],
+ "fluocinolone acetonide": [
+  "C05AA10",
+  "D07AC04",
+  "S01BA15",
+  "S02BA08"
+ ],
+ "fluocinolone acetonide and antibiotics": [
+  "D07CC02"
+ ],
+ "fluocinolone acetonide and antiinfectives": [
+  "S01CA10",
+  "S02CA05"
+ ],
+ "fluocinolone acetonide and antiseptics": [
+  "D07BC02"
+ ],
+ "fluocinonide": [
+  "C05AA11",
+  "D07AC08"
+ ],
+ "fluocinonide and antibiotics": [
+  "D07CC05"
+ ],
+ "fluocortin": [
+  "D07AB04"
+ ],
+ "fluocortolone": [
+  "C05AA08",
+  "D07AC05",
+  "D07XC05",
+  "H02AB03"
+ ],
+ "fluocortolone and antibiotics": [
+  "D07CC06"
+ ],
+ "fluocortolone and antiinfectives": [
+  "S01CA04"
+ ],
+ "fluocortolone and antiseptics": [
+  "D07BC03"
+ ],
+ "fluorescein": [
+  "S01JA01"
+ ],
+ "fluorescein, combinations": [
+  "S01JA51"
+ ],
+ "fluoride, combinations": [
+  "A12CD51"
+ ],
+ "fluorocarbon blood substitutes": [
+  "B05AA03"
+ ],
+ "fluorocholine(18f)": [
+  "V09IX07"
+ ],
+ "fluorodopa (18f)": [
+  "V09IX05"
+ ],
+ "fluoroestradiol (18f)": [
+  "V09IX11"
+ ],
+ "fluoroethyl-l-tyrosine (18f)": [
+  "V09IX10"
+ ],
+ "fluoroethylcholine (18f)": [
+  "V09IX08"
+ ],
+ "fluorometholone": [
+  "C05AA06",
+  "D07AB06",
+  "D07XB04",
+  "D10AA01",
+  "S01BA07",
+  "S01CB05"
+ ],
+ "fluorometholone and antibiotics": [
+  "D07CB03"
+ ],
+ "fluorometholone and antiinfectives": [
+  "S01CA07"
+ ],
+ "fluorometholone and mydriatics": [
+  "S01BB03"
+ ],
+ "fluorouracil": [
+  "L01BC02"
+ ],
+ "fluorouracil, combinations": [
+  "L01BC52"
+ ],
+ "fluostigmine": [
+  "S01EB07"
+ ],
+ "fluoxetine": [
+  "N06AB03"
+ ],
+ "fluoxetine and psycholeptics": [
+  "N06CA03"
+ ],
+ "fluoxymesterone": [
+  "G03BA01"
+ ],
+ "flupentixol": [
+  "N05AF01"
+ ],
+ "fluperolone": [
+  "D07AB05"
+ ],
+ "fluphenazine": [
+  "N05AB02"
+ ],
+ "flupirtine": [
+  "N02BG07"
+ ],
+ "fluprednidene": [
+  "D07AB07",
+  "D07XB03"
+ ],
+ "fluprednidene and antibiotics": [
+  "D07CB02"
+ ],
+ "flurazepam": [
+  "N05CD01"
+ ],
+ "flurbiprofen": [
+  "M01AE09",
+  "M02AA19",
+  "R02AX01",
+  "S01BC04"
+ ],
+ "flurithromycin": [
+  "J01FA14"
+ ],
+ "fluspirilene": [
+  "N05AG01"
+ ],
+ "flutamide": [
+  "L02BB01"
+ ],
+ "flutemetamol (18f)": [
+  "V09AX04"
+ ],
+ "fluticasone": [
+  "D07AC17",
+  "R01AD08",
+  "R03BA05"
+ ],
+ "fluticasone furoate": [
+  "R01AD12",
+  "R03BA09"
+ ],
+ "fluticasone, combinations": [
+  "R01AD58"
+ ],
+ "flutrimazole": [
+  "D01AC16",
+  "G01AF18"
+ ],
+ "fluvastatin": [
+  "C10AA04"
+ ],
+ "fluvoxamine": [
+  "N06AB08"
+ ],
+ "folic acid": [
+  "B03BB01",
+  "V04CX02"
+ ],
+ "folic acid, combinations": [
+  "B03BB51"
+ ],
+ "follitropin alfa": [
+  "G03GA05"
+ ],
+ "follitropin beta": [
+  "G03GA06"
+ ],
+ "follitropin delta": [
+  "G03GA10"
+ ],
+ "fomepizole": [
+  "V03AB34"
+ ],
+ "fomivirsen": [
+  "S01AD08"
+ ],
+ "fondaparinux": [
+  "B01AX05"
+ ],
+ "food": [
+  "V01AA08"
+ ],
+ "formestane": [
+  "L02BG02"
+ ],
+ "formocortal": [
+  "S01BA12"
+ ],
+ "formoterol": [
+  "R03AC13",
+  "R03CC15"
+ ],
+ "formoterol and aclidinium bromide": [
+  "R03AL05"
+ ],
+ "formoterol and beclometasone": [
+  "R03AK08"
+ ],
+ "formoterol and budesonide": [
+  "R03AK07"
+ ],
+ "formoterol and fluticasone": [
+  "R03AK11"
+ ],
+ "formoterol and glycopyrronium bromide": [
+  "R03AL07"
+ ],
+ "formoterol and mometasone": [
+  "R03AK09"
+ ],
+ "formoterol and tiotropium bromide": [
+  "R03AL10"
+ ],
+ "formoterol, glycopyrronium bromide and beclometasone": [
+  "R03AL09"
+ ],
+ "formoterol, glycopyrronium bromide and budesonide": [
+  "R03AL11"
+ ],
+ "fosamprenavir": [
+  "J05AE07"
+ ],
+ "foscarnet": [
+  "J05AD01"
+ ],
+ "fosdenopterin": [
+  "A16AX19"
+ ],
+ "fosfestrol": [
+  "L02AA04"
+ ],
+ "fosfocreatine": [
+  "C01EB06"
+ ],
+ "fosfomycin": [
+  "J01XX01",
+  "S02AA17"
+ ],
+ "fosfonet": [
+  "J05AD02"
+ ],
+ "fosinopril": [
+  "C09AA09"
+ ],
+ "fosinopril and diuretics": [
+  "C09BA09"
+ ],
+ "foslevodopa and decarboxylase inhibitor": [
+  "N04BA07"
+ ],
+ "fosphenytoin": [
+  "N03AB05"
+ ],
+ "fosravuconazole": [
+  "D01BA03"
+ ],
+ "fostamatinib": [
+  "B02BX09"
+ ],
+ "fostemsavir": [
+  "J05AX29"
+ ],
+ "fotemustine": [
+  "L01AD05"
+ ],
+ "framycetin": [
+  "D09AA01",
+  "R01AX08",
+  "S01AA07"
+ ],
+ "fremanezumab": [
+  "N02CD03"
+ ],
+ "frovatriptan": [
+  "N02CC07"
+ ],
+ "fructose": [
+  "V06DC02"
+ ],
+ "fructose 1,6-diphosphate": [
+  "C01EB07"
+ ],
+ "fruquintinib": [
+  "L01EK04"
+ ],
+ "ftivazide": [
+  "J04AC02"
+ ],
+ "fulvestrant": [
+  "L02BA03"
+ ],
+ "fumagillin": [
+  "P01AX10"
+ ],
+ "fumaric acid": [
+  "D05AX01"
+ ],
+ "fumaric acid derivatives, combinations": [
+  "D05BX51"
+ ],
+ "furazidin": [
+  "J01XE03"
+ ],
+ "furazolidone": [
+  "G01AX06"
+ ],
+ "furosemide": [
+  "C03CA01"
+ ],
+ "furosemide and potassium": [
+  "C03CB01"
+ ],
+ "furosemide and potassium-sparing agents": [
+  "C03EB01"
+ ],
+ "fusafungine": [
+  "R02AB03"
+ ],
+ "fusidic acid": [
+  "D06AX01",
+  "D09AA02",
+  "J01XC01",
+  "S01AA13"
+ ],
+ "futibatinib": [
+  "L01EN04"
+ ],
+ "g-strophanthin": [
+  "C01AC01"
+ ],
+ "gabapentin": [
+  "N02BF01"
+ ],
+ "gadobenic acid": [
+  "V08CA08"
+ ],
+ "gadobutrol": [
+  "V08CA09"
+ ],
+ "gadodiamide": [
+  "V08CA03"
+ ],
+ "gadofosveset": [
+  "V08CA11"
+ ],
+ "gadopentetic acid": [
+  "V08CA01"
+ ],
+ "gadopiclenol": [
+  "V08CA12"
+ ],
+ "gadoteric acid": [
+  "V08CA02"
+ ],
+ "gadoteridol": [
+  "V08CA04"
+ ],
+ "gadoversetamide": [
+  "V08CA06"
+ ],
+ "gadoxetic acid": [
+  "V08CA10"
+ ],
+ "galactose": [
+  "V04CE01"
+ ],
+ "galantamine": [
+  "N06DA04"
+ ],
+ "galcanezumab": [
+  "N02CD02"
+ ],
+ "gallamine": [
+  "M03AC02"
+ ],
+ "gallium (67ga) citrate": [
+  "V09HX01"
+ ],
+ "gallium (68ga) edotreotide": [
+  "V09IX09"
+ ],
+ "gallium (68ga) gozetotide": [
+  "V09IX14"
+ ],
+ "gallopamil": [
+  "C08DA02"
+ ],
+ "galsulfase": [
+  "A16AB08"
+ ],
+ "gamolenic acid": [
+  "D11AX02"
+ ],
+ "gamolenic acid, combinations": [
+  "D11AX52"
+ ],
+ "ganaxolone": [
+  "N03AX27"
+ ],
+ "ganciclovir": [
+  "J05AB06",
+  "S01AD09"
+ ],
+ "ganirelix": [
+  "H01CC01"
+ ],
+ "garadacimab": [
+  "B06AC07"
+ ],
+ "garenoxacin": [
+  "J01MA19"
+ ],
+ "gas-gangrene sera": [
+  "J06AA05"
+ ],
+ "gatifloxacin": [
+  "J01MA16",
+  "S01AE06"
+ ],
+ "gedocarnil": [
+  "N05BX02"
+ ],
+ "gefapixant": [
+  "R05DB29"
+ ],
+ "gefarnate": [
+  "A02BX07"
+ ],
+ "gefarnate, combinations with psycholeptics": [
+  "A02BX77"
+ ],
+ "gefitinib": [
+  "L01EB01"
+ ],
+ "gelatin agents": [
+  "B05AA06"
+ ],
+ "gemcitabine": [
+  "L01BC05"
+ ],
+ "gemeprost": [
+  "G02AD03"
+ ],
+ "gemfibrozil": [
+  "C10AB04"
+ ],
+ "gemifloxacin": [
+  "J01MA15"
+ ],
+ "gemigliptin": [
+  "A10BH06"
+ ],
+ "gemigliptin and dapagliflozin": [
+  "A10BD30"
+ ],
+ "gemigliptin and rosuvastatin": [
+  "A10BH52"
+ ],
+ "gemtuzumab ozogamicin": [
+  "L01FX02"
+ ],
+ "gentamicin": [
+  "D06AX07",
+  "J01GB03",
+  "S01AA11",
+  "S02AA14",
+  "S03AA06"
+ ],
+ "gepefrine": [
+  "C01CA15"
+ ],
+ "gepirone": [
+  "N06AX19"
+ ],
+ "gepotidacin": [
+  "J01XX13"
+ ],
+ "gestodene and ethinylestradiol": [
+  "G03AA10",
+  "G03AB06"
+ ],
+ "gestonorone": [
+  "G03DA01",
+  "L02AB03"
+ ],
+ "gestrinone": [
+  "G03XA02"
+ ],
+ "gilteritinib": [
+  "L01EX13"
+ ],
+ "ginkgo folium": [
+  "N06DX02"
+ ],
+ "gitoformate": [
+  "C01AA09"
+ ],
+ "givinostat": [
+  "M09AX14"
+ ],
+ "givosiran": [
+  "A16AX16"
+ ],
+ "glafenine": [
+  "N02BG03"
+ ],
+ "glasdegib": [
+  "L01XJ03"
+ ],
+ "glatiramer acetate": [
+  "L03AX13"
+ ],
+ "glecaprevir and pibrentasvir": [
+  "J05AP57"
+ ],
+ "glibenclamide": [
+  "A10BB01"
+ ],
+ "glibornuride": [
+  "A10BB04"
+ ],
+ "gliclazide": [
+  "A10BB09"
+ ],
+ "glimepiride": [
+  "A10BB12"
+ ],
+ "glimepiride and pioglitazone": [
+  "A10BD06"
+ ],
+ "glimepiride and rosiglitazone": [
+  "A10BD04"
+ ],
+ "glipizide": [
+  "A10BB07"
+ ],
+ "gliquidone": [
+  "A10BB08"
+ ],
+ "glisoxepide": [
+  "A10BB11"
+ ],
+ "glofitamab": [
+  "L01FX28"
+ ],
+ "glucagon": [
+  "H04AA01"
+ ],
+ "glucarpidase": [
+  "V03AF09"
+ ],
+ "glucosamine": [
+  "M01AX05"
+ ],
+ "glucosaminoglycan polysulfate": [
+  "M01AX12"
+ ],
+ "glucose": [
+  "B05CX01",
+  "V04CA02",
+  "V06DC01"
+ ],
+ "glucose, combinations": [
+  "C05BB56"
+ ],
+ "glutamic acid hydrochloride": [
+  "A09AB01"
+ ],
+ "glutamine": [
+  "A16AA03"
+ ],
+ "glutathione": [
+  "V03AB32"
+ ],
+ "glutethimide": [
+  "N05CE01"
+ ],
+ "glycerol": [
+  "A06AG04",
+  "A06AX01"
+ ],
+ "glycerol phenylbutyrate": [
+  "A16AX09"
+ ],
+ "glyceryl trinitrate": [
+  "C01DA02",
+  "C05AE01"
+ ],
+ "glyceryl trinitrate, combinations": [
+  "C01DA52"
+ ],
+ "glycine": [
+  "B05CX03"
+ ],
+ "glycobiarsol": [
+  "P01AR03"
+ ],
+ "glycobiarsol, combinations": [
+  "P01AR53"
+ ],
+ "glycopyrronium": [
+  "D11AA01"
+ ],
+ "glycopyrronium bromide": [
+  "A03AB02",
+  "R03BB06"
+ ],
+ "glycopyrronium bromide and psycholeptics": [
+  "A03CA05"
+ ],
+ "glycyrrhizic acid": [
+  "A05BA08"
+ ],
+ "glymidine": [
+  "A10BC01"
+ ],
+ "goflikicept": [
+  "L04AC26"
+ ],
+ "gold (198au) colloidal": [
+  "V10AX06"
+ ],
+ "golimumab": [
+  "L04AB06"
+ ],
+ "golodirsen": [
+  "M09AX08"
+ ],
+ "gonadorelin": [
+  "H01CA01",
+  "V04CM01"
+ ],
+ "goserelin": [
+  "L02AE03"
+ ],
+ "govorestat": [
+  "A16AX24"
+ ],
+ "gramicidin": [
+  "R02AB30"
+ ],
+ "granisetron": [
+  "A04AA02"
+ ],
+ "grass pollen": [
+  "V01AA02"
+ ],
+ "grazoprevir": [
+  "J05AP11"
+ ],
+ "grepafloxacin": [
+  "J01MA11"
+ ],
+ "griseofulvin": [
+  "D01AA08",
+  "D01BA01"
+ ],
+ "guacetisal": [
+  "N02BA14"
+ ],
+ "guaiacolsulfonate": [
+  "R05CA09"
+ ],
+ "guaiazulen": [
+  "S01XA01"
+ ],
+ "guaifenesin": [
+  "R05CA03"
+ ],
+ "guanazodine": [
+  "C02CC06"
+ ],
+ "guanethidine": [
+  "C02CC02",
+  "S01EX01"
+ ],
+ "guanethidine and diuretics": [
+  "C02LF01"
+ ],
+ "guanfacine": [
+  "C02AC02"
+ ],
+ "guanoclor": [
+  "C02CC05"
+ ],
+ "guanoxabenz": [
+  "C02CC07"
+ ],
+ "guanoxan": [
+  "C02CC03"
+ ],
+ "guar gum": [
+  "A10BX01"
+ ],
+ "guselkumab": [
+  "L04AC16"
+ ],
+ "gusperimus": [
+  "L04AA19"
+ ],
+ "hachimycin": [
+  "D01AA03",
+  "G01AA06",
+  "J02AA02"
+ ],
+ "haemophilus influenza b, combinations with meningococcus c,y, conjugated": [
+  "J07AG54"
+ ],
+ "halazepam": [
+  "N05BA13"
+ ],
+ "halcinonide": [
+  "D07AD02"
+ ],
+ "halofantrine": [
+  "P01BX01"
+ ],
+ "halometasone": [
+  "D07AC12"
+ ],
+ "haloperidol": [
+  "N05AD01"
+ ],
+ "haloprogin": [
+  "D01AE11"
+ ],
+ "halothane": [
+  "N01AB01"
+ ],
+ "hederae helicis folium": [
+  "R05CA12"
+ ],
+ "helium": [
+  "V03AN03"
+ ],
+ "hemin": [
+  "B06AB01"
+ ],
+ "hemoglobin crosfumaril": [
+  "B05AA08"
+ ],
+ "hemoglobin glutamer (bovine)": [
+  "B05AA10"
+ ],
+ "hemoglobin raffimer": [
+  "B05AA09"
+ ],
+ "hemophilus influenzae b and hepatitis b": [
+  "J07CA08"
+ ],
+ "hemophilus influenzae b and poliomyelitis": [
+  "J07CA04"
+ ],
+ "hemophilus influenzae b, combinations with meningococcus c, conjugated": [
+  "J07AG53"
+ ],
+ "hemophilus influenzae b, combinations with pertussis and toxoids": [
+  "J07AG52"
+ ],
+ "hemophilus influenzae b, combinations with toxoids": [
+  "J07AG51"
+ ],
+ "hemophilus influenzae b, purified antigen conjugated": [
+  "J07AG01"
+ ],
+ "heparin": [
+  "B01AB01",
+  "C05BA03",
+  "S01XA14"
+ ],
+ "heparin, combinations": [
+  "B01AB51",
+  "C05BA53"
+ ],
+ "heparinoid, combinations": [
+  "C05BA51"
+ ],
+ "hepatitis a immunoglobulin": [
+  "J06BB11"
+ ],
+ "hepatitis a, inactivated, whole virus": [
+  "J07BC02"
+ ],
+ "hepatitis b immunoglobulin": [
+  "J06BB04"
+ ],
+ "hepatitis b, purified antigen": [
+  "J07BC01"
+ ],
+ "heptabarbital": [
+  "N05CA11"
+ ],
+ "heptaminol": [
+  "C01DX08"
+ ],
+ "hetacillin": [
+  "J01CA18"
+ ],
+ "hexachlorophene": [
+  "D08AE01"
+ ],
+ "hexafluronium": [
+  "M03AC05"
+ ],
+ "hexamidine": [
+  "D08AC04",
+  "R01AX07",
+  "R02AA18",
+  "S01AX08",
+  "S03AA05"
+ ],
+ "hexaminolevulinate": [
+  "V04CX06"
+ ],
+ "hexapropymate": [
+  "N05CM10"
+ ],
+ "hexetidine": [
+  "A01AB12",
+  "G01AX16"
+ ],
+ "hexobarbital": [
+  "N01AF02",
+  "N05CA16"
+ ],
+ "hexobendine": [
+  "C01DX06"
+ ],
+ "hexocyclium": [
+  "A03AB10"
+ ],
+ "hexoprenaline": [
+  "R03AC06",
+  "R03CC05"
+ ],
+ "hexylresorcinol": [
+  "R02AA12"
+ ],
+ "hidrosmin": [
+  "C05CA05"
+ ],
+ "hippocastani semen": [
+  "C05CX03"
+ ],
+ "histamine dihydrochloride": [
+  "L03AX14"
+ ],
+ "histamine phosphate": [
+  "V04CG03"
+ ],
+ "histapyrrodine": [
+  "R06AC02"
+ ],
+ "histapyrrodine, combinations": [
+  "R06AC52"
+ ],
+ "histrelin": [
+  "L02AE05"
+ ],
+ "homatropine": [
+  "S01FA05"
+ ],
+ "homatropine methylbromide": [
+  "A03BB06"
+ ],
+ "homatropine methylbromide and psycholeptics": [
+  "A03CB04"
+ ],
+ "house dust mites": [
+  "V01AA03"
+ ],
+ "human menopausal gonadotrophin": [
+  "G03GA02"
+ ],
+ "hyaluronic acid": [
+  "D03AX05",
+  "M09AX01",
+  "R01AX09",
+  "S01KA01"
+ ],
+ "hyaluronic acid, combinations": [
+  "S01KA51"
+ ],
+ "hyaluronidase": [
+  "B06AA03"
+ ],
+ "hydralazine": [
+  "C02DB02"
+ ],
+ "hydralazine and diuretics": [
+  "C02LG02"
+ ],
+ "hydrochloric acid": [
+  "A09AB03",
+  "B05XA13"
+ ],
+ "hydrochlorothiazide": [
+  "C03AA03"
+ ],
+ "hydrochlorothiazide and potassium": [
+  "C03AB03"
+ ],
+ "hydrochlorothiazide and potassium-sparing agents": [
+  "C03EA01"
+ ],
+ "hydrochlorothiazide, combinations": [
+  "C03AX01"
+ ],
+ "hydrocodone": [
+  "R05DA03"
+ ],
+ "hydrocodone and ibuprofen": [
+  "N02AJ23"
+ ],
+ "hydrocodone and paracetamol": [
+  "N02AJ22"
+ ],
+ "hydrocortisone": [
+  "A01AC03",
+  "A07EA02",
+  "C05AA01",
+  "D07AA02",
+  "D07XA01",
+  "H02AB09",
+  "S01BA02",
+  "S01CB03",
+  "S02BA01"
+ ],
+ "hydrocortisone aceponate": [
+  "D07AC16"
+ ],
+ "hydrocortisone and antibiotics": [
+  "D07CA01"
+ ],
+ "hydrocortisone and antiinfectives": [
+  "S01CA03",
+  "S02CA03",
+  "S03CA04"
+ ],
+ "hydrocortisone and antiseptics": [
+  "D07BA04"
+ ],
+ "hydrocortisone and mydriatics": [
+  "S01BB01"
+ ],
+ "hydrocortisone buteprate": [
+  "D07AB11"
+ ],
+ "hydrocortisone butyrate": [
+  "D07AB02"
+ ],
+ "hydrocortisone butyrate and antiseptics": [
+  "D07BB04"
+ ],
+ "hydrocortisone, combinations": [
+  "R01AD60"
+ ],
+ "hydroflumethiazide": [
+  "C03AA02"
+ ],
+ "hydroflumethiazide and potassium": [
+  "C03AB02"
+ ],
+ "hydroflumethiazide, combinations": [
+  "C03AH02"
+ ],
+ "hydrogen peroxide": [
+  "A01AB02",
+  "D08AX01",
+  "D11AX25",
+  "S02AA06"
+ ],
+ "hydromorphone": [
+  "N02AA03"
+ ],
+ "hydromorphone and antispasmodics": [
+  "N02AG04"
+ ],
+ "hydromorphone and naloxone": [
+  "N02AA53"
+ ],
+ "hydroquinidine": [
+  "C01BA13"
+ ],
+ "hydroquinine": [
+  "M09AA01"
+ ],
+ "hydroquinone": [
+  "D11AX11"
+ ],
+ "hydrotalcite": [
+  "A02AD04"
+ ],
+ "hydroxocobalamin": [
+  "B03BA03",
+  "V03AB33"
+ ],
+ "hydroxocobalamin, combinations": [
+  "B03BA53"
+ ],
+ "hydroxycarbamide": [
+  "L01XX05"
+ ],
+ "hydroxychloroquine": [
+  "P01BA02"
+ ],
+ "hydroxyethylpromethazine": [
+  "R06AD05"
+ ],
+ "hydroxyethylpromethazine, combinations": [
+  "R06AD55"
+ ],
+ "hydroxyethylstarch": [
+  "B05AA07"
+ ],
+ "hydroxyprogesterone": [
+  "G03DA03"
+ ],
+ "hydroxyprogesterone and estrogen": [
+  "G03FA02"
+ ],
+ "hydroxyzine": [
+  "N05BB01"
+ ],
+ "hydroxyzine, combinations": [
+  "N05BB51"
+ ],
+ "hymecromone": [
+  "A05AX02"
+ ],
+ "hyoscyamine": [
+  "A03BA03"
+ ],
+ "hyoscyamine and psycholeptics": [
+  "A03CB31"
+ ],
+ "hyperici herba": [
+  "N06AX25"
+ ],
+ "hypromellose": [
+  "S01KA02"
+ ],
+ "ibacitabine": [
+  "D06BB08"
+ ],
+ "ibalizumab": [
+  "J05AX23"
+ ],
+ "ibandronic acid": [
+  "M05BA06"
+ ],
+ "ibandronic acid and colecalciferol": [
+  "M05BB09"
+ ],
+ "ibopamine": [
+  "C01CA16",
+  "S01FB03"
+ ],
+ "ibrexafungerp": [
+  "J02AX07"
+ ],
+ "ibritumomab tiuxetan (90y)": [
+  "V10XX02"
+ ],
+ "ibrutinib": [
+  "L01EL01"
+ ],
+ "ibudilast": [
+  "R03DC04"
+ ],
+ "ibuprofen": [
+  "C01EB16",
+  "G02CC01",
+  "M01AE01",
+  "M02AA13",
+  "R02AX02"
+ ],
+ "ibuprofen, combinations": [
+  "M01AE51"
+ ],
+ "ibuproxam": [
+  "M01AE13"
+ ],
+ "ibutilide": [
+  "C01BD05"
+ ],
+ "icatibant": [
+  "B06AC02"
+ ],
+ "ichtasol": [
+  "D10BX01"
+ ],
+ "iclaprim": [
+  "J01EA03"
+ ],
+ "icotinib": [
+  "L01EB08"
+ ],
+ "idanpramine": [
+  "A03AX06"
+ ],
+ "idarubicin": [
+  "L01DB06"
+ ],
+ "idarucizumab": [
+  "V03AB37"
+ ],
+ "idebenone": [
+  "N06BX13"
+ ],
+ "idecabtagene vicleucel": [
+  "L01XL07"
+ ],
+ "idelalisib": [
+  "L01EM01"
+ ],
+ "idoxuridine": [
+  "D06BB01",
+  "J05AB02",
+  "S01AD01"
+ ],
+ "idrocilamide": [
+  "M02AX05"
+ ],
+ "idroxioleic acid": [
+  "L01XX85"
+ ],
+ "idursulfase": [
+  "A16AB09"
+ ],
+ "idursulfase beta": [
+  "A16AB16"
+ ],
+ "ifenprodil": [
+  "C04AX28"
+ ],
+ "ifosfamide": [
+  "L01AA06"
+ ],
+ "ilaprazole": [
+  "A02BC11"
+ ],
+ "iloperidone": [
+  "N05AX14"
+ ],
+ "iloprost": [
+  "B01AC11"
+ ],
+ "imatinib": [
+  "L01EA01"
+ ],
+ "imeglimin": [
+  "A10BX15"
+ ],
+ "imetelstat": [
+  "L01XX80"
+ ],
+ "imidafenacin": [
+  "G04BD14"
+ ],
+ "imidapril": [
+  "C09AA16"
+ ],
+ "imidazole salicylate": [
+  "N02BA16"
+ ],
+ "imidazoles/triazoles in combination with corticosteroids": [
+  "D01AC20"
+ ],
+ "imiglucerase": [
+  "A16AB02"
+ ],
+ "imipenem and cilastatin": [
+  "J01DH51"
+ ],
+ "imipenem, cilastatin and relebactam": [
+  "J01DH56"
+ ],
+ "imipramine": [
+  "N06AA02"
+ ],
+ "imipramine oxide": [
+  "N06AA03"
+ ],
+ "imiquimod": [
+  "D06BB10"
+ ],
+ "imlifidase": [
+  "L04AA41"
+ ],
+ "immunocyanin": [
+  "L03AX10"
+ ],
+ "immunoglobulins, normal human, for extravascular adm.": [
+  "J06BA01"
+ ],
+ "immunoglobulins, normal human, for intravascular adm.": [
+  "J06BA02"
+ ],
+ "imolamine": [
+  "C01DX09"
+ ],
+ "inclisiran": [
+  "C10AX16"
+ ],
+ "indacaterol": [
+  "R03AC18"
+ ],
+ "indacaterol and glycopyrronium bromide": [
+  "R03AL04"
+ ],
+ "indacaterol and mometasone": [
+  "R03AK14"
+ ],
+ "indacaterol, glycopyrronium bromide and mometasone": [
+  "R03AL12"
+ ],
+ "indanazoline": [
+  "R01AA15"
+ ],
+ "indapamide": [
+  "C03BA11"
+ ],
+ "indigo carmine": [
+  "V04CH02"
+ ],
+ "indinavir": [
+  "J05AE02"
+ ],
+ "indium (111in) antiovariumcarcinoma antibody": [
+  "V09IB03"
+ ],
+ "indium (111in) capromab pendetide": [
+  "V09IB04"
+ ],
+ "indium (111in) imciromab": [
+  "V09GX02"
+ ],
+ "indium (111in) oxinate labelled cells": [
+  "V09HB01"
+ ],
+ "indium (111in) pentetic acid": [
+  "V09AX01"
+ ],
+ "indium (111in) pentetreotide": [
+  "V09IB01"
+ ],
+ "indium (111in) satumomab pendetide": [
+  "V09IB02"
+ ],
+ "indium (111in) tropolonate labelled cells": [
+  "V09HB02"
+ ],
+ "indobufen": [
+  "B01AC10"
+ ],
+ "indocyanine green": [
+  "V04CX01"
+ ],
+ "indometacin": [
+  "C01EB03",
+  "M01AB01",
+  "M02AA23",
+  "S01BC01"
+ ],
+ "indometacin and antiinfectives": [
+  "S01CC02"
+ ],
+ "indometacin, combinations": [
+  "M01AB51"
+ ],
+ "indoprofen": [
+  "M01AE10"
+ ],
+ "indoramin": [
+  "C02CA02"
+ ],
+ "inebilizumab": [
+  "L04AG10"
+ ],
+ "infigratinib": [
+  "L01EN03"
+ ],
+ "infliximab": [
+  "L04AB02"
+ ],
+ "influenza, inactivated, split virus or surface antigen": [
+  "J07BB02"
+ ],
+ "influenza, inactivated, whole virus": [
+  "J07BB01"
+ ],
+ "influenza, live attenuated": [
+  "J07BB03"
+ ],
+ "influenza, rna-based vaccine": [
+  "J07BB05"
+ ],
+ "influenza, virus like particles": [
+  "J07BB04"
+ ],
+ "ingenol mebutate": [
+  "D06BX02"
+ ],
+ "inosine": [
+  "D06BB05",
+  "G01AX02",
+  "S01XA10"
+ ],
+ "inosine pranobex": [
+  "J05AX05"
+ ],
+ "inositol": [
+  "A11HA07"
+ ],
+ "inositol nicotinate": [
+  "C04AC03"
+ ],
+ "inotersen": [
+  "N07XX15"
+ ],
+ "inotuzumab ozogamicin": [
+  "L01FB01"
+ ],
+ "insects": [
+  "V01AA07"
+ ],
+ "insulin (beef)": [
+  "A10AB02",
+  "A10AC02",
+  "A10AD02",
+  "A10AE02"
+ ],
+ "insulin (human)": [
+  "A10AB01",
+  "A10AC01",
+  "A10AD01",
+  "A10AE01",
+  "A10AF01"
+ ],
+ "insulin (pork)": [
+  "A10AB03",
+  "A10AC03",
+  "A10AD03",
+  "A10AE03"
+ ],
+ "insulin aspart": [
+  "A10AB05",
+  "A10AD05"
+ ],
+ "insulin degludec": [
+  "A10AE06"
+ ],
+ "insulin degludec and insulin aspart": [
+  "A10AD06"
+ ],
+ "insulin degludec and liraglutide": [
+  "A10AE56"
+ ],
+ "insulin detemir": [
+  "A10AE05"
+ ],
+ "insulin glargine": [
+  "A10AE04"
+ ],
+ "insulin glargine and lixisenatide": [
+  "A10AE54"
+ ],
+ "insulin glulisine": [
+  "A10AB06"
+ ],
+ "insulin icodec": [
+  "A10AE07"
+ ],
+ "insulin lispro": [
+  "A10AB04",
+  "A10AC04"
+ ],
+ "interferon": [
+  "S01AD05"
+ ],
+ "interferon alfa natural": [
+  "L03AB01"
+ ],
+ "interferon alfa-2a": [
+  "L03AB04"
+ ],
+ "interferon alfa-2b": [
+  "L03AB05"
+ ],
+ "interferon alfa-n1": [
+  "L03AB06"
+ ],
+ "interferon alfacon-1": [
+  "L03AB09"
+ ],
+ "interferon beta natural": [
+  "L03AB02"
+ ],
+ "interferon beta-1a": [
+  "L03AB07"
+ ],
+ "interferon beta-1b": [
+  "L03AB08"
+ ],
+ "interferon gamma": [
+  "L03AB03"
+ ],
+ "inulin and other polyfructosans": [
+  "V04CH01"
+ ],
+ "invert sugar": [
+  "C05BB03"
+ ],
+ "iobenguane (123i)": [
+  "V09IX01"
+ ],
+ "iobenguane (131i)": [
+  "V09IX02",
+  "V10XA02"
+ ],
+ "iobenzamic acid": [
+  "V08AC05"
+ ],
+ "iobitridol": [
+  "V08AB11"
+ ],
+ "iocarmic acid": [
+  "V08AA08"
+ ],
+ "iocetamic acid": [
+  "V08AC07"
+ ],
+ "iodamide": [
+  "V08AA03"
+ ],
+ "iodine": [
+  "D08AG03"
+ ],
+ "iodine (124i) 2beta-carbomethoxy-3beta-(4 iodophenyl)-tropane": [
+  "V09AX03"
+ ],
+ "iodine (125i) cc49-monoclonal antibody": [
+  "V09IX03"
+ ],
+ "iodine (125i) human albumin": [
+  "V09GB02"
+ ],
+ "iodine (131i) apamistamab": [
+  "V10XA04"
+ ],
+ "iodine (131i) human albumin": [
+  "V09XA03"
+ ],
+ "iodine (131i) norcholesterol": [
+  "V09XA01"
+ ],
+ "iodine (131i) omburtamab": [
+  "V10XA03"
+ ],
+ "iodine iofetamine (123i)": [
+  "V09AB01"
+ ],
+ "iodine ioflupane (123i)": [
+  "V09AB03"
+ ],
+ "iodine iolopride (123i)": [
+  "V09AB02"
+ ],
+ "iodine/octylphenoxypolyglycolether": [
+  "D08AG01"
+ ],
+ "iodixanol": [
+  "V08AB09"
+ ],
+ "iodocholesterol (131i)": [
+  "V09XA02"
+ ],
+ "iodoform": [
+  "D09AA13"
+ ],
+ "iodoheparinate": [
+  "S01XA09"
+ ],
+ "iodoxamic acid": [
+  "V08AC01"
+ ],
+ "iofendylate": [
+  "V08AD04"
+ ],
+ "ioglicic acid": [
+  "V08AA06"
+ ],
+ "ioglycamic acid": [
+  "V08AC03"
+ ],
+ "iohexol": [
+  "V08AB02"
+ ],
+ "iomeprol": [
+  "V08AB10"
+ ],
+ "iopamidol": [
+  "V08AB04"
+ ],
+ "iopanoic acid": [
+  "V08AC06"
+ ],
+ "iopentol": [
+  "V08AB08"
+ ],
+ "iopromide": [
+  "V08AB05"
+ ],
+ "iopydol": [
+  "V08AD02"
+ ],
+ "iotalamic acid": [
+  "V08AA04"
+ ],
+ "iotrolan": [
+  "V08AB06"
+ ],
+ "iotroxic acid": [
+  "V08AC02"
+ ],
+ "ioversol": [
+  "V08AB07"
+ ],
+ "ioxaglic acid": [
+  "V08AB03"
+ ],
+ "ioxilan": [
+  "V08AB12"
+ ],
+ "ioxitalamic acid": [
+  "V08AA05"
+ ],
+ "ipecacuanha": [
+  "R05CA04",
+  "V03AB01"
+ ],
+ "ipidacrine": [
+  "N06DA05"
+ ],
+ "ipilimumab": [
+  "L01FX04"
+ ],
+ "ipragliflozin": [
+  "A10BK05"
+ ],
+ "ipratropium bromide": [
+  "R01AX03",
+  "R03BB01"
+ ],
+ "iprazochrome": [
+  "N02CX03"
+ ],
+ "ipriflavone": [
+  "M05BX01"
+ ],
+ "iprindole": [
+  "N06AA13"
+ ],
+ "iproclozide": [
+  "N06AF06"
+ ],
+ "iproniazide": [
+  "N06AF05"
+ ],
+ "iptacopan": [
+  "L04AJ08"
+ ],
+ "irbesartan": [
+  "C09CA04"
+ ],
+ "irbesartan and amlodipine": [
+  "C09DB05"
+ ],
+ "irbesartan and diuretics": [
+  "C09DA04"
+ ],
+ "irbesartan, amlodipine and hydrochlorothiazide": [
+  "C09DX07"
+ ],
+ "irinotecan": [
+  "L01CE02"
+ ],
+ "iron and multivitamins": [
+  "B03AE03"
+ ],
+ "iron oxide, nanoparticles": [
+  "V08CB03"
+ ],
+ "iron, multivitamins and folic acid": [
+  "B03AE02"
+ ],
+ "iron, multivitamins and minerals": [
+  "B03AE04"
+ ],
+ "iron, vitamin b12 and folic acid": [
+  "B03AE01"
+ ],
+ "irsogladine": [
+  "A02BX16"
+ ],
+ "isatuximab": [
+  "L01FC02"
+ ],
+ "isavuconazole": [
+  "J02AC05"
+ ],
+ "isepamicin": [
+  "J01GB11"
+ ],
+ "isoaminile": [
+  "R05DB04"
+ ],
+ "isobromindione": [
+  "M04AB04"
+ ],
+ "isocarboxazid": [
+  "N06AF01"
+ ],
+ "isoconazole": [
+  "D01AC05",
+  "G01AF07"
+ ],
+ "isoetarine": [
+  "R03AC07",
+  "R03CC06"
+ ],
+ "isoflurane": [
+  "N01AB06"
+ ],
+ "isometheptene": [
+  "A03AX10"
+ ],
+ "isoniazid": [
+  "J04AC01"
+ ],
+ "isoniazid, combinations": [
+  "J04AC51"
+ ],
+ "isoniazid, sulfamethoxazole and trimethoprim": [
+  "J04AM08"
+ ],
+ "isoprenaline": [
+  "C01CA02",
+  "R03AB02",
+  "R03CB01"
+ ],
+ "isoprenaline and other drugs for obstructive airway diseases": [
+  "R03AK02"
+ ],
+ "isoprenaline, combinations": [
+  "R03CB51"
+ ],
+ "isopropamide": [
+  "A03AB09"
+ ],
+ "isopropamide and psycholeptics": [
+  "A03CA01"
+ ],
+ "isopropanol": [
+  "D08AX05"
+ ],
+ "isosorbide dinitrate": [
+  "C01DA08",
+  "C05AE02"
+ ],
+ "isosorbide dinitrate, combinations": [
+  "C01DA58"
+ ],
+ "isosorbide mononitrate": [
+  "C01DA14"
+ ],
+ "isothipendyl": [
+  "D04AA22",
+  "R06AD09"
+ ],
+ "isotretinoin": [
+  "D10AD04",
+  "D10BA01"
+ ],
+ "isotretinoin, combinations": [
+  "D10AD54"
+ ],
+ "isoxsuprine": [
+  "C04AA01"
+ ],
+ "ispaghula (psylla seeds)": [
+  "A06AC01"
+ ],
+ "ispaghula, combinations": [
+  "A06AC51"
+ ],
+ "isradipine": [
+  "C08CA03"
+ ],
+ "istradefylline": [
+  "N04CX01"
+ ],
+ "itacitinib": [
+  "L04AF05"
+ ],
+ "itopride": [
+  "A03FA07"
+ ],
+ "itraconazole": [
+  "J02AC02"
+ ],
+ "itramin tosilate": [
+  "C01DX01"
+ ],
+ "itramin tosilate, combinations": [
+  "C01DX51"
+ ],
+ "ivabradine": [
+  "C01EB17"
+ ],
+ "ivacaftor": [
+  "R07AX02"
+ ],
+ "ivacaftor and lumacaftor": [
+  "R07AX30"
+ ],
+ "ivacaftor and tezacaftor": [
+  "R07AX31"
+ ],
+ "ivacaftor, tezacaftor and elexacaftor": [
+  "R07AX32"
+ ],
+ "ivermectin": [
+  "D11AX22",
+  "P02CF01"
+ ],
+ "ivosidenib": [
+  "L01XM02"
+ ],
+ "ixabepilone": [
+  "L01DC04"
+ ],
+ "ixazomib": [
+  "L01XG03"
+ ],
+ "ixekizumab": [
+  "L04AC13"
+ ],
+ "josamycin": [
+  "J01FA07"
+ ],
+ "kallidinogenase": [
+  "C04AF01"
+ ],
+ "kanamycin": [
+  "A07AA08",
+  "J01GB04",
+  "S01AA24"
+ ],
+ "kaolin": [
+  "A07BC02"
+ ],
+ "kebuzone": [
+  "M01AA06"
+ ],
+ "ketamine": [
+  "N01AX03"
+ ],
+ "ketanserin": [
+  "C02KD01"
+ ],
+ "ketazolam": [
+  "N05BA10"
+ ],
+ "ketobemidone": [
+  "N02AB01"
+ ],
+ "ketobemidone and antispasmodics": [
+  "N02AG02"
+ ],
+ "ketoconazole": [
+  "D01AC08",
+  "G01AF11",
+  "H02CA03",
+  "J02AB02"
+ ],
+ "ketoprofen": [
+  "M01AE03",
+  "M02AA10"
+ ],
+ "ketoprofen, combinations": [
+  "M01AE53"
+ ],
+ "ketorolac": [
+  "M01AB15",
+  "S01BC05"
+ ],
+ "ketotifen": [
+  "R06AX17",
+  "S01GX08"
+ ],
+ "krypton (81mkr) gas": [
+  "V09EX01"
+ ],
+ "labetalol": [
+  "C07AG01"
+ ],
+ "labetalol and other diuretics": [
+  "C07CG01"
+ ],
+ "labetalol and thiazides": [
+  "C07BG01"
+ ],
+ "labuvirtide": [
+  "J05AX33"
+ ],
+ "lacidipine": [
+  "C08CA09"
+ ],
+ "lacosamide": [
+  "N03AX18"
+ ],
+ "lactic acid": [
+  "G01AD01"
+ ],
+ "lactic acid producing organisms": [
+  "A07FA01"
+ ],
+ "lactic acid producing organisms, combinations": [
+  "A07FA51"
+ ],
+ "lactitol": [
+  "A06AD12"
+ ],
+ "lactobacillus": [
+  "G01AX14"
+ ],
+ "lactulose": [
+  "A06AD11"
+ ],
+ "lactulose, combinations": [
+  "A06AD61"
+ ],
+ "lafutidine": [
+  "A02BA08"
+ ],
+ "lamivudine": [
+  "J05AF05"
+ ],
+ "lamivudine and abacavir": [
+  "J05AR02"
+ ],
+ "lamivudine and dolutegravir": [
+  "J05AR25"
+ ],
+ "lamivudine and raltegravir": [
+  "J05AR16"
+ ],
+ "lamivudine and tenofovir disoproxil": [
+  "J05AR12"
+ ],
+ "lamivudine, abacavir and dolutegravir": [
+  "J05AR13"
+ ],
+ "lamivudine, tenofovir disoproxil and dolutegravir": [
+  "J05AR27"
+ ],
+ "lamivudine, tenofovir disoproxil and doravirine": [
+  "J05AR24"
+ ],
+ "lamivudine, tenofovir disoproxil and efavirenz": [
+  "J05AR11"
+ ],
+ "lamotrigine": [
+  "N03AX09"
+ ],
+ "lanadelumab": [
+  "B06AC05"
+ ],
+ "lanatoside c": [
+  "C01AA06"
+ ],
+ "landiolol": [
+  "C07AB14"
+ ],
+ "laninamivir": [
+  "J05AH04"
+ ],
+ "lanoconazole": [
+  "D01AC22"
+ ],
+ "lanreotide": [
+  "H01CB03"
+ ],
+ "lansoprazole": [
+  "A02BC03"
+ ],
+ "lansoprazole, amoxicillin and clarithromycin": [
+  "A02BD07"
+ ],
+ "lansoprazole, amoxicillin and levofloxacin": [
+  "A02BD10"
+ ],
+ "lansoprazole, amoxicillin and metronidazole": [
+  "A02BD03"
+ ],
+ "lansoprazole, clarithromycin and tinidazole": [
+  "A02BD09"
+ ],
+ "lansoprazole, combinations": [
+  "A02BC53"
+ ],
+ "lansoprazole, tetracycline and metronidazole": [
+  "A02BD02"
+ ],
+ "lanthanum carbonate": [
+  "V03AE03"
+ ],
+ "lapatinib": [
+  "L01EH01"
+ ],
+ "laquinimod": [
+  "N07XX10"
+ ],
+ "laronidase": [
+  "A16AB05"
+ ],
+ "larotrectinib": [
+  "L01EX12"
+ ],
+ "lascufloxacin": [
+  "J01MA25"
+ ],
+ "lasmiditan": [
+  "N02CC08"
+ ],
+ "lasofoxifene": [
+  "G03XC03"
+ ],
+ "latamoxef": [
+  "J01DD06"
+ ],
+ "latanoprost": [
+  "S01EE01"
+ ],
+ "latanoprost and dorzolamide": [
+  "S01EE52"
+ ],
+ "latanoprost and netarsudil": [
+  "S01EE51"
+ ],
+ "latanoprostene bunod": [
+  "S01EE06"
+ ],
+ "lavandulae aetheroleum": [
+  "N05BX05"
+ ],
+ "lazertinib": [
+  "L01EB09"
+ ],
+ "lebrikizumab": [
+  "D11AH10"
+ ],
+ "lecanemab": [
+  "N06DX04"
+ ],
+ "lefamulin": [
+  "J01XX12"
+ ],
+ "leflunomide": [
+  "L04AK01"
+ ],
+ "lemborexant": [
+  "N05CJ02"
+ ],
+ "lenacapavir": [
+  "J05AX31"
+ ],
+ "lenalidomide": [
+  "L04AX04"
+ ],
+ "leniolisib": [
+  "L03AX22"
+ ],
+ "lenograstim": [
+  "L03AA10"
+ ],
+ "lentinan": [
+  "L03AX01"
+ ],
+ "lenvatinib": [
+  "L01EX08"
+ ],
+ "lepirudin": [
+  "B01AE02"
+ ],
+ "leptospira vaccines": [
+  "J07AX01"
+ ],
+ "lercanidipine": [
+  "C08CA13"
+ ],
+ "leriglitazone": [
+  "A16AX23"
+ ],
+ "lesinurad": [
+  "M04AB05"
+ ],
+ "letermovir": [
+  "J05AX18"
+ ],
+ "letosteine": [
+  "R05CB09"
+ ],
+ "letrozole": [
+  "L02BG04"
+ ],
+ "leuprorelin": [
+  "L02AE02"
+ ],
+ "leuprorelin and bicalutamide": [
+  "L02AE51"
+ ],
+ "levacetylmethadol": [
+  "N07BC03"
+ ],
+ "levamisole": [
+  "P02CE01"
+ ],
+ "levamlodipine": [
+  "C08CA17"
+ ],
+ "levetiracetam": [
+  "N03AX14"
+ ],
+ "levilimab": [
+  "L04AC25"
+ ],
+ "levobunolol": [
+  "S01ED03"
+ ],
+ "levobupivacaine": [
+  "N01BB10"
+ ],
+ "levocabastine": [
+  "R01AC02",
+  "S01GX02"
+ ],
+ "levocarnitine": [
+  "A16AA01"
+ ],
+ "levocetirizine": [
+  "R06AE09"
+ ],
+ "levodopa": [
+  "N04BA01"
+ ],
+ "levodopa and decarboxylase inhibitor": [
+  "N04BA02"
+ ],
+ "levodopa, decarboxylase inhibitor and comt inhibitor": [
+  "N04BA03"
+ ],
+ "levodropropizine": [
+  "R05DB27"
+ ],
+ "levofloxacin": [
+  "J01MA12",
+  "S01AE05"
+ ],
+ "levofloxacin and ornidazole": [
+  "J01RA05"
+ ],
+ "levoketoconazole": [
+  "H02CA04"
+ ],
+ "levomepromazine": [
+  "N05AA02"
+ ],
+ "levomethadone": [
+  "N07BC05"
+ ],
+ "levomilnacipran": [
+  "N06AX28"
+ ],
+ "levonadifloxacin": [
+  "J01MA24"
+ ],
+ "levonorgestrel": [
+  "G03AC03",
+  "G03AD01"
+ ],
+ "levonorgestrel and estrogen": [
+  "G03FA11",
+  "G03FB09"
+ ],
+ "levonorgestrel and ethinylestradiol": [
+  "G03AA07",
+  "G03AB03"
+ ],
+ "levosimendan": [
+  "C01CX08"
+ ],
+ "levosulpiride": [
+  "N05AL07"
+ ],
+ "levothyroxine sodium": [
+  "H03AA01"
+ ],
+ "levothyroxine sodium and iodine compounds": [
+  "H03AA51"
+ ],
+ "levoverbenone": [
+  "R05CA11"
+ ],
+ "lidocaine": [
+  "C01BB01",
+  "C05AD01",
+  "D04AB01",
+  "N01BB02",
+  "R02AD02",
+  "S01HA07",
+  "S02DA01"
+ ],
+ "lidocaine, combinations": [
+  "N01BB52"
+ ],
+ "lidoflazine": [
+  "C08EX01"
+ ],
+ "lifileucel": [
+  "L01XL11"
+ ],
+ "lifitegrast": [
+  "S01XA25"
+ ],
+ "limaprost": [
+  "B01AC28"
+ ],
+ "limbal stems cells, autologous": [
+  "S01XA19"
+ ],
+ "linaclotide": [
+  "A06AX04"
+ ],
+ "linagliptin": [
+  "A10BH05"
+ ],
+ "linagliptin and empagliflozin": [
+  "A10BD19"
+ ],
+ "lincomycin": [
+  "J01FF02"
+ ],
+ "lindane": [
+  "P03AB02"
+ ],
+ "linezolid": [
+  "J01XX08"
+ ],
+ "linopirdine": [
+  "N06BX09"
+ ],
+ "linseed": [
+  "A06AC05"
+ ],
+ "linseed, combinations": [
+  "A06AC55"
+ ],
+ "linsidomine": [
+  "C01DX18"
+ ],
+ "linzagolix": [
+  "H01CC04"
+ ],
+ "liothyronine sodium": [
+  "H03AA02"
+ ],
+ "lipegfilgrastim": [
+  "L03AA14"
+ ],
+ "liquid paraffin": [
+  "A06AA01"
+ ],
+ "liquid paraffin, combinations": [
+  "A06AA51"
+ ],
+ "liraglutide": [
+  "A10BJ02"
+ ],
+ "liranaftate": [
+  "D01AE25"
+ ],
+ "lisdexamfetamine": [
+  "N06BA12"
+ ],
+ "lisinopril": [
+  "C09AA03"
+ ],
+ "lisinopril and amlodipine": [
+  "C09BB03"
+ ],
+ "lisinopril and diuretics": [
+  "C09BA03"
+ ],
+ "lisocabtagene maraleucel": [
+  "L01XL08"
+ ],
+ "lisuride": [
+  "G02CB02",
+  "N02CA07"
+ ],
+ "lithium": [
+  "N05AN01"
+ ],
+ "lithium chloride": [
+  "V04CX11"
+ ],
+ "lithium succinate": [
+  "D11AX04"
+ ],
+ "lixisenatide": [
+  "A10BJ03"
+ ],
+ "lobeglitazone": [
+  "A10BG04"
+ ],
+ "lodoxamide": [
+  "S01GX05"
+ ],
+ "lofepramine": [
+  "N06AA07"
+ ],
+ "lofexidine": [
+  "N07BC04"
+ ],
+ "lomefloxacin": [
+  "J01MA07",
+  "S01AE04"
+ ],
+ "lomitapide": [
+  "C10AX12"
+ ],
+ "lomustine": [
+  "L01AD02"
+ ],
+ "lonafarnib": [
+  "A16AX20"
+ ],
+ "lonapegsomatropin": [
+  "H01AC09"
+ ],
+ "lonazolac": [
+  "M01AB09"
+ ],
+ "loncastuximab tesirine": [
+  "L01FX22"
+ ],
+ "lonidamine": [
+  "L01XX07"
+ ],
+ "loperamide": [
+  "A07DA03"
+ ],
+ "loperamide oxide": [
+  "A07DA05"
+ ],
+ "loperamide, combinations": [
+  "A07DA53"
+ ],
+ "lopinavir and ritonavir": [
+  "J05AR10"
+ ],
+ "loprazolam": [
+  "N05CD11"
+ ],
+ "loracarbef": [
+  "J01DC08"
+ ],
+ "lorajmine": [
+  "C01BA12"
+ ],
+ "loratadine": [
+  "R06AX13"
+ ],
+ "lorazepam": [
+  "N05BA06"
+ ],
+ "lorazepam, combinations": [
+  "N05BA56"
+ ],
+ "lorcainide": [
+  "C01BC07"
+ ],
+ "lorcaserin": [
+  "A08AA11"
+ ],
+ "lorlatinib": [
+  "L01ED05"
+ ],
+ "lormetazepam": [
+  "N05CD06"
+ ],
+ "lornoxicam": [
+  "M01AC05"
+ ],
+ "losartan": [
+  "C09CA01"
+ ],
+ "losartan and amlodipine": [
+  "C09DB06"
+ ],
+ "losartan and diuretics": [
+  "C09DA01"
+ ],
+ "loteprednol": [
+  "S01BA14"
+ ],
+ "loteprednol and antiinfectives": [
+  "S01CA12"
+ ],
+ "lotilaner": [
+  "S01AX25"
+ ],
+ "lovastatin": [
+  "C10AA02"
+ ],
+ "lovastatin and nicotinic acid": [
+  "C10BA01"
+ ],
+ "loxapine": [
+  "N05AH01"
+ ],
+ "loxoprofen": [
+  "M01AE19",
+  "M02AA31"
+ ],
+ "lubiprostone": [
+  "A06AX03"
+ ],
+ "luliconazole": [
+  "D01AC18"
+ ],
+ "lumasiran": [
+  "A16AX18"
+ ],
+ "lumateperone": [
+  "N05AD10"
+ ],
+ "lumiracoxib": [
+  "M01AH06"
+ ],
+ "lurasidone": [
+  "N05AE05"
+ ],
+ "lurbinectedin": [
+  "L01XX69"
+ ],
+ "luseogliflozin": [
+  "A10BK07"
+ ],
+ "luspatercept": [
+  "B03XA06"
+ ],
+ "lusutrombopag": [
+  "B02BX07"
+ ],
+ "lutetium (177lu) oxodotreotide": [
+  "V10XX04"
+ ],
+ "lutetium (177lu) vipivotide tetraxetan": [
+  "V10XX05"
+ ],
+ "lutropin alfa": [
+  "G03GA07"
+ ],
+ "lymecycline": [
+  "J01AA04"
+ ],
+ "lynestrenol": [
+  "G03AC02",
+  "G03DC03"
+ ],
+ "lynestrenol and estrogen": [
+  "G03FA07",
+  "G03FB02"
+ ],
+ "lynestrenol and ethinylestradiol": [
+  "G03AA03",
+  "G03AB02"
+ ],
+ "lypressin": [
+  "H01BA03"
+ ],
+ "lysine": [
+  "B05XB03"
+ ],
+ "lysozyme": [
+  "D06BB07",
+  "J05AX02"
+ ],
+ "macimorelin": [
+  "V04CD06"
+ ],
+ "macitentan": [
+  "C02KX04"
+ ],
+ "macitentan and tadalafil": [
+  "C02KX54"
+ ],
+ "macrogol": [
+  "A06AD15"
+ ],
+ "macrogol, combinations": [
+  "A06AD65"
+ ],
+ "mafenide": [
+  "D06BA03"
+ ],
+ "magaldrate": [
+  "A02AD02"
+ ],
+ "magaldrate and antiflatulents": [
+  "A02AF01"
+ ],
+ "magnesium (different salts in combination)": [
+  "A12CC30"
+ ],
+ "magnesium aspartate": [
+  "A12CC05"
+ ],
+ "magnesium carbonate": [
+  "A02AA01",
+  "A06AD01"
+ ],
+ "magnesium chloride": [
+  "A12CC01",
+  "B05XA11"
+ ],
+ "magnesium citrate": [
+  "A06AD19",
+  "A12CC04",
+  "B05CB03"
+ ],
+ "magnesium gluconate": [
+  "A12CC03"
+ ],
+ "magnesium hydroxide": [
+  "A02AA04",
+  "G04BX01"
+ ],
+ "magnesium lactate": [
+  "A12CC06"
+ ],
+ "magnesium levulinate": [
+  "A12CC07"
+ ],
+ "magnesium orotate": [
+  "A12CC09"
+ ],
+ "magnesium oxide": [
+  "A02AA02",
+  "A06AD02",
+  "A12CC10"
+ ],
+ "magnesium peroxide": [
+  "A02AA03",
+  "A06AD03"
+ ],
+ "magnesium phosphate": [
+  "B05XA10"
+ ],
+ "magnesium pidolate": [
+  "A12CC08"
+ ],
+ "magnesium pyridoxal 5-phosphate glutamate": [
+  "C10AX07"
+ ],
+ "magnesium salicylate, combinations excl. psycholeptics": [
+  "N02BA67"
+ ],
+ "magnesium silicate": [
+  "A02AA05"
+ ],
+ "magnesium sulfate": [
+  "A06AD04",
+  "A12CC02",
+  "B05XA05",
+  "D11AX05",
+  "V04CC02"
+ ],
+ "malaria vaccines": [
+  "J07XA01"
+ ],
+ "malathion": [
+  "P03AX03"
+ ],
+ "mandelic acid": [
+  "B05CA06",
+  "J01XX06"
+ ],
+ "mangafodipir": [
+  "V08CA05"
+ ],
+ "manidipine": [
+  "C08CA11"
+ ],
+ "mannitol": [
+  "A06AD16",
+  "B05BC01",
+  "B05CX04",
+  "R05CB16",
+  "V04CX04"
+ ],
+ "mannosulfan": [
+  "L01AB03"
+ ],
+ "maprotiline": [
+  "N06AA21"
+ ],
+ "maralixibat chloride": [
+  "A05AX04"
+ ],
+ "maraviroc": [
+  "J05AX09"
+ ],
+ "margetuximab": [
+  "L01FD06"
+ ],
+ "maribavir": [
+  "J05AX10"
+ ],
+ "marstacimab": [
+  "B02BX11"
+ ],
+ "masitinib": [
+  "L01EX06"
+ ],
+ "masoprocol": [
+  "L01XX10"
+ ],
+ "mavacamten": [
+  "C01EB24"
+ ],
+ "mavorixafor": [
+  "L03AX24"
+ ],
+ "mazaticol": [
+  "N04AA10"
+ ],
+ "mazindol": [
+  "A08AA05"
+ ],
+ "measles immunoglobulin": [
+  "J06BB14"
+ ],
+ "measles, combinations with mumps and rubella, live attenuated": [
+  "J07BD52"
+ ],
+ "measles, combinations with mumps, live attenuated": [
+  "J07BD51"
+ ],
+ "measles, combinations with mumps, rubella and varicella, live attenuated": [
+  "J07BD54"
+ ],
+ "measles, combinations with rubella, live attenuated": [
+  "J07BD53"
+ ],
+ "measles, live attenuated": [
+  "J07BD01"
+ ],
+ "mebendazole": [
+  "P02CA01"
+ ],
+ "mebendazole, combinations": [
+  "P02CA51"
+ ],
+ "mebeverine": [
+  "A03AA04"
+ ],
+ "mebhydrolin": [
+  "R06AX15"
+ ],
+ "mebutamate": [
+  "N05BC04"
+ ],
+ "mebutizide": [
+  "C03AA13"
+ ],
+ "mebutizide and potassium-sparing agents": [
+  "C03EA05"
+ ],
+ "mecamylamine": [
+  "C02BB01"
+ ],
+ "mecasermin": [
+  "H01AC03"
+ ],
+ "mecasermin rinfabate": [
+  "H01AC05"
+ ],
+ "mecillinam": [
+  "J01CA11"
+ ],
+ "meclocycline": [
+  "D10AF04"
+ ],
+ "meclofenamic acid": [
+  "M01AG04",
+  "M02AA18"
+ ],
+ "meclofenoxate": [
+  "N06BX01"
+ ],
+ "meclozine": [
+  "R06AE05"
+ ],
+ "meclozine, combinations": [
+  "R06AE55"
+ ],
+ "mecobalamin": [
+  "B03BA05"
+ ],
+ "medazepam": [
+  "N05BA03"
+ ],
+ "medical air": [
+  "V03AN05"
+ ],
+ "medicinal charcoal": [
+  "A07BA01"
+ ],
+ "medicinal charcoal, combinations": [
+  "A07BA51"
+ ],
+ "medifoxamine": [
+  "N06AX13"
+ ],
+ "medrogestone": [
+  "G03DB03"
+ ],
+ "medrogestone and estrogen": [
+  "G03FB07"
+ ],
+ "medroxyprogesterone": [
+  "G03AC06",
+  "G03DA02",
+  "L02AB02"
+ ],
+ "medroxyprogesterone and estradiol": [
+  "G03AA17"
+ ],
+ "medroxyprogesterone and estrogen": [
+  "G03FA12",
+  "G03FB06"
+ ],
+ "medroxyprogesterone and ethinylestradiol": [
+  "G03AA08"
+ ],
+ "medrysone": [
+  "S01BA08"
+ ],
+ "mefenamic acid": [
+  "M01AG01"
+ ],
+ "mefenorex": [
+  "A08AA09"
+ ],
+ "mefloquine": [
+  "P01BC02"
+ ],
+ "mefruside": [
+  "C03BA05"
+ ],
+ "mefruside and potassium": [
+  "C03BB05"
+ ],
+ "megestrol": [
+  "G03AC05",
+  "G03DB02",
+  "L02AB01"
+ ],
+ "megestrol and estrogen": [
+  "G03FA08",
+  "G03FB04"
+ ],
+ "megestrol and ethinylestradiol": [
+  "G03AA04",
+  "G03AB01"
+ ],
+ "meglumine antimonate": [
+  "P01CB01"
+ ],
+ "meglutol": [
+  "C10AX05"
+ ],
+ "meladrazine": [
+  "G04BD03"
+ ],
+ "melagatran": [
+  "B01AE04"
+ ],
+ "melanoma vaccine": [
+  "L03AX12"
+ ],
+ "melarsoprol": [
+  "P01CD01"
+ ],
+ "melatonin": [
+  "N05CH01"
+ ],
+ "meldonium": [
+  "C01EB22"
+ ],
+ "melevodopa": [
+  "N04BA04"
+ ],
+ "melevodopa and decarboxylase inhibitor": [
+  "N04BA05"
+ ],
+ "melitracen": [
+  "N06AA14"
+ ],
+ "melitracen and psycholeptics": [
+  "N06CA02"
+ ],
+ "meloxicam": [
+  "M01AC06"
+ ],
+ "meloxicam, combinations": [
+  "M01AC56"
+ ],
+ "melperone": [
+  "N05AD03"
+ ],
+ "melphalan": [
+  "L01AA03"
+ ],
+ "melphalan flufenamide": [
+  "L01AA10"
+ ],
+ "memantine": [
+  "N06DX01"
+ ],
+ "menadione": [
+  "B02BA02"
+ ],
+ "menatetrenone": [
+  "M05BX08"
+ ],
+ "meningococcus a, purified polysaccharides antigen": [
+  "J07AH01"
+ ],
+ "meningococcus a, purified polysaccharides antigen conjugated": [
+  "J07AH10"
+ ],
+ "meningococcus a,b,c,y,w-135, pentavalent purified polysaccharides antigen conjugated and factor h binding protein": [
+  "J07AH11"
+ ],
+ "meningococcus a,c, bivalent purified polysaccharides antigen": [
+  "J07AH03"
+ ],
+ "meningococcus a,c,y,w-135, tetravalent purified polysaccharides antigen": [
+  "J07AH04"
+ ],
+ "meningococcus a,c,y,w-135, tetravalent purified polysaccharides antigen conjugated": [
+  "J07AH08"
+ ],
+ "meningococcus b, multicomponent vaccine": [
+  "J07AH09"
+ ],
+ "meningococcus b, outer membrane vesicle vaccine": [
+  "J07AH06"
+ ],
+ "meningococcus c, purified polysaccharides antigen conjugated": [
+  "J07AH07"
+ ],
+ "menthae piperitae aetheroleum": [
+  "A03AX15"
+ ],
+ "mepacrine": [
+  "P01AX05"
+ ],
+ "mepartricin": [
+  "A01AB16",
+  "D01AA06",
+  "G01AA09",
+  "G04CX03"
+ ],
+ "mepenzolate": [
+  "A03AB12"
+ ],
+ "mephenesin": [
+  "M03BX06"
+ ],
+ "mephenoxalone": [
+  "N05BX01"
+ ],
+ "mephentermine": [
+  "C01CA11"
+ ],
+ "mephenytoin": [
+  "N03AB04"
+ ],
+ "mephenytoin, combinations": [
+  "N03AB54"
+ ],
+ "mepindolol": [
+  "C07AA14"
+ ],
+ "mepivacaine": [
+  "N01BB03"
+ ],
+ "mepivacaine, combinations": [
+  "N01BB53"
+ ],
+ "mepixanox": [
+  "R07AB09"
+ ],
+ "mepolizumab": [
+  "R03DX09"
+ ],
+ "meprednisone": [
+  "H02AB15"
+ ],
+ "meprobamate": [
+  "N05BC01"
+ ],
+ "meprobamate, combinations": [
+  "N05BC51",
+  "N05CX01"
+ ],
+ "meprotixol": [
+  "R05DB22"
+ ],
+ "meptazinol": [
+  "N02AX05"
+ ],
+ "mepyramine": [
+  "D04AA02",
+  "R06AC01"
+ ],
+ "mepyramine theophyllinacetate": [
+  "R03DA12"
+ ],
+ "mequinol": [
+  "D11AX06"
+ ],
+ "mequitazine": [
+  "R06AD07"
+ ],
+ "merbromin": [
+  "D08AK04"
+ ],
+ "mercaptamine": [
+  "A16AA04",
+  "S01XA21"
+ ],
+ "mercaptopurine": [
+  "L01BB02"
+ ],
+ "mercuric amidochloride": [
+  "D08AK01"
+ ],
+ "mercuric chloride": [
+  "D08AK03"
+ ],
+ "mercuric iodide": [
+  "D08AK30"
+ ],
+ "mercury compounds": [
+  "S01AX01"
+ ],
+ "mercury, metallic": [
+  "D08AK05"
+ ],
+ "meropenem": [
+  "J01DH02"
+ ],
+ "meropenem and vaborbactam": [
+  "J01DH52"
+ ],
+ "mersalyl": [
+  "C03BC01"
+ ],
+ "mesalazine": [
+  "A07EC02"
+ ],
+ "mesna": [
+  "R05CB05",
+  "V03AF01"
+ ],
+ "mesoridazine": [
+  "N05AC03"
+ ],
+ "mesterolone": [
+  "G03BB01"
+ ],
+ "mesulfen": [
+  "D10AB05",
+  "P03AA03"
+ ],
+ "mesuximide": [
+  "N03AD03"
+ ],
+ "metabutethamine": [
+  "N01BA01"
+ ],
+ "metacycline": [
+  "J01AA05"
+ ],
+ "metadoxine": [
+  "A05BA09"
+ ],
+ "metahexamide": [
+  "A10BB10"
+ ],
+ "metamfetamine": [
+  "N06BA03"
+ ],
+ "metamizole sodium": [
+  "N02BB02"
+ ],
+ "metamizole sodium, combinations excl. psycholeptics": [
+  "N02BB52"
+ ],
+ "metamizole sodium, combinations with psycholeptics": [
+  "N02BB72"
+ ],
+ "metampicillin": [
+  "J01CA14"
+ ],
+ "metandienone": [
+  "A14AA03",
+  "D11AE01"
+ ],
+ "metaraminol": [
+  "C01CA09"
+ ],
+ "metenolone": [
+  "A14AA04"
+ ],
+ "metergoline": [
+  "G02CB05"
+ ],
+ "metformin": [
+  "A10BA02"
+ ],
+ "metformin and acarbose": [
+  "A10BD17"
+ ],
+ "metformin and alogliptin": [
+  "A10BD13"
+ ],
+ "metformin and canagliflozin": [
+  "A10BD16"
+ ],
+ "metformin and dapagliflozin": [
+  "A10BD15"
+ ],
+ "metformin and empagliflozin": [
+  "A10BD20"
+ ],
+ "metformin and ertugliflozin": [
+  "A10BD23"
+ ],
+ "metformin and evogliptin": [
+  "A10BD22"
+ ],
+ "metformin and gemigliptin": [
+  "A10BD18"
+ ],
+ "metformin and linagliptin": [
+  "A10BD11"
+ ],
+ "metformin and lobeglitazone": [
+  "A10BD26"
+ ],
+ "metformin and pioglitazone": [
+  "A10BD05"
+ ],
+ "metformin and repaglinide": [
+  "A10BD14"
+ ],
+ "metformin and rosiglitazone": [
+  "A10BD03"
+ ],
+ "metformin and saxagliptin": [
+  "A10BD10"
+ ],
+ "metformin and sitagliptin": [
+  "A10BD07"
+ ],
+ "metformin and sulfonylureas": [
+  "A10BD02"
+ ],
+ "metformin and teneligliptin": [
+  "A10BD28"
+ ],
+ "metformin and vildagliptin": [
+  "A10BD08"
+ ],
+ "metformin, linagliptin and empagliflozin": [
+  "A10BD27"
+ ],
+ "metformin, saxagliptin and dapagliflozin": [
+  "A10BD25"
+ ],
+ "methacetin (13c)": [
+  "V04CE03"
+ ],
+ "methacholine": [
+  "V04CX03"
+ ],
+ "methadone": [
+  "N07BC02"
+ ],
+ "methadone, combinations excl. psycholeptics": [
+  "N02AC52"
+ ],
+ "methallenestril": [
+  "G03CB03",
+  "G03CC03"
+ ],
+ "methantheline": [
+  "A03AB07"
+ ],
+ "methapyrilene": [
+  "R06AC05"
+ ],
+ "methaqualone": [
+  "N05CM01"
+ ],
+ "methaqualone, combinations": [
+  "N05CX02"
+ ],
+ "metharbital": [
+  "N03AA30"
+ ],
+ "methazolamide": [
+  "S01EC05"
+ ],
+ "methdilazine": [
+  "R06AD04"
+ ],
+ "methenamine": [
+  "J01XX05"
+ ],
+ "methiodal": [
+  "V08AA09"
+ ],
+ "methionine": [
+  "V03AB26"
+ ],
+ "methionine (11c)": [
+  "V09IX13"
+ ],
+ "methiosulfonium chloride": [
+  "A02BX04"
+ ],
+ "methocarbamol": [
+  "M03BA03"
+ ],
+ "methocarbamol, combinations excl. psycholeptics": [
+  "M03BA53"
+ ],
+ "methocarbamol, combinations with psycholeptics": [
+  "M03BA73"
+ ],
+ "methohexital": [
+  "N01AF01",
+  "N05CA15"
+ ],
+ "methoserpidine": [
+  "C02AA06"
+ ],
+ "methoserpidine and diuretics": [
+  "C02LA04"
+ ],
+ "methotrexate": [
+  "L01BA01",
+  "L04AX03"
+ ],
+ "methoxamine": [
+  "C01CA10"
+ ],
+ "methoxsalen": [
+  "D05AD02",
+  "D05BA02"
+ ],
+ "methoxy polyethylene glycol-epoetin beta": [
+  "B03XA03"
+ ],
+ "methoxyflurane": [
+  "N02BG09"
+ ],
+ "methoxyphenamine": [
+  "R03CB02"
+ ],
+ "methyclothiazide": [
+  "C03AA08"
+ ],
+ "methyclothiazide and potassium": [
+  "C03AB08"
+ ],
+ "methyl aminolevulinate": [
+  "L01XD03"
+ ],
+ "methylatropine": [
+  "A03BB02"
+ ],
+ "methylcellulose": [
+  "A06AC06"
+ ],
+ "methyldopa (levorotatory)": [
+  "C02AB01"
+ ],
+ "methyldopa (levorotatory) and diuretics": [
+  "C02LB01"
+ ],
+ "methyldopa (racemic)": [
+  "C02AB02"
+ ],
+ "methylergometrine": [
+  "G02AB01"
+ ],
+ "methylergometrine and oxytocin": [
+  "G02AC01"
+ ],
+ "methylestrenolone": [
+  "G03DC31"
+ ],
+ "methylnaltrexone bromide": [
+  "A06AH01"
+ ],
+ "methylnortestosterone and estrogen": [
+  "G03FA05"
+ ],
+ "methylpentynol": [
+  "N05CM15"
+ ],
+ "methylpentynol, combinations": [
+  "N05CX03"
+ ],
+ "methylphenidate": [
+  "N06BA04"
+ ],
+ "methylphenobarbital": [
+  "N03AA01"
+ ],
+ "methylprednisolone": [
+  "D07AA01",
+  "D10AA02",
+  "H02AB04"
+ ],
+ "methylprednisolone aceponate": [
+  "D07AC14"
+ ],
+ "methylprednisolone and antibiotics": [
+  "D07CA02"
+ ],
+ "methylprednisolone and antiinfectives": [
+  "S01CA08",
+  "S03CA07"
+ ],
+ "methylprednisolone, combinations": [
+  "H02BX01"
+ ],
+ "methylpropylpropanediol dinitrate": [
+  "C01DA04"
+ ],
+ "methylpropylpropanediol dinitrate, combinations": [
+  "C01DA54"
+ ],
+ "methylrosaniline": [
+  "D01AE02",
+  "G01AX09"
+ ],
+ "methylscopolamine": [
+  "A03BB03",
+  "S01FA03"
+ ],
+ "methylscopolamine and psycholeptics": [
+  "A03CB01"
+ ],
+ "methyltestosterone": [
+  "G03BA02",
+  "G03EK01"
+ ],
+ "methyltestosterone and estrogen": [
+  "G03EA01"
+ ],
+ "methylthioninium chloride": [
+  "V03AB17",
+  "V04CG05"
+ ],
+ "methylthiouracil": [
+  "H03BA01"
+ ],
+ "methyprylon": [
+  "N05CE02"
+ ],
+ "methysergide": [
+  "N02CA04"
+ ],
+ "meticillin": [
+  "J01CF03"
+ ],
+ "meticrane": [
+  "C03BA09"
+ ],
+ "metildigoxin": [
+  "C01AA08"
+ ],
+ "metipranolol": [
+  "S01ED04"
+ ],
+ "metipranolol and thiazides, combinations": [
+  "C07BA68"
+ ],
+ "metipranolol, combinations": [
+  "S01ED54"
+ ],
+ "metirosine": [
+  "C02KB01"
+ ],
+ "metisazone": [
+  "J05AA01"
+ ],
+ "metixene": [
+  "N04AA03"
+ ],
+ "metizoline": [
+  "R01AA10"
+ ],
+ "metoclopramide": [
+  "A03FA01"
+ ],
+ "metolazone": [
+  "C03BA08"
+ ],
+ "metolazone and potassium-sparing agents": [
+  "C03EA12"
+ ],
+ "metopimazine": [
+  "A04AD05"
+ ],
+ "metoprolol": [
+  "C07AB02"
+ ],
+ "metoprolol and acetylsalicylic acid": [
+  "C07FX03"
+ ],
+ "metoprolol and amlodipine": [
+  "C07FB13"
+ ],
+ "metoprolol and felodipine": [
+  "C07FB02"
+ ],
+ "metoprolol and ivabradine": [
+  "C07FX05"
+ ],
+ "metoprolol and other diuretics": [
+  "C07CB02"
+ ],
+ "metoprolol and thiazides": [
+  "C07BB02"
+ ],
+ "metoprolol and thiazides, combinations": [
+  "C07BB52"
+ ],
+ "metreleptin": [
+  "A16AA07"
+ ],
+ "metrifonate": [
+  "P02BB01"
+ ],
+ "metrizamide": [
+  "V08AB01"
+ ],
+ "metrizoic acid": [
+  "V08AA02"
+ ],
+ "metronidazole": [
+  "A01AB17",
+  "D06BX01",
+  "G01AF01",
+  "J01XD01",
+  "P01AB01"
+ ],
+ "metronidazole and diloxanide": [
+  "P01AB52"
+ ],
+ "metronidazole, combinations": [
+  "P01AB51"
+ ],
+ "metyrapone": [
+  "V04CD01"
+ ],
+ "mexazolam": [
+  "N05BA25"
+ ],
+ "mexiletine": [
+  "C01BB02"
+ ],
+ "mezlocillin": [
+  "J01CA10"
+ ],
+ "mianserin": [
+  "N06AX03"
+ ],
+ "mibefradil": [
+  "C08CX01"
+ ],
+ "micafungin": [
+  "J02AX05"
+ ],
+ "miconazole": [
+  "A01AB09",
+  "A07AC01",
+  "D01AC02",
+  "G01AF04",
+  "J02AB01",
+  "S02AA13"
+ ],
+ "miconazole, combinations": [
+  "D01AC52"
+ ],
+ "micronomicin": [
+  "S01AA22"
+ ],
+ "microparticles of galactose": [
+  "V08DA02"
+ ],
+ "midazolam": [
+  "N05CD08"
+ ],
+ "midecamycin": [
+  "J01FA03"
+ ],
+ "midodrine": [
+  "C01CA17"
+ ],
+ "midostaurin": [
+  "L01EX10"
+ ],
+ "mifamurtide": [
+  "L03AX15"
+ ],
+ "mifepristone": [
+  "G03XB01"
+ ],
+ "mifepristone, combinations": [
+  "G03XB51"
+ ],
+ "migalastat": [
+  "A16AX14"
+ ],
+ "miglitol": [
+  "A10BF02"
+ ],
+ "miglustat": [
+  "A16AX06"
+ ],
+ "milnacipran": [
+  "N06AX17"
+ ],
+ "milrinone": [
+  "C01CE02"
+ ],
+ "miltefosine": [
+  "P01CX04"
+ ],
+ "minaprine": [
+  "N06AX07"
+ ],
+ "mineral salts in combination": [
+  "A06AD10"
+ ],
+ "minocycline": [
+  "A01AB23",
+  "D10AF07",
+  "J01AA08"
+ ],
+ "minoxidil": [
+  "C02DC01",
+  "D11AX01"
+ ],
+ "miocamycin": [
+  "J01FA11"
+ ],
+ "mipomersen": [
+  "C10AX11"
+ ],
+ "mirabegron": [
+  "G04BD12"
+ ],
+ "mirdametinib": [
+  "L01EE05"
+ ],
+ "mirikizumab": [
+  "L04AC24"
+ ],
+ "mirogabalin": [
+  "N02BF03"
+ ],
+ "mirtazapine": [
+  "N06AX11"
+ ],
+ "mirvetuximab soravtansine": [
+  "L01FX26"
+ ],
+ "misoprostol": [
+  "A02BB01",
+  "G02AD06"
+ ],
+ "mitapivat": [
+  "B06AX04"
+ ],
+ "mitiglinide": [
+  "A10BX08"
+ ],
+ "mitobronitol": [
+  "L01AX01"
+ ],
+ "mitoguazone": [
+  "L01XX16"
+ ],
+ "mitomycin": [
+  "L01DC03"
+ ],
+ "mitotane": [
+  "L01XX23"
+ ],
+ "mitoxantrone": [
+  "L01DB07"
+ ],
+ "mivacurium chloride": [
+  "M03AC10"
+ ],
+ "mizolastine": [
+  "R06AX25"
+ ],
+ "mobocertinib": [
+  "L01EB10"
+ ],
+ "moclobemide": [
+  "N06AG02"
+ ],
+ "modafinil": [
+  "N06BA07"
+ ],
+ "moexipril": [
+  "C09AA13"
+ ],
+ "moexipril and diuretics": [
+  "C09BA13"
+ ],
+ "mofebutazone": [
+  "M01AA02",
+  "M02AA02"
+ ],
+ "mogamulizumab": [
+  "L01FX09"
+ ],
+ "molgramostim": [
+  "L03AA03"
+ ],
+ "molidustat": [
+  "B03XA09"
+ ],
+ "molindone": [
+  "N05AE02"
+ ],
+ "molnupiravir": [
+  "J05AB18"
+ ],
+ "molsidomine": [
+  "C01DX12"
+ ],
+ "momelotinib": [
+  "L01EJ04"
+ ],
+ "mometasone": [
+  "D07AC13",
+  "D07XC03",
+  "R01AD09",
+  "R03BA07"
+ ],
+ "mometasone, combinations": [
+  "R01AD59"
+ ],
+ "monobenzone": [
+  "D11AX13"
+ ],
+ "monoethanolamine oleate": [
+  "C05BB01"
+ ],
+ "monoxerutin": [
+  "C05CA02"
+ ],
+ "montelukast": [
+  "R03DC03"
+ ],
+ "montelukast, combinations": [
+  "R03DC53"
+ ],
+ "moperone": [
+  "N05AD04"
+ ],
+ "moracizine": [
+  "C01BG01"
+ ],
+ "morclofone": [
+  "R05DB25"
+ ],
+ "morinamide": [
+  "J04AK04"
+ ],
+ "morniflumate": [
+  "M01AX22"
+ ],
+ "moroxydine": [
+  "J05AX01"
+ ],
+ "morphine": [
+  "N02AA01"
+ ],
+ "morphine and antispasmodics": [
+  "N02AG01"
+ ],
+ "morphine, combinations": [
+  "A07DA52",
+  "N02AA51"
+ ],
+ "morpholine salicylate": [
+  "N02BA08"
+ ],
+ "mosapramine": [
+  "N05AX10"
+ ],
+ "mosapride": [
+  "A03FA09"
+ ],
+ "mosunetuzumab": [
+  "L01FX25"
+ ],
+ "motavizumab": [
+  "J06BD02"
+ ],
+ "motixafortide": [
+  "L03AX23"
+ ],
+ "motretinide": [
+  "D10AD05"
+ ],
+ "mould fungus and yeast fungus": [
+  "V01AA04"
+ ],
+ "moxaverine": [
+  "A03AD30"
+ ],
+ "moxestrol": [
+  "G03CB04"
+ ],
+ "moxetumomab pasudotox": [
+  "L01FB02"
+ ],
+ "moxidectin": [
+  "P02CX03"
+ ],
+ "moxifloxacin": [
+  "J01MA14",
+  "S01AE07"
+ ],
+ "moxisylyte": [
+  "C04AX10",
+  "G04BE06"
+ ],
+ "moxonidine": [
+  "C02AC05"
+ ],
+ "moxonidine and diuretics": [
+  "C02LC05"
+ ],
+ "multienzymes (lipase, protease etc.)": [
+  "A09AA02"
+ ],
+ "multienzymes and acid preparations": [
+  "A09AC02"
+ ],
+ "multivitamins and calcium": [
+  "A11AA02"
+ ],
+ "multivitamins and iron": [
+  "A11AA01"
+ ],
+ "multivitamins and other minerals, incl. combinations": [
+  "A11AA03"
+ ],
+ "multivitamins and trace elements": [
+  "A11AA04"
+ ],
+ "mumps immunoglobulin": [
+  "J06BB15"
+ ],
+ "mumps, live attenuated": [
+  "J07BE01"
+ ],
+ "mupirocin": [
+  "D06AX09",
+  "R01AX06"
+ ],
+ "muromonab-cd3": [
+  "L04AG01"
+ ],
+ "muzolimine": [
+  "C03CD01"
+ ],
+ "mycophenolic acid": [
+  "L04AA06"
+ ],
+ "myristyl-benzalkonium": [
+  "R02AA10"
+ ],
+ "nabilone": [
+  "A04AD11"
+ ],
+ "nabumetone": [
+  "M01AX01"
+ ],
+ "nadifloxacin": [
+  "D10AF05"
+ ],
+ "nadofaragene firadenovec": [
+  "L01XL10"
+ ],
+ "nadolol": [
+  "C07AA12"
+ ],
+ "nadolol and thiazides": [
+  "C07BA12"
+ ],
+ "nadroparin": [
+  "B01AB06"
+ ],
+ "nafarelin": [
+  "H01CA02"
+ ],
+ "nafcillin": [
+  "J01CF06"
+ ],
+ "naftazone": [
+  "C05CX02"
+ ],
+ "naftidrofuryl": [
+  "C04AX21"
+ ],
+ "naftifine": [
+  "D01AE22"
+ ],
+ "nalbuphine": [
+  "N02AF02"
+ ],
+ "naldemedine": [
+  "A06AH05"
+ ],
+ "nalfurafine": [
+  "V03AX02"
+ ],
+ "nalidixic acid": [
+  "J01MB02"
+ ],
+ "nalmefene": [
+  "N07BB05"
+ ],
+ "nalorphine": [
+  "V03AB02"
+ ],
+ "naloxegol": [
+  "A06AH03"
+ ],
+ "naloxone": [
+  "A06AH04",
+  "V03AB15"
+ ],
+ "naltrexone": [
+  "N07BB04"
+ ],
+ "nandrolone": [
+  "A14AB01",
+  "S01XA11"
+ ],
+ "naphazoline": [
+  "R01AA08",
+  "R01AB02",
+  "S01GA01"
+ ],
+ "naphazoline, combinations": [
+  "S01GA51"
+ ],
+ "naproxcinod": [
+  "M01AE18"
+ ],
+ "naproxen": [
+  "G02CC02",
+  "M01AE02",
+  "M02AA12"
+ ],
+ "naproxen and diphenhydramine": [
+  "M01AE57"
+ ],
+ "naproxen and esomeprazole": [
+  "M01AE52"
+ ],
+ "naproxen and misoprostol": [
+  "M01AE56"
+ ],
+ "naratriptan": [
+  "N02CC02"
+ ],
+ "narcobarbital": [
+  "N01AG01"
+ ],
+ "narlaprevir": [
+  "J05AP14"
+ ],
+ "natalizumab": [
+  "L04AG03"
+ ],
+ "natamycin": [
+  "A01AB10",
+  "A07AA03",
+  "D01AA02",
+  "G01AA02",
+  "S01AA10"
+ ],
+ "nateglinide": [
+  "A10BX03"
+ ],
+ "natural phospholipids": [
+  "R07AA02"
+ ],
+ "navitoclax": [
+  "L01XX78"
+ ],
+ "naxitamab": [
+  "L01FX21"
+ ],
+ "nebacumab": [
+  "J06BC01"
+ ],
+ "nebivolol": [
+  "C07AB12"
+ ],
+ "nebivolol and amlodipine": [
+  "C07FB12"
+ ],
+ "nebivolol and thiazides": [
+  "C07BB12"
+ ],
+ "necitumumab": [
+  "L01FE03"
+ ],
+ "nedocromil": [
+  "R01AC07",
+  "R03BC03",
+  "S01GX04"
+ ],
+ "nedosiran": [
+  "A16AX25"
+ ],
+ "nefazodone": [
+  "N06AX06"
+ ],
+ "nefopam": [
+  "N02BG06"
+ ],
+ "nelarabine": [
+  "L01BB07"
+ ],
+ "nelfinavir": [
+  "J05AE04"
+ ],
+ "neltenexine": [
+  "R05CB14"
+ ],
+ "nemolizumab": [
+  "D11AH12"
+ ],
+ "nemonoxacin": [
+  "J01MB08"
+ ],
+ "neomycin": [
+  "A01AB08",
+  "A07AA01",
+  "B05CA09",
+  "D06AX04",
+  "J01GB05",
+  "R02AB01",
+  "S01AA03",
+  "S02AA07",
+  "S03AA01"
+ ],
+ "neomycin, combinations": [
+  "A07AA51"
+ ],
+ "neostigmine": [
+  "N07AA01",
+  "S01EB06"
+ ],
+ "neostigmine, combinations": [
+  "N07AA51"
+ ],
+ "nepafenac": [
+  "S01BC10"
+ ],
+ "nepinalone": [
+  "R05DB26"
+ ],
+ "neratinib": [
+  "L01EH02"
+ ],
+ "nesiritide": [
+  "C01DX19"
+ ],
+ "netakimab": [
+  "L04AC20"
+ ],
+ "netarsudil": [
+  "S01EX05"
+ ],
+ "neticonazole": [
+  "D01AC21"
+ ],
+ "netilmicin": [
+  "J01GB07",
+  "S01AA23"
+ ],
+ "nevirapine": [
+  "J05AG01"
+ ],
+ "nialamide": [
+  "N06AF02"
+ ],
+ "niaprazine": [
+  "N05CM16"
+ ],
+ "nicardipine": [
+  "C08CA04"
+ ],
+ "nicergoline": [
+  "C04AE02"
+ ],
+ "niceritrol": [
+  "C10AD01"
+ ],
+ "niclosamide": [
+  "P02DA01"
+ ],
+ "nicofetamide": [
+  "A03AC04"
+ ],
+ "nicofuranose": [
+  "C10AD03"
+ ],
+ "nicomorphine": [
+  "N02AA04"
+ ],
+ "nicorandil": [
+  "C01DX16"
+ ],
+ "nicotinamide": [
+  "A11HA01"
+ ],
+ "nicotine": [
+  "N07BA01"
+ ],
+ "nicotinic acid": [
+  "C04AC01",
+  "C10AD02"
+ ],
+ "nicotinic acid, combinations": [
+  "C10AD52"
+ ],
+ "nicotinyl alcohol (pyridylcarbinol)": [
+  "C04AC02",
+  "C10AD05"
+ ],
+ "nicotinyl methylamide": [
+  "A05AB01"
+ ],
+ "nifedipine": [
+  "C08CA05"
+ ],
+ "nifedipine and diuretics": [
+  "C08GA01"
+ ],
+ "nifedipine, combinations": [
+  "C08CA55"
+ ],
+ "nifenazone": [
+  "M02AA24",
+  "N02BB05"
+ ],
+ "niflumic acid": [
+  "M01AX02",
+  "M02AA17"
+ ],
+ "nifuratel": [
+  "G01AX05"
+ ],
+ "nifuroxazide": [
+  "A07AX03"
+ ],
+ "nifurtimox": [
+  "P01CC01"
+ ],
+ "nifurtoinol": [
+  "J01XE02"
+ ],
+ "nifurzide": [
+  "A07AX04"
+ ],
+ "nikethamide": [
+  "R07AB02"
+ ],
+ "nikethamide, combinations": [
+  "R07AB52"
+ ],
+ "nilotinib": [
+  "L01EA03"
+ ],
+ "nilutamide": [
+  "L02BB02"
+ ],
+ "nilvadipine": [
+  "C08CA10"
+ ],
+ "nimesulide": [
+  "M01AX17",
+  "M02AA26"
+ ],
+ "nimetazepam": [
+  "N05CD15"
+ ],
+ "nimodipine": [
+  "C08CA06"
+ ],
+ "nimorazole": [
+  "P01AB06"
+ ],
+ "nimustine": [
+  "L01AD06"
+ ],
+ "nintedanib": [
+  "L01EX09"
+ ],
+ "niperotidine": [
+  "A02BA05"
+ ],
+ "niraparib": [
+  "L01XK02"
+ ],
+ "niraparib and abiraterone": [
+  "L01XK52"
+ ],
+ "niridazole": [
+  "P02BX02"
+ ],
+ "nirmatrelvir and ritonavir": [
+  "J05AE30"
+ ],
+ "nirogacestat": [
+  "L01XX81"
+ ],
+ "nirsevimab": [
+  "J06BD08"
+ ],
+ "nisoldipine": [
+  "C08CA07"
+ ],
+ "nitazoxanide": [
+  "P01AX11"
+ ],
+ "nitisinone": [
+  "A16AX04"
+ ],
+ "nitrazepam": [
+  "N05CD02"
+ ],
+ "nitrendipine": [
+  "C08CA08"
+ ],
+ "nitric oxide": [
+  "R07AX01"
+ ],
+ "nitrofural": [
+  "B05CA03",
+  "D08AF01",
+  "D09AA03",
+  "P01CC02",
+  "S01AX04",
+  "S02AA02"
+ ],
+ "nitrofurantoin": [
+  "J01XE01"
+ ],
+ "nitrofurantoin, combinations": [
+  "J01XE51"
+ ],
+ "nitrogen": [
+  "V03AN04"
+ ],
+ "nitroprusside": [
+  "C02DD01"
+ ],
+ "nitrous oxide": [
+  "N01AX13"
+ ],
+ "nitrous oxide, combinations": [
+  "N01AX63"
+ ],
+ "nitroxoline": [
+  "J01XX07"
+ ],
+ "nivolumab": [
+  "L01FF01"
+ ],
+ "nivolumab and relatlimab": [
+  "L01FY02"
+ ],
+ "nizatidine": [
+  "A02BA04"
+ ],
+ "nizofenone": [
+  "N06BX10"
+ ],
+ "nomegestrol": [
+  "G03DB04"
+ ],
+ "nomegestrol and estradiol": [
+  "G03AA14"
+ ],
+ "nomegestrol and estrogen": [
+  "G03FB12"
+ ],
+ "nomifensine": [
+  "N06AX04"
+ ],
+ "nordazepam": [
+  "N05BA16"
+ ],
+ "norelgestromin and ethinylestradiol": [
+  "G03AA13"
+ ],
+ "norepinephrine": [
+  "C01CA03"
+ ],
+ "norethandrolone": [
+  "A14AA09"
+ ],
+ "norethisterone": [
+  "G03AC01",
+  "G03DC02"
+ ],
+ "norethisterone and estrogen": [
+  "G03FA01",
+  "G03FB05"
+ ],
+ "norethisterone and ethinylestradiol": [
+  "G03AA05",
+  "G03AB04"
+ ],
+ "noretynodrel and estrogen": [
+  "G03FA09"
+ ],
+ "norfenefrine": [
+  "C01CA05"
+ ],
+ "norfloxacin": [
+  "J01MA06",
+  "S01AE02"
+ ],
+ "norfloxacin and metronidazole": [
+  "J01RA14"
+ ],
+ "norfloxacin and tinidazole": [
+  "J01RA13"
+ ],
+ "norgestimate and estrogen": [
+  "G03FA13"
+ ],
+ "norgestimate and ethinylestradiol": [
+  "G03AA11",
+  "G03AB09"
+ ],
+ "norgestrel and estrogen": [
+  "G03FA10",
+  "G03FB01"
+ ],
+ "norgestrel and ethinylestradiol": [
+  "G03AA06"
+ ],
+ "norgestrienone": [
+  "G03AC07"
+ ],
+ "normethadone": [
+  "R05DA06"
+ ],
+ "nortriptyline": [
+  "N06AA10"
+ ],
+ "noscapine": [
+  "R05DA07"
+ ],
+ "noxytiolin": [
+  "B05CA07"
+ ],
+ "nusinersen": [
+  "M09AX07"
+ ],
+ "nystatin": [
+  "A07AA02",
+  "D01AA01",
+  "G01AA01"
+ ],
+ "nystatin, combinations": [
+  "G01AA51"
+ ],
+ "obecabtagene autoleucel": [
+  "L01XL12"
+ ],
+ "obeticholic acid": [
+  "A05AA04"
+ ],
+ "obidoxime": [
+  "V03AB13"
+ ],
+ "obiltoxaximab": [
+  "J06BC04"
+ ],
+ "obinutuzumab": [
+  "L01FA03"
+ ],
+ "oblimersen": [
+  "L01XX36"
+ ],
+ "ocrelizumab": [
+  "L04AG08"
+ ],
+ "ocriplasmin": [
+  "S01XA22"
+ ],
+ "octenidine": [
+  "A01AB24",
+  "R02AA21"
+ ],
+ "octenidine, combinations": [
+  "D08AJ57",
+  "G01AX66"
+ ],
+ "octinoxate": [
+  "D02BA02"
+ ],
+ "octopamine": [
+  "C01CA18"
+ ],
+ "octreotide": [
+  "H01CB02"
+ ],
+ "odevixibat": [
+  "A05AX05"
+ ],
+ "odronextamab": [
+  "L01FX34"
+ ],
+ "ofatumumab": [
+  "L01FA02",
+  "L04AG12"
+ ],
+ "ofloxacin": [
+  "J01MA01",
+  "S01AE01",
+  "S02AA16"
+ ],
+ "ofloxacin and nitazoxanide": [
+  "J01RA17"
+ ],
+ "ofloxacin and ornidazole": [
+  "J01RA09"
+ ],
+ "ofloxacin and tinidazole": [
+  "J01RA18"
+ ],
+ "oil": [
+  "A06AG06"
+ ],
+ "olaflur": [
+  "A01AA03"
+ ],
+ "olanzapine": [
+  "N05AH03"
+ ],
+ "olanzapine and samidorphan": [
+  "N05AH53"
+ ],
+ "olaparib": [
+  "L01XK01"
+ ],
+ "olaratumab": [
+  "L01FX10"
+ ],
+ "oleandomycin": [
+  "J01FA05"
+ ],
+ "oliceridine": [
+  "N02AX07"
+ ],
+ "olipudase alfa": [
+  "A16AB25"
+ ],
+ "olmesartan medoxomil": [
+  "C09CA08"
+ ],
+ "olmesartan medoxomil and amlodipine": [
+  "C09DB02"
+ ],
+ "olmesartan medoxomil and diuretics": [
+  "C09DA08"
+ ],
+ "olmesartan medoxomil, amlodipine and hydrochlorothiazide": [
+  "C09DX03"
+ ],
+ "olmutinib": [
+  "L01EB06"
+ ],
+ "olodaterol": [
+  "R03AC19"
+ ],
+ "olodaterol and tiotropium bromide": [
+  "R03AL06"
+ ],
+ "olokizumab": [
+  "L04AC23"
+ ],
+ "olopatadine": [
+  "R01AC08",
+  "S01GX09"
+ ],
+ "olsalazine": [
+  "A07EC03"
+ ],
+ "olutasidenib": [
+  "L01XM03"
+ ],
+ "omacetaxine mepesuccinate": [
+  "L01XX40"
+ ],
+ "omadacycline": [
+  "J01AA15"
+ ],
+ "omalizumab": [
+  "R03DX05"
+ ],
+ "omaveloxolone": [
+  "N07XX25"
+ ],
+ "ombitasvir, paritaprevir and ritonavir": [
+  "J05AP53"
+ ],
+ "omecamtiv mecarbil": [
+  "C01CX10"
+ ],
+ "omega-3-triglycerides incl. other esters and acids": [
+  "C10AX06"
+ ],
+ "omeprazole": [
+  "A02BC01"
+ ],
+ "omeprazole, amoxicillin and clarithromycin": [
+  "A02BD05"
+ ],
+ "omeprazole, amoxicillin and metronidazole": [
+  "A02BD01"
+ ],
+ "omeprazole, amoxicillin and rifabutin": [
+  "A02BD16"
+ ],
+ "omeprazole, combinations": [
+  "A02BC51"
+ ],
+ "omidenepag": [
+  "S01EX06"
+ ],
+ "omoconazole": [
+  "D01AC13",
+  "G01AF16"
+ ],
+ "onasemnogene abeparvovec": [
+  "M09AX09"
+ ],
+ "ondansetron": [
+  "A04AA01"
+ ],
+ "ondelopran": [
+  "N07BB06"
+ ],
+ "opicapone": [
+  "N04BX04"
+ ],
+ "opinercept": [
+  "L04AB07"
+ ],
+ "opipramol": [
+  "N06AA05"
+ ],
+ "opium": [
+  "A07DA02",
+  "N02AA02"
+ ],
+ "opium alkaloids with morphine": [
+  "R05DA05"
+ ],
+ "opium derivatives and expectorants": [
+  "R05FA02"
+ ],
+ "opium derivatives and mucolytics": [
+  "R05FA01"
+ ],
+ "oportuzumab monatox": [
+  "L01FX16"
+ ],
+ "oprelvekin": [
+  "L03AC02"
+ ],
+ "orciprenaline": [
+  "R03AB03",
+  "R03CB03"
+ ],
+ "orciprenaline, combinations": [
+  "R03CB53"
+ ],
+ "ordinary salt combinations": [
+  "A02AD01"
+ ],
+ "ordinary salt combinations and antiflatulents": [
+  "A02AF02"
+ ],
+ "orelabrutinib": [
+  "L01EL04"
+ ],
+ "organic nitrates in combination": [
+  "C01DA20"
+ ],
+ "organic nitrates in combination with psycholeptics": [
+  "C01DA70"
+ ],
+ "organo-heparinoid": [
+  "C05BA01"
+ ],
+ "orgotein": [
+  "M01AX14"
+ ],
+ "oritavancin": [
+  "J01XA05"
+ ],
+ "orlistat": [
+  "A08AB01"
+ ],
+ "ormeloxifene": [
+  "G03XC04"
+ ],
+ "ornidazole": [
+  "G01AF06",
+  "J01XD03",
+  "P01AB03"
+ ],
+ "ornipressin": [
+  "H01BA05"
+ ],
+ "ornithine oxoglurate": [
+  "A05BA06"
+ ],
+ "orphenadrine (chloride)": [
+  "N04AB02"
+ ],
+ "orphenadrine (citrate)": [
+  "M03BC01"
+ ],
+ "orphenadrine, combinations": [
+  "M03BC51"
+ ],
+ "oseltamivir": [
+  "J05AH02"
+ ],
+ "osilodrostat": [
+  "H02CA02"
+ ],
+ "osimertinib": [
+  "L01EB04"
+ ],
+ "ospemifene": [
+  "G03XC05"
+ ],
+ "oteseconazole": [
+  "J02AC06"
+ ],
+ "other meningococcal monovalent purified polysaccharides antigen": [
+  "J07AH02"
+ ],
+ "other meningococcal polyvalent purified polysaccharides antigen": [
+  "J07AH05"
+ ],
+ "other plasma protein fractions": [
+  "B05AA02"
+ ],
+ "other preparations, combinations": [
+  "C05AX03"
+ ],
+ "others": [
+  "D11AC30"
+ ],
+ "otilonium bromide": [
+  "A03AB06"
+ ],
+ "otilonium bromide and psycholeptics": [
+  "A03CA04"
+ ],
+ "oxabolone cipionate": [
+  "A14AB03"
+ ],
+ "oxaceprol": [
+  "D11AX09",
+  "M01AX24"
+ ],
+ "oxacillin": [
+  "J01CF04"
+ ],
+ "oxaflozane": [
+  "N06AX10"
+ ],
+ "oxaliplatin": [
+  "L01XA03"
+ ],
+ "oxametacin": [
+  "M01AB13"
+ ],
+ "oxamniquine": [
+  "P02BA02"
+ ],
+ "oxandrolone": [
+  "A14AA08"
+ ],
+ "oxantel": [
+  "P02CC02"
+ ],
+ "oxaprozin": [
+  "M01AE12"
+ ],
+ "oxatomide": [
+  "R06AE06"
+ ],
+ "oxazepam": [
+  "N05BA04"
+ ],
+ "oxcarbazepine": [
+  "N03AF02"
+ ],
+ "oxedrine": [
+  "C01CA08",
+  "S01GA06"
+ ],
+ "oxedrine, combinations": [
+  "S01GA56"
+ ],
+ "oxeladin": [
+  "R05DB09"
+ ],
+ "oxetacaine": [
+  "C05AD06"
+ ],
+ "oxetorone": [
+  "N02CX06"
+ ],
+ "oxiconazole": [
+  "D01AC11",
+  "G01AF17"
+ ],
+ "oxidized cellulose": [
+  "B02BC02"
+ ],
+ "oxiracetam": [
+  "N06BX07"
+ ],
+ "oxitriptan": [
+  "N06AX01"
+ ],
+ "oxitropium bromide": [
+  "R03BB02"
+ ],
+ "oxolamine": [
+  "R05DB07"
+ ],
+ "oxolinic acid": [
+  "J01MB05"
+ ],
+ "oxomemazine": [
+  "R06AD08"
+ ],
+ "oxprenolol": [
+  "C07AA02"
+ ],
+ "oxprenolol and other diuretics": [
+  "C07CA02"
+ ],
+ "oxprenolol and thiazides": [
+  "C07BA02"
+ ],
+ "oxybuprocaine": [
+  "D04AB03",
+  "S01HA02"
+ ],
+ "oxybutynin": [
+  "G04BD04"
+ ],
+ "oxycinchophen": [
+  "M01CA03"
+ ],
+ "oxycodone": [
+  "N02AA05"
+ ],
+ "oxycodone and acetylsalicylic acid": [
+  "N02AJ18"
+ ],
+ "oxycodone and ibuprofen": [
+  "N02AJ19"
+ ],
+ "oxycodone and naloxone": [
+  "N02AA55"
+ ],
+ "oxycodone and naltrexone": [
+  "N02AA56"
+ ],
+ "oxycodone and paracetamol": [
+  "N02AJ17"
+ ],
+ "oxyfedrine": [
+  "C01DX03"
+ ],
+ "oxyfedrine, combinations": [
+  "C01DX53"
+ ],
+ "oxygen": [
+  "V03AN01"
+ ],
+ "oxymetazoline": [
+  "D11AX27",
+  "R01AA05",
+  "R01AB07",
+  "S01GA04"
+ ],
+ "oxymetholone": [
+  "A14AA05"
+ ],
+ "oxymorphone": [
+  "N02AA11"
+ ],
+ "oxypertine": [
+  "N05AE01"
+ ],
+ "oxyphenbutazone": [
+  "M01AA03",
+  "M02AA04",
+  "S01BC02"
+ ],
+ "oxyphencyclimine": [
+  "A03AA01"
+ ],
+ "oxyphencyclimine and psycholeptics": [
+  "A03CA03"
+ ],
+ "oxyphenisatine": [
+  "A06AB01"
+ ],
+ "oxyphenonium": [
+  "A03AB03"
+ ],
+ "oxyphenonium, combinations": [
+  "A03AB53"
+ ],
+ "oxyquinoline": [
+  "A01AB07",
+  "D08AH03",
+  "G01AC30",
+  "R02AA14"
+ ],
+ "oxytetracycline": [
+  "A01AB25",
+  "D06AA03",
+  "G01AA07",
+  "J01AA06",
+  "S01AA04"
+ ],
+ "oxytetracycline, combinations": [
+  "J01AA56"
+ ],
+ "oxytocin": [
+  "H01BB02"
+ ],
+ "ozanimod": [
+  "L04AE02"
+ ],
+ "ozenoxacin": [
+  "D06AX14"
+ ],
+ "pabinafusp alfa": [
+  "A16AB27"
+ ],
+ "paclitaxel": [
+  "L01CD01"
+ ],
+ "paclitaxel and encequidar": [
+  "L01CD51"
+ ],
+ "paclitaxel poliglumex": [
+  "L01CD03"
+ ],
+ "pacritinib": [
+  "L01EJ03"
+ ],
+ "padeliporfin": [
+  "L01XD07"
+ ],
+ "pafolacianine": [
+  "V04CX10"
+ ],
+ "palbociclib": [
+  "L01EF01"
+ ],
+ "palifermin": [
+  "V03AF08"
+ ],
+ "paliperidone": [
+  "N05AX13"
+ ],
+ "palivizumab": [
+  "J06BD01"
+ ],
+ "palonosetron": [
+  "A04AA05"
+ ],
+ "palonosetron, combinations": [
+  "A04AA55"
+ ],
+ "palopegteriparatide": [
+  "H05AA05"
+ ],
+ "palovarotene": [
+  "M09AX11"
+ ],
+ "pamidronic acid": [
+  "M05BA03"
+ ],
+ "pamiparib": [
+  "L01XK06"
+ ],
+ "pancreozymin (cholecystokinin)": [
+  "V04CK02"
+ ],
+ "pancuronium": [
+  "M03AC01"
+ ],
+ "panipenem and betamipron": [
+  "J01DH55"
+ ],
+ "panitumumab": [
+  "L01FE02"
+ ],
+ "panobinostat": [
+  "L01XH03"
+ ],
+ "pantethine": [
+  "A11HA32"
+ ],
+ "pantoprazole": [
+  "A02BC02"
+ ],
+ "pantoprazole, amoxicillin and clarithromycin": [
+  "A02BD04"
+ ],
+ "pantoprazole, amoxicillin, clarithromycin and metronidazole": [
+  "A02BD11"
+ ],
+ "papaveretum": [
+  "N02AA10"
+ ],
+ "papaverine": [
+  "A03AD01",
+  "G04BE02"
+ ],
+ "papaverine, combinations": [
+  "G04BE52"
+ ],
+ "papillomavirus (human types 16, 18)": [
+  "J07BM02"
+ ],
+ "papillomavirus (human types 6, 11, 16, 18)": [
+  "J07BM01"
+ ],
+ "papillomavirus (human types 6, 11, 16, 18, 31, 33, 45, 52, 58)": [
+  "J07BM03"
+ ],
+ "para-toluenesulfonamide": [
+  "L01XX83"
+ ],
+ "paracetamol": [
+  "N02BE01"
+ ],
+ "paracetamol, combinations excl. psycholeptics": [
+  "N02BE51"
+ ],
+ "paracetamol, combinations with psycholeptics": [
+  "N02BE71"
+ ],
+ "paraldehyde": [
+  "N05CC05"
+ ],
+ "paramethadione": [
+  "N03AC01"
+ ],
+ "paramethasone": [
+  "H02AB05"
+ ],
+ "paraoxon": [
+  "S01EB10"
+ ],
+ "parathyroid gland extract": [
+  "H05AA01"
+ ],
+ "parathyroid hormone": [
+  "H05AA03"
+ ],
+ "parecoxib": [
+  "M01AH04"
+ ],
+ "pargyline": [
+  "C02KC01"
+ ],
+ "pargyline and diuretics": [
+  "C02LL01"
+ ],
+ "paricalcitol": [
+  "H05BX02"
+ ],
+ "parnaparin": [
+  "B01AB07"
+ ],
+ "paromomycin": [
+  "A07AA06"
+ ],
+ "paroxetine": [
+  "N06AB05"
+ ],
+ "parsaclisib": [
+  "L01EM05"
+ ],
+ "pasireotide": [
+  "H01CB05"
+ ],
+ "patent blue": [
+  "V04CX09"
+ ],
+ "patiromer calcium": [
+  "V03AE09"
+ ],
+ "patisiran": [
+  "N07XX12"
+ ],
+ "patritumab deruxtecan": [
+  "L01FX36"
+ ],
+ "pazopanib": [
+  "L01EX03"
+ ],
+ "pazufloxacin": [
+  "J01MA18"
+ ],
+ "pecilocin": [
+  "D01AA04"
+ ],
+ "pectin": [
+  "A07BC01"
+ ],
+ "peficitinib": [
+  "L04AF06"
+ ],
+ "pefloxacin": [
+  "J01MA03"
+ ],
+ "pegademase": [
+  "L03AX04"
+ ],
+ "pegaptanib": [
+  "S01LA03"
+ ],
+ "pegaspargase": [
+  "L01XX24"
+ ],
+ "pegcetacoplan": [
+  "L04AJ03",
+  "S01XA31"
+ ],
+ "pegfilgrastim": [
+  "L03AA13"
+ ],
+ "peginesatide": [
+  "B03XA04"
+ ],
+ "peginterferon alfa-2a": [
+  "L03AB11"
+ ],
+ "peginterferon alfa-2a, combinations": [
+  "L03AB61"
+ ],
+ "peginterferon alfa-2b": [
+  "L03AB10"
+ ],
+ "peginterferon alfa-2b, combinations": [
+  "L03AB60"
+ ],
+ "peginterferon alfacon-2": [
+  "L03AB16"
+ ],
+ "peginterferon beta-1a": [
+  "L03AB13"
+ ],
+ "pegloticase": [
+  "M04AX02"
+ ],
+ "pegteograstim": [
+  "L03AA17"
+ ],
+ "pegunigalsidase alfa": [
+  "A16AB20"
+ ],
+ "pegvaliase": [
+  "A16AB19"
+ ],
+ "pegvisomant": [
+  "H01AX01"
+ ],
+ "pegzilarginase": [
+  "A16AB24"
+ ],
+ "pelabresib": [
+  "L01XX84"
+ ],
+ "pelubiprofen": [
+  "M01AE20"
+ ],
+ "pemafibrate": [
+  "C10AB12"
+ ],
+ "pembrolizumab": [
+  "L01FF02"
+ ],
+ "pemetrexed": [
+  "L01BA04"
+ ],
+ "pemigatinib": [
+  "L01EN02"
+ ],
+ "pemoline": [
+  "N06BA05"
+ ],
+ "penamecillin": [
+  "J01CE06"
+ ],
+ "penbutolol": [
+  "C07AA23"
+ ],
+ "penbutolol and other diuretics": [
+  "C07CA23"
+ ],
+ "penciclovir": [
+  "D06BB06",
+  "J05AB13"
+ ],
+ "penfluridol": [
+  "N05AG03"
+ ],
+ "penicillamine": [
+  "M01CC01"
+ ],
+ "penicillins, combinations with other antibacterials": [
+  "J01RA01"
+ ],
+ "penimepicycline": [
+  "J01AA10"
+ ],
+ "pentaerithrityl": [
+  "A06AD14"
+ ],
+ "pentaerithrityl tetranitrate": [
+  "C01DA05"
+ ],
+ "pentaerithrityl tetranitrate, combinations": [
+  "C01DA55"
+ ],
+ "pentagastrin": [
+  "V04CG04"
+ ],
+ "pentamidine isethionate": [
+  "P01CX01"
+ ],
+ "pentamycin": [
+  "G01AA11"
+ ],
+ "pentanedioic acid imidazolyl ethanamide": [
+  "J05AX21"
+ ],
+ "pentazocine": [
+  "N02AD01"
+ ],
+ "pentazocine and naloxone": [
+  "N02AD51"
+ ],
+ "pentetrazol": [
+  "R07AB03"
+ ],
+ "pentetrazol, combinations": [
+  "R07AB53"
+ ],
+ "penthienate": [
+  "A03AB04"
+ ],
+ "pentifylline": [
+  "C04AD01"
+ ],
+ "pentobarbital": [
+  "N05CA01"
+ ],
+ "pentosan polysulfate sodium": [
+  "C05BA04",
+  "G04BX15"
+ ],
+ "pentostatin": [
+  "L01XX08"
+ ],
+ "pentoxifylline": [
+  "C04AD03"
+ ],
+ "pentoxyverine": [
+  "R05DB05"
+ ],
+ "pepsin": [
+  "A09AA03"
+ ],
+ "pepsin and acid preparations": [
+  "A09AC01"
+ ],
+ "peramivir": [
+  "J05AH03"
+ ],
+ "perampanel": [
+  "N03AX22"
+ ],
+ "perazine": [
+  "N05AB10"
+ ],
+ "perflenapent": [
+  "V08DA03"
+ ],
+ "perflubron": [
+  "V08CX01"
+ ],
+ "perflubutane, phospholipid microspheres": [
+  "V08DA06"
+ ],
+ "perflutren, human albumin microspheres": [
+  "V08DA01"
+ ],
+ "perflutren, phospholipid microspheres": [
+  "V08DA04"
+ ],
+ "pergolide": [
+  "N04BC02"
+ ],
+ "perhexiline": [
+  "C08EX02"
+ ],
+ "periciazine": [
+  "N05AC01"
+ ],
+ "perindopril": [
+  "C09AA04"
+ ],
+ "perindopril and amlodipine": [
+  "C09BB04"
+ ],
+ "perindopril and bisoprolol": [
+  "C09BX02"
+ ],
+ "perindopril and diuretics": [
+  "C09BA04"
+ ],
+ "perindopril, amlodipine and indapamide": [
+  "C09BX01"
+ ],
+ "perindopril, bisoprolol and amlodipine": [
+  "C09BX04"
+ ],
+ "perindopril, bisoprolol, amlodipine and indapamide": [
+  "C09BX06"
+ ],
+ "permethrin": [
+  "P03AC04"
+ ],
+ "permethrin, combinations": [
+  "P03AC54"
+ ],
+ "perphenazine": [
+  "N05AB03"
+ ],
+ "pertussis immunoglobulin": [
+  "J06BB13"
+ ],
+ "pertussis, inactivated, whole cell": [
+  "J07AJ01"
+ ],
+ "pertussis, inactivated, whole cell, combinations with toxoids": [
+  "J07AJ51"
+ ],
+ "pertussis, purified antigen": [
+  "J07AJ02"
+ ],
+ "pertussis, purified antigen, combinations with toxoids": [
+  "J07AJ52"
+ ],
+ "pertuzumab": [
+  "L01FD02"
+ ],
+ "pertuzumab and trastuzumab": [
+  "L01FY01"
+ ],
+ "peruvoside": [
+  "C01AX02"
+ ],
+ "pethidine": [
+  "N02AB02"
+ ],
+ "pethidine and antispasmodics": [
+  "N02AG03"
+ ],
+ "pethidine, combinations excl. psycholeptics": [
+  "N02AB52"
+ ],
+ "pethidine, combinations with psycholeptics": [
+  "N02AB72"
+ ],
+ "pexidartinib": [
+  "L01EX15"
+ ],
+ "phanquinone": [
+  "P01AX04"
+ ],
+ "phenacemide": [
+  "N03AX07"
+ ],
+ "phenacetin": [
+  "N02BE03"
+ ],
+ "phenacetin, combinations excl. psycholeptics": [
+  "N02BE53"
+ ],
+ "phenacetin, combinations with psycholeptics": [
+  "N02BE73"
+ ],
+ "phenazocine": [
+  "N02AD02"
+ ],
+ "phenazone": [
+  "N02BB01",
+  "S02DA03"
+ ],
+ "phenazone, combinations excl. psycholeptics": [
+  "N02BB51"
+ ],
+ "phenazone, combinations with psycholeptics": [
+  "N02BB71"
+ ],
+ "phenazopyridine": [
+  "G04BX06"
+ ],
+ "phenelzine": [
+  "N06AF03"
+ ],
+ "pheneticillin": [
+  "J01CE05"
+ ],
+ "pheneturide": [
+  "N03AX13"
+ ],
+ "phenformin": [
+  "A10BA01"
+ ],
+ "phenformin and sulfonylureas": [
+  "A10BD01"
+ ],
+ "phenglutarimide": [
+  "N04AA09"
+ ],
+ "phenibut": [
+  "N06BX22"
+ ],
+ "phenindamine": [
+  "R06AX04"
+ ],
+ "phenindione": [
+  "B01AA02"
+ ],
+ "pheniramine": [
+  "D04AA16",
+  "R06AB05"
+ ],
+ "phenobarbital": [
+  "N03AA02"
+ ],
+ "phenol": [
+  "C05BB05",
+  "D08AE03",
+  "N01BX03",
+  "R02AA19"
+ ],
+ "phenolphthalein": [
+  "A06AB04"
+ ],
+ "phenolsulfonphthalein": [
+  "V04CH03"
+ ],
+ "phenoperidine": [
+  "N01AH04"
+ ],
+ "phenothrin": [
+  "P03AC03"
+ ],
+ "phenothrin, combinations": [
+  "P03AC53"
+ ],
+ "phenoxybenzamine": [
+  "C04AX02"
+ ],
+ "phenoxymethylpenicillin": [
+  "J01CE02"
+ ],
+ "phenprobamate": [
+  "M03BA01"
+ ],
+ "phenprobamate, combinations excl. psycholeptics": [
+  "M03BA51"
+ ],
+ "phenprobamate, combinations with psycholeptics": [
+  "M03BA71"
+ ],
+ "phenprocoumon": [
+  "B01AA04"
+ ],
+ "phensuximide": [
+  "N03AD02"
+ ],
+ "phentermine": [
+  "A08AA01"
+ ],
+ "phentermine and topiramate": [
+  "A08AA51"
+ ],
+ "phentolamine": [
+  "C04AB01",
+  "V03AB36"
+ ],
+ "phenyl salicylate": [
+  "G04BX12"
+ ],
+ "phenylbutazone": [
+  "M01AA01",
+  "M02AA01"
+ ],
+ "phenylbutazone and corticosteroids": [
+  "M01BA01"
+ ],
+ "phenylephrine": [
+  "C01CA06",
+  "C05AX06",
+  "R01AA04",
+  "R01AB01",
+  "R01BA03",
+  "S01FB01",
+  "S01GA05"
+ ],
+ "phenylephrine and ketorolac": [
+  "S01FB51"
+ ],
+ "phenylephrine, combinations": [
+  "R01BA53",
+  "S01GA55"
+ ],
+ "phenylmercuric borate": [
+  "D08AK02"
+ ],
+ "phenylmercuric nitrate": [
+  "D09AA04"
+ ],
+ "phenylpropanolamine": [
+  "R01BA01"
+ ],
+ "phenylpropanolamine, combinations": [
+  "R01BA51"
+ ],
+ "phenytoin": [
+  "N03AB02"
+ ],
+ "phenytoin, combinations": [
+  "N03AB52"
+ ],
+ "phloroglucinol": [
+  "A03AX12"
+ ],
+ "pholcodine": [
+  "R05DA08"
+ ],
+ "phospholipids": [
+  "A05BA10"
+ ],
+ "phosphorous (32p) chromicphosphate colloid": [
+  "V10AX01"
+ ],
+ "phthalylsulfathiazole": [
+  "A07AB02"
+ ],
+ "physostigmine": [
+  "S01EB05",
+  "V03AB19"
+ ],
+ "phytomenadione": [
+  "B02BA01"
+ ],
+ "picloxydine": [
+  "S01AX16"
+ ],
+ "picodralazine and diuretics": [
+  "C02LG03"
+ ],
+ "picodralazine and diuretics, combinations with psycholeptics": [
+  "C02LG73"
+ ],
+ "picotamide": [
+  "B01AC03"
+ ],
+ "pidotimod": [
+  "L03AX05"
+ ],
+ "piflufolastat (18f)": [
+  "V09IX16"
+ ],
+ "piketoprofen": [
+  "M02AA28"
+ ],
+ "pilocarpine": [
+  "N07AX01",
+  "S01EB01"
+ ],
+ "pilocarpine, combinations": [
+  "S01EB51"
+ ],
+ "pimavanserin": [
+  "N05AX17"
+ ],
+ "pimecrolimus": [
+  "D11AH02"
+ ],
+ "pimethixene": [
+  "R06AX23"
+ ],
+ "pimozide": [
+  "N05AG02"
+ ],
+ "pinacidil": [
+  "C02DG01"
+ ],
+ "pinacidil and diuretics": [
+  "C02LX01"
+ ],
+ "pinaverium": [
+  "A03AX04"
+ ],
+ "pinazepam": [
+  "N05BA14"
+ ],
+ "pindolol": [
+  "C07AA03"
+ ],
+ "pindolol and other diuretics": [
+  "C07CA03"
+ ],
+ "pioglitazone": [
+  "A10BG03"
+ ],
+ "pioglitazone and alogliptin": [
+  "A10BD09"
+ ],
+ "pioglitazone and sitagliptin": [
+  "A10BD12"
+ ],
+ "pipamperone": [
+  "N05AD05"
+ ],
+ "pipazetate": [
+  "R05DB11"
+ ],
+ "pipecuronium bromide": [
+  "M03AC06"
+ ],
+ "pipemidic acid": [
+  "J01MB04"
+ ],
+ "pipenzolate": [
+  "A03AB14"
+ ],
+ "pipenzolate and psycholeptics": [
+  "A03CA09"
+ ],
+ "piperacillin": [
+  "J01CA12"
+ ],
+ "piperacillin and beta-lactamase inhibitor": [
+  "J01CR05"
+ ],
+ "piperazine": [
+  "P02CB01"
+ ],
+ "piperidione": [
+  "R05DB23"
+ ],
+ "piperidolate": [
+  "A03AA30"
+ ],
+ "pipobroman": [
+  "L01AX02"
+ ],
+ "pipotiazine": [
+  "N05AC04"
+ ],
+ "pipradrol": [
+  "N06BX15"
+ ],
+ "piprozolin": [
+  "A05AX01"
+ ],
+ "piracetam": [
+  "N06BX03"
+ ],
+ "pirarubicin": [
+  "L01DB08"
+ ],
+ "pirbuterol": [
+  "R03AC08",
+  "R03CC07"
+ ],
+ "pirenzepine": [
+  "A02BX03"
+ ],
+ "piretanide": [
+  "C03CA03"
+ ],
+ "pirfenidone": [
+  "L04AX05"
+ ],
+ "piribedil": [
+  "N04BC08"
+ ],
+ "pirisudanol": [
+  "N06BX08"
+ ],
+ "piritramide": [
+  "N02AC03"
+ ],
+ "piromidic acid": [
+  "J01MB03"
+ ],
+ "piroxicam": [
+  "M01AC01",
+  "M02AA07",
+  "S01BC06"
+ ],
+ "pirprofen": [
+  "M01AE08"
+ ],
+ "pirtobrutinib": [
+  "L01EL05"
+ ],
+ "pitavastatin": [
+  "C10AA08"
+ ],
+ "pitavastatin and ezetimibe": [
+  "C10BA13"
+ ],
+ "pitofenone and analgesics": [
+  "A03DA02"
+ ],
+ "pitolisant": [
+  "N07XX11"
+ ],
+ "pivagabine": [
+  "N06AX15"
+ ],
+ "pivampicillin": [
+  "J01CA02"
+ ],
+ "pivmecillinam": [
+  "J01CA08"
+ ],
+ "pixantrone": [
+  "L01DB11"
+ ],
+ "pizotifen": [
+  "N02CX01"
+ ],
+ "plague, inactivated, whole cell": [
+  "J07AK01"
+ ],
+ "plastic iud": [
+  "G02BA01"
+ ],
+ "plastic iud with copper": [
+  "G02BA02"
+ ],
+ "plastic iud with progestogen": [
+  "G02BA03"
+ ],
+ "plazomicin": [
+  "J01GB14"
+ ],
+ "plecanatide": [
+  "A06AX07"
+ ],
+ "pleconaril": [
+  "J05AX06"
+ ],
+ "plerixafor": [
+  "L03AX16"
+ ],
+ "plicamycin": [
+  "L01DC02"
+ ],
+ "plitidepsin": [
+  "L01XX57"
+ ],
+ "pneumococcus purified polysaccharides antigen and haemophilus influenzae, conjugated": [
+  "J07AL52"
+ ],
+ "pneumococcus, purified polysaccharides antigen": [
+  "J07AL01"
+ ],
+ "pneumococcus, purified polysaccharides antigen conjugated": [
+  "J07AL02"
+ ],
+ "podophyllotoxin": [
+  "D06BB04"
+ ],
+ "polatuzumab vedotin": [
+  "L01FX14"
+ ],
+ "poldine": [
+  "A03AB11"
+ ],
+ "policosanol": [
+  "C10AX08"
+ ],
+ "policresulen": [
+  "D08AE02",
+  "G01AX03"
+ ],
+ "polidocanol": [
+  "C05BB02"
+ ],
+ "polihexanide": [
+  "D08AC05",
+  "S01AX24"
+ ],
+ "poliomyelitis oral, bivalent, live attenuated": [
+  "J07BF04"
+ ],
+ "poliomyelitis oral, monovalent, live attenuated": [
+  "J07BF01"
+ ],
+ "poliomyelitis oral, trivalent, live attenuated": [
+  "J07BF02"
+ ],
+ "poliomyelitis, trivalent, inactivated, whole virus": [
+  "J07BF03"
+ ],
+ "polmacoxib": [
+  "M01AH07"
+ ],
+ "poly i:c": [
+  "L03AX07"
+ ],
+ "poly iclc": [
+  "L03AX08"
+ ],
+ "polycarbophil calcium": [
+  "A06AC08"
+ ],
+ "polyestradiol phosphate": [
+  "L02AA02"
+ ],
+ "polymyxin b": [
+  "A07AA05",
+  "J01XB02",
+  "S01AA18",
+  "S02AA11",
+  "S03AA03"
+ ],
+ "polynoxylin": [
+  "A01AB05",
+  "D01AE05"
+ ],
+ "polyplatillen": [
+  "L01XA05"
+ ],
+ "polystyrene sulfonate": [
+  "V03AE01"
+ ],
+ "polythiazide": [
+  "C03AA05"
+ ],
+ "polythiazide and potassium": [
+  "C03AB05"
+ ],
+ "pomalidomide": [
+  "L04AX06"
+ ],
+ "ponatinib": [
+  "L01EA05"
+ ],
+ "ponesimod": [
+  "L04AE04"
+ ],
+ "porfimer sodium": [
+  "L01XD01"
+ ],
+ "posaconazole": [
+  "J02AC04"
+ ],
+ "potassium (different salts in combination)": [
+  "A12BA30"
+ ],
+ "potassium acetate": [
+  "B05XA17"
+ ],
+ "potassium canrenoate": [
+  "C03DA02"
+ ],
+ "potassium chloride": [
+  "A12BA01",
+  "B05XA01"
+ ],
+ "potassium citrate": [
+  "A12BA02"
+ ],
+ "potassium clorazepate": [
+  "N05BA05"
+ ],
+ "potassium gluconate": [
+  "A12BA05"
+ ],
+ "potassium hydrogencarbonate": [
+  "A12BA04"
+ ],
+ "potassium hydrogentartrate": [
+  "A12BA03"
+ ],
+ "potassium iodide": [
+  "R05CA02",
+  "S01XA04",
+  "V03AB21"
+ ],
+ "potassium lactate": [
+  "B05XA15"
+ ],
+ "potassium perchlorate": [
+  "H03BC01"
+ ],
+ "potassium permanganate": [
+  "D08AX06",
+  "V03AB18"
+ ],
+ "potassium phosphate, incl. combinations with other potassium salts": [
+  "B05XA06"
+ ],
+ "potassium polysulfide": [
+  "P03AA02"
+ ],
+ "potassium salicylate": [
+  "N02BA12"
+ ],
+ "potassium, combinations": [
+  "A12BA51"
+ ],
+ "povidone-iodine": [
+  "D08AG02",
+  "D09AA09",
+  "D11AC06",
+  "G01AX11",
+  "R02AA15",
+  "S01AX18"
+ ],
+ "pozelimab": [
+  "L04AJ11"
+ ],
+ "practolol": [
+  "C07AB01"
+ ],
+ "prajmaline": [
+  "C01BA08"
+ ],
+ "pralatrexate": [
+  "L01BA05"
+ ],
+ "pralidoxime": [
+  "V03AB04"
+ ],
+ "pralidoxime and atropine": [
+  "V03AB54"
+ ],
+ "pralsetinib": [
+  "L01EX23"
+ ],
+ "pramipexole": [
+  "N04BC05"
+ ],
+ "pramiracetam": [
+  "N06BX16"
+ ],
+ "pramlintide": [
+  "A10BX05"
+ ],
+ "pramocaine": [
+  "C05AD07",
+  "D04AB07"
+ ],
+ "pranlukast": [
+  "R03DC02"
+ ],
+ "pranoprofen": [
+  "S01BC09"
+ ],
+ "prasterone": [
+  "A14AA07",
+  "G03XX01"
+ ],
+ "prasterone and estrogen": [
+  "G03EA03"
+ ],
+ "prasugrel": [
+  "B01AC22"
+ ],
+ "pravastatin": [
+  "C10AA03"
+ ],
+ "pravastatin and acetylsalicylic acid": [
+  "C10BX02"
+ ],
+ "pravastatin and ezetimibe": [
+  "C10BA11"
+ ],
+ "pravastatin and fenofibrate": [
+  "C10BA03"
+ ],
+ "pravastatin, ezetimibe and fenofibrate": [
+  "C10BA12"
+ ],
+ "prazepam": [
+  "N05BA11"
+ ],
+ "praziquantel": [
+  "P02BA01"
+ ],
+ "prazosin": [
+  "C02CA01"
+ ],
+ "prazosin and diuretics": [
+  "C02LE01"
+ ],
+ "prednicarbate": [
+  "D07AC18"
+ ],
+ "prednimustine": [
+  "L01AA08"
+ ],
+ "prednisolone": [
+  "A01AC04",
+  "A07EA01",
+  "C05AA04",
+  "D07AA03",
+  "D07XA02",
+  "H02AB06",
+  "R01AD02",
+  "S01BA04",
+  "S01CB02",
+  "S02BA03",
+  "S03BA02"
+ ],
+ "prednisolone and antibiotics": [
+  "D07CA03"
+ ],
+ "prednisolone and antiinfectives": [
+  "S01CA02",
+  "S02CA01",
+  "S03CA02"
+ ],
+ "prednisolone and antiseptics": [
+  "D07BA01"
+ ],
+ "prednisolone and mydriatics": [
+  "S01BB02"
+ ],
+ "prednisolone and promethazine": [
+  "V03AB05"
+ ],
+ "prednisolone, combinations": [
+  "A01AC54",
+  "R01AD52"
+ ],
+ "prednisone": [
+  "A07EA03",
+  "H02AB07"
+ ],
+ "prednylidene": [
+  "H02AB11"
+ ],
+ "pregabalin": [
+  "N02BF02"
+ ],
+ "prenalterol": [
+  "C01CA13"
+ ],
+ "prenoxdiazine": [
+  "R05DB18"
+ ],
+ "prenylamine": [
+  "C01DX02"
+ ],
+ "prenylamine, combinations": [
+  "C01DX52"
+ ],
+ "prethcamide": [
+  "R07AB06"
+ ],
+ "pretomanid": [
+  "J04AK08"
+ ],
+ "pridinol": [
+  "M03BX03"
+ ],
+ "pridinol, combinations": [
+  "M03BX53"
+ ],
+ "prifinium bromide": [
+  "A03AB18"
+ ],
+ "prilocaine": [
+  "N01BB04"
+ ],
+ "prilocaine, combinations": [
+  "N01BB54"
+ ],
+ "primaquine": [
+  "P01BA03"
+ ],
+ "primidone": [
+  "N03AA03"
+ ],
+ "pristinamycin": [
+  "J01FG01"
+ ],
+ "probenecid": [
+  "M04AB01"
+ ],
+ "probucol": [
+  "C10AX02"
+ ],
+ "procainamide": [
+  "C01BA02"
+ ],
+ "procaine": [
+  "C05AD05",
+  "N01BA02",
+  "S01HA05"
+ ],
+ "procaine benzylpenicillin": [
+  "J01CE09"
+ ],
+ "procaine, combinations": [
+  "N01BA52"
+ ],
+ "procarbazine": [
+  "L01XB01"
+ ],
+ "procaterol": [
+  "R03AC16",
+  "R03CC08"
+ ],
+ "prochlorperazine": [
+  "N05AB04"
+ ],
+ "procyclidine": [
+  "N04AA04"
+ ],
+ "profenamine": [
+  "N04AA05"
+ ],
+ "progabide": [
+  "N03AG05"
+ ],
+ "progesterone": [
+  "G03DA04"
+ ],
+ "progesterone and estrogen": [
+  "G03FA04"
+ ],
+ "proglumetacin": [
+  "M01AB14"
+ ],
+ "proglumide": [
+  "A02BX06"
+ ],
+ "proguanil": [
+  "P01BB01"
+ ],
+ "proguanil, combinations": [
+  "P01BB51"
+ ],
+ "prolgolimab": [
+  "L01FF08"
+ ],
+ "prolgolimab and nurulimab": [
+  "L01FY03"
+ ],
+ "prolintane": [
+  "N06BX14"
+ ],
+ "promazine": [
+  "N05AA03"
+ ],
+ "promegestone": [
+  "G03DB07"
+ ],
+ "promestriene": [
+  "G03CA09"
+ ],
+ "promethazine": [
+  "D04AA10",
+  "R06AD02"
+ ],
+ "promethazine, combinations": [
+  "R06AD52"
+ ],
+ "propacetamol": [
+  "N02BE05"
+ ],
+ "propafenone": [
+  "C01BC03"
+ ],
+ "propamidine": [
+  "D08AC03",
+  "S01AX15"
+ ],
+ "propanidid": [
+  "N01AX04"
+ ],
+ "propanol": [
+  "D08AX03"
+ ],
+ "propanol, combinations": [
+  "D08AX53"
+ ],
+ "propantheline": [
+  "A03AB05"
+ ],
+ "propantheline and psycholeptics": [
+  "A03CA34"
+ ],
+ "propatylnitrate": [
+  "C01DA07"
+ ],
+ "propatylnitrate, combinations": [
+  "C01DA57"
+ ],
+ "propenidazole": [
+  "G01AF14",
+  "P01AB05"
+ ],
+ "propentofylline": [
+  "N06BC02"
+ ],
+ "propicillin": [
+  "J01CE03"
+ ],
+ "propiomazine": [
+  "N05CM06"
+ ],
+ "propiverine": [
+  "G04BD06"
+ ],
+ "propofol": [
+  "N01AX10"
+ ],
+ "propranolol": [
+  "C07AA05"
+ ],
+ "propranolol and other combinations": [
+  "C07FX01"
+ ],
+ "propranolol and thiazides": [
+  "C07BA05"
+ ],
+ "propyliodone": [
+  "V08AD03"
+ ],
+ "propylthiouracil": [
+  "H03BA02"
+ ],
+ "propyphenazone": [
+  "N02BB04"
+ ],
+ "propyphenazone, combinations excl. psycholeptics": [
+  "N02BB54"
+ ],
+ "propyphenazone, combinations with psycholeptics": [
+  "N02BB74"
+ ],
+ "proquazone": [
+  "M01AX13"
+ ],
+ "proscillaridin": [
+  "C01AB01"
+ ],
+ "proscillaridin, combinations": [
+  "C01AB51"
+ ],
+ "protamine": [
+  "V03AB14"
+ ],
+ "protein c": [
+  "B01AD12"
+ ],
+ "protein hydrolysates": [
+  "B05BA04"
+ ],
+ "prothipendyl": [
+  "N05AX07"
+ ],
+ "protiofate": [
+  "G01AX13"
+ ],
+ "protionamide": [
+  "J04AD01"
+ ],
+ "protirelin": [
+  "V04CJ02"
+ ],
+ "protriptyline": [
+  "N06AA11"
+ ],
+ "proxazole": [
+  "A03AX07"
+ ],
+ "proxibarbal": [
+  "N05CA22"
+ ],
+ "proxymetacaine": [
+  "S01HA04"
+ ],
+ "proxyphylline": [
+  "R03DA03"
+ ],
+ "proxyphylline and adrenergics": [
+  "R03DB03"
+ ],
+ "prucalopride": [
+  "A06AX05"
+ ],
+ "prulifloxacin": [
+  "J01MA17"
+ ],
+ "prunus africanae cortex": [
+  "G04CX01"
+ ],
+ "prussian blue": [
+  "V03AB31"
+ ],
+ "pseudoephedrine": [
+  "R01BA02"
+ ],
+ "pseudoephedrine, combinations": [
+  "R01BA52"
+ ],
+ "psma-1007 (18f)": [
+  "V09IX17"
+ ],
+ "pyrantel": [
+  "P02CC01"
+ ],
+ "pyrazinamide": [
+  "J04AK01"
+ ],
+ "pyrazinamide, ethambutol, isoniazid and lomefloxacin": [
+  "J04AM09"
+ ],
+ "pyrazinamide, ethambutol, protionamide and lomefloxacin": [
+  "J04AM10"
+ ],
+ "pyrethrum": [
+  "P03AC01"
+ ],
+ "pyrethrum, combinations": [
+  "P03AC51"
+ ],
+ "pyridostigmine": [
+  "N07AA02"
+ ],
+ "pyridoxal phosphate": [
+  "A11HA06"
+ ],
+ "pyridoxine (vit b6)": [
+  "A11HA02"
+ ],
+ "pyrimethamine": [
+  "P01BD01"
+ ],
+ "pyrimethamine, combinations": [
+  "P01BD51"
+ ],
+ "pyrithione zinc": [
+  "D11AX12"
+ ],
+ "pyrithyldione": [
+  "N05CE03"
+ ],
+ "pyritinol": [
+  "N06BX02"
+ ],
+ "pyrrobutamine": [
+  "R06AX08"
+ ],
+ "pyrrobutamine, combinations": [
+  "R06AX58"
+ ],
+ "pyrrolnitrin": [
+  "D01AA07"
+ ],
+ "pyrvinium": [
+  "P02CX01"
+ ],
+ "quassia": [
+  "P03AX04"
+ ],
+ "quazepam": [
+  "N05CD10"
+ ],
+ "quetiapine": [
+  "N05AH04"
+ ],
+ "quifenadine": [
+  "R06AX31"
+ ],
+ "quinagolide": [
+  "G02CB04"
+ ],
+ "quinapril": [
+  "C09AA06"
+ ],
+ "quinapril and diuretics": [
+  "C09BA06"
+ ],
+ "quinbolone": [
+  "A14AA06"
+ ],
+ "quinethazone": [
+  "C03BA02"
+ ],
+ "quinethazone and potassium": [
+  "C03BB02"
+ ],
+ "quingestanol": [
+  "G03AC04"
+ ],
+ "quingestanol and ethinylestradiol": [
+  "G03AA02"
+ ],
+ "quinidine": [
+  "C01BA01"
+ ],
+ "quinidine, combinations excl. psycholeptics": [
+  "C01BA51"
+ ],
+ "quinidine, combinations with psycholeptics": [
+  "C01BA71"
+ ],
+ "quinine": [
+  "P01BC01"
+ ],
+ "quinine, combinations with psycholeptics": [
+  "M09AA72"
+ ],
+ "quinisocaine": [
+  "D04AB05"
+ ],
+ "quinupramine": [
+  "N06AA23"
+ ],
+ "quinupristin/dalfopristin": [
+  "J01FG02"
+ ],
+ "quizartinib": [
+  "L01EX11"
+ ],
+ "rabeprazole": [
+  "A02BC04"
+ ],
+ "rabeprazole, amoxicillin and clarithromycin": [
+  "A02BD12"
+ ],
+ "rabeprazole, amoxicillin and metronidazole": [
+  "A02BD13"
+ ],
+ "rabeprazole, combinations": [
+  "A02BC54"
+ ],
+ "rabies immunoglobulin": [
+  "J06BB05"
+ ],
+ "rabies serum": [
+  "J06AA06"
+ ],
+ "rabies, inactivated, whole virus": [
+  "J07BG01"
+ ],
+ "racecadotril": [
+  "A07XA04"
+ ],
+ "radium (223ra) dichloride": [
+  "V10XX03"
+ ],
+ "raloxifene": [
+  "G03XC01"
+ ],
+ "raltegravir": [
+  "J05AJ01"
+ ],
+ "raltitrexed": [
+  "L01BA03"
+ ],
+ "ramelteon": [
+  "N05CH02"
+ ],
+ "ramipril": [
+  "C09AA05"
+ ],
+ "ramipril and amlodipine": [
+  "C09BB07"
+ ],
+ "ramipril and bisoprolol": [
+  "C09BX05"
+ ],
+ "ramipril and diuretics": [
+  "C09BA05"
+ ],
+ "ramipril and felodipine": [
+  "C09BB05"
+ ],
+ "ramipril, amlodipine and hydrochlorothiazide": [
+  "C09BX03"
+ ],
+ "ramucirumab": [
+  "L01FG02"
+ ],
+ "ranibizumab": [
+  "S01LA04"
+ ],
+ "ranimustine": [
+  "L01AD07"
+ ],
+ "ranitidine": [
+  "A02BA02"
+ ],
+ "ranitidine bismuth citrate": [
+  "A02BA07"
+ ],
+ "ranolazine": [
+  "C01EB18"
+ ],
+ "rasagiline": [
+  "N04BD02"
+ ],
+ "rasburicase": [
+  "V03AF07"
+ ],
+ "rauwolfia alkaloids, whole root": [
+  "C02AA04"
+ ],
+ "rauwolfia alkaloids, whole root and diuretics": [
+  "C02LA08"
+ ],
+ "ravidasvir": [
+  "J05AP13"
+ ],
+ "ravulizumab": [
+  "L04AJ02"
+ ],
+ "raxibacumab": [
+  "J06BC02"
+ ],
+ "rebamipide": [
+  "A02BX14"
+ ],
+ "reboxetine": [
+  "N06AX18"
+ ],
+ "regadenoson": [
+  "C01EB21"
+ ],
+ "regdanvimab": [
+  "J06BD06"
+ ],
+ "regorafenib": [
+  "L01EX05"
+ ],
+ "relugolix": [
+  "L02BX04"
+ ],
+ "relugolix, estradiol and norethisterone": [
+  "H01CC54"
+ ],
+ "remdesivir": [
+  "J05AB16"
+ ],
+ "remibrutinib": [
+  "L04AA60"
+ ],
+ "remifentanil": [
+  "N01AH06"
+ ],
+ "remikiren": [
+  "C09XA01"
+ ],
+ "remimazolam": [
+  "N05CD14"
+ ],
+ "remoxipride": [
+  "N05AL04"
+ ],
+ "repaglinide": [
+  "A10BX02"
+ ],
+ "reposal": [
+  "N05CA12"
+ ],
+ "repotrectinib": [
+  "L01EX28"
+ ],
+ "reproterol": [
+  "R03AC15",
+  "R03CC14"
+ ],
+ "reproterol and sodium cromoglicate": [
+  "R03AK05"
+ ],
+ "rescinnamine": [
+  "C02AA01"
+ ],
+ "rescinnamine and diuretics": [
+  "C02LA02"
+ ],
+ "rescinnamine and diuretics, combinations with other drugs": [
+  "C02LA52"
+ ],
+ "reserpine": [
+  "C02AA02"
+ ],
+ "reserpine and diuretics": [
+  "C02LA01"
+ ],
+ "reserpine and diuretics, combinations with other drugs": [
+  "C02LA51"
+ ],
+ "reserpine and diuretics, combinations with psycholeptics": [
+  "C02LA71"
+ ],
+ "reserpine, combinations": [
+  "C02AA52"
+ ],
+ "reslizumab": [
+  "R03DX08"
+ ],
+ "resminostat": [
+  "L01XH07"
+ ],
+ "resorcinol": [
+  "D10AX02",
+  "S01AX06"
+ ],
+ "respiratory syncytial virus vaccines": [
+  "J07BX05"
+ ],
+ "retapamulin": [
+  "D06AX13"
+ ],
+ "reteplase": [
+  "B01AD07"
+ ],
+ "retifanlimab": [
+  "L01FF10"
+ ],
+ "retigabine": [
+  "N03AX21"
+ ],
+ "retinol": [
+  "D10AD02",
+  "R01AX02",
+  "S01XA02"
+ ],
+ "retinol (vit a)": [
+  "A11CA01"
+ ],
+ "revefenacin": [
+  "R03BB08"
+ ],
+ "reviparin": [
+  "B01AB08"
+ ],
+ "rezafungin acetate": [
+  "J02AX08"
+ ],
+ "rhenium (186re) etidronic acid": [
+  "V10BX03"
+ ],
+ "rhenium (186re) sulfide colloid": [
+  "V10AX05"
+ ],
+ "riamilovir": [
+  "J05AX32"
+ ],
+ "ribavirin": [
+  "J05AP01"
+ ],
+ "ribociclib": [
+  "L01EF02"
+ ],
+ "riboflavin": [
+  "S01XA26"
+ ],
+ "riboflavin (vit b2)": [
+  "A11HA04"
+ ],
+ "ribostamycin": [
+  "J01GB10"
+ ],
+ "ridaforolimus": [
+  "L01EG03"
+ ],
+ "rifabutin": [
+  "J04AB04"
+ ],
+ "rifabutin, pyrazinamide and protionamide": [
+  "J04AM11"
+ ],
+ "rifampicin": [
+  "J04AB02"
+ ],
+ "rifampicin and isoniazid": [
+  "J04AM02"
+ ],
+ "rifampicin, ethambutol and isoniazid": [
+  "J04AM07"
+ ],
+ "rifampicin, pyrazinamide and isoniazid": [
+  "J04AM05"
+ ],
+ "rifampicin, pyrazinamide, ethambutol and isoniazid": [
+  "J04AM06"
+ ],
+ "rifampicin, pyrazinamide, isoniazid and levofloxacin": [
+  "J04AM12"
+ ],
+ "rifamycin": [
+  "A07AA13",
+  "D06AX15",
+  "J04AB03",
+  "S01AA16",
+  "S02AA12"
+ ],
+ "rifapentine": [
+  "J04AB05"
+ ],
+ "rifaximin": [
+  "A07AA11",
+  "D06AX11"
+ ],
+ "rilmenidine": [
+  "C02AC06"
+ ],
+ "rilonacept": [
+  "L04AC04"
+ ],
+ "rilpivirine": [
+  "J05AG05"
+ ],
+ "riluzole": [
+  "N07XX02"
+ ],
+ "rimantadine": [
+  "J05AC02"
+ ],
+ "rimazolium": [
+  "N02BG02"
+ ],
+ "rimegepant": [
+  "N02CD06"
+ ],
+ "rimexolone": [
+  "H02AB12",
+  "S01BA13"
+ ],
+ "rimiterol": [
+  "R03AC05"
+ ],
+ "rimonabant": [
+  "A08AX01"
+ ],
+ "riociguat": [
+  "C02KX05"
+ ],
+ "ripasudil": [
+  "S01EX07"
+ ],
+ "ripretinib": [
+  "L01EX19"
+ ],
+ "risankizumab": [
+  "L04AC18"
+ ],
+ "risdiplam": [
+  "M09AX10"
+ ],
+ "risedronic acid": [
+  "M05BA07"
+ ],
+ "risedronic acid and calcium, sequential": [
+  "M05BB02"
+ ],
+ "risedronic acid and colecalciferol": [
+  "M05BB07"
+ ],
+ "risedronic acid, calcium and colecalciferol, sequential": [
+  "M05BB04"
+ ],
+ "risperidone": [
+  "N05AX08"
+ ],
+ "ritiometan": [
+  "R01AX05"
+ ],
+ "ritlecitinib": [
+  "L04AF08"
+ ],
+ "ritodrine": [
+  "G02CA01"
+ ],
+ "ritonavir": [
+  "J05AE03"
+ ],
+ "rituximab": [
+  "L01FA01"
+ ],
+ "rivaroxaban": [
+  "B01AF01"
+ ],
+ "rivaroxaban and acetylsalicylic acid": [
+  "B01AF51"
+ ],
+ "rivastigmine": [
+  "N06DA03"
+ ],
+ "rizatriptan": [
+  "N02CC04"
+ ],
+ "rociletinib": [
+  "L01EB05"
+ ],
+ "rociverine": [
+  "A03AA06"
+ ],
+ "rocuronium bromide": [
+  "M03AC09"
+ ],
+ "rofecoxib": [
+  "M01AH02"
+ ],
+ "roflumilast": [
+  "D05AX06",
+  "R03DX07"
+ ],
+ "rokitamycin": [
+  "J01FA12"
+ ],
+ "rolapitant": [
+  "A04AD14"
+ ],
+ "rolitetracycline": [
+  "J01AA09"
+ ],
+ "romidepsin": [
+  "L01XH02"
+ ],
+ "romiplostim": [
+  "B02BX04"
+ ],
+ "romosozumab": [
+  "M05BX06"
+ ],
+ "ronifibrate": [
+  "C10AB07"
+ ],
+ "ropeginterferon alfa-2b": [
+  "L03AB15"
+ ],
+ "ropinirole": [
+  "N04BC04"
+ ],
+ "ropivacaine": [
+  "N01BB09"
+ ],
+ "roquinimex": [
+  "L03AX02"
+ ],
+ "rose bengal sodium": [
+  "S01JA02"
+ ],
+ "rosiglitazone": [
+  "A10BG02"
+ ],
+ "rosoxacin": [
+  "J01MB01"
+ ],
+ "rosuvastatin": [
+  "C10AA07"
+ ],
+ "rosuvastatin and acetylsalicylic acid": [
+  "C10BX05"
+ ],
+ "rosuvastatin and amlodipine": [
+  "C10BX09"
+ ],
+ "rosuvastatin and ezetimibe": [
+  "C10BA06"
+ ],
+ "rosuvastatin and fenofibrate": [
+  "C10BA09"
+ ],
+ "rosuvastatin and fimasartan": [
+  "C10BX16"
+ ],
+ "rosuvastatin and nebivolol": [
+  "C10BX22"
+ ],
+ "rosuvastatin and omega-3 fatty acids": [
+  "C10BA07"
+ ],
+ "rosuvastatin and perindopril": [
+  "C10BX21"
+ ],
+ "rosuvastatin and ramipril": [
+  "C10BX17"
+ ],
+ "rosuvastatin and telmisartan": [
+  "C10BX20"
+ ],
+ "rosuvastatin and valsartan": [
+  "C10BX10"
+ ],
+ "rosuvastatin, amlodipine and lisinopril": [
+  "C10BX07"
+ ],
+ "rosuvastatin, amlodipine and perindopril": [
+  "C10BX14"
+ ],
+ "rosuvastatin, perindopril and indapamide": [
+  "C10BX13"
+ ],
+ "rota virus, live attenuated": [
+  "J07BH01"
+ ],
+ "rota virus, pentavalent, live, reassorted": [
+  "J07BH02"
+ ],
+ "rotigotine": [
+  "N04BC09"
+ ],
+ "roxadustat": [
+  "B03XA05"
+ ],
+ "roxatidine": [
+  "A02BA06"
+ ],
+ "roxithromycin": [
+  "J01FA06"
+ ],
+ "rozanolixizumab": [
+  "L04AG16"
+ ],
+ "rubella immunoglobulin": [
+  "J06BB06"
+ ],
+ "rubella, combinations with mumps, live attenuated": [
+  "J07BJ51"
+ ],
+ "rubella, live attenuated": [
+  "J07BJ01"
+ ],
+ "rubidium (82rb) chloride": [
+  "V09GX04"
+ ],
+ "rucaparib": [
+  "L01XK03"
+ ],
+ "rufinamide": [
+  "N03AF03"
+ ],
+ "rufloxacin": [
+  "J01MA10"
+ ],
+ "rupatadine": [
+  "R06AX28"
+ ],
+ "rutoside": [
+  "C05CA01"
+ ],
+ "rutoside, combinations": [
+  "C05CA51"
+ ],
+ "ruxolitinib": [
+  "D11AH09",
+  "L01EJ01"
+ ],
+ "s-atenolol": [
+  "C07AB11"
+ ],
+ "sabalis serrulatae fructus": [
+  "G04CX02"
+ ],
+ "sabatolimab": [
+  "L01FX19"
+ ],
+ "saccharated iron oxide": [
+  "B03AB02"
+ ],
+ "saccharomyces boulardii": [
+  "A07FA02"
+ ],
+ "sacituzumab govitecan": [
+  "L01FX17"
+ ],
+ "sacrosidase": [
+  "A16AB06"
+ ],
+ "safinamide": [
+  "N04BD03"
+ ],
+ "salbutamol": [
+  "R03AC02",
+  "R03CC02"
+ ],
+ "salbutamol and beclometasone": [
+  "R03AK13"
+ ],
+ "salbutamol and budesonide": [
+  "R03AK15"
+ ],
+ "salbutamol and ipratropium bromide": [
+  "R03AL02"
+ ],
+ "salicylamide": [
+  "N02BA05"
+ ],
+ "salicylamide, combinations excl. psycholeptics": [
+  "N02BA55"
+ ],
+ "salicylamide, combinations with psycholeptics": [
+  "N02BA75"
+ ],
+ "salicylic acid": [
+  "D01AE12",
+  "S01BC08"
+ ],
+ "salmeterol": [
+  "R03AC12"
+ ],
+ "salmeterol and budesonide": [
+  "R03AK12"
+ ],
+ "salmeterol and fluticasone": [
+  "R03AK06"
+ ],
+ "salsalate": [
+  "N02BA06"
+ ],
+ "samarium (153sm) hydroxyapatite colloid": [
+  "V10AX02"
+ ],
+ "samarium (153sm) lexidronam": [
+  "V10BX02"
+ ],
+ "sampeginterferon beta-1a": [
+  "L03AB17"
+ ],
+ "sapropterin": [
+  "A16AX07"
+ ],
+ "saquinavir": [
+  "J05AE01"
+ ],
+ "sarecycline": [
+  "J01AA14"
+ ],
+ "sargramostim": [
+  "L03AA09"
+ ],
+ "sarilumab": [
+  "L04AC14"
+ ],
+ "saruplase": [
+  "B01AD08"
+ ],
+ "satralizumab": [
+  "L04AC19"
+ ],
+ "satranidazole": [
+  "P01AB08"
+ ],
+ "satraplatin": [
+  "L01XA04"
+ ],
+ "saxagliptin": [
+  "A10BH03"
+ ],
+ "saxagliptin and dapagliflozin": [
+  "A10BD21"
+ ],
+ "scopolamine": [
+  "A04AD01",
+  "N05CM05",
+  "S01FA02"
+ ],
+ "scopolamine, combinations": [
+  "A04AD51"
+ ],
+ "sebelipase alfa": [
+  "A16AB14"
+ ],
+ "sebetralstat": [
+  "B06AC08"
+ ],
+ "secnidazole": [
+  "P01AB07"
+ ],
+ "secobarbital": [
+  "N05CA06"
+ ],
+ "secretin": [
+  "V04CK01"
+ ],
+ "secukinumab": [
+  "L04AC10"
+ ],
+ "seladelpar": [
+  "A05AX07"
+ ],
+ "selegiline": [
+  "N04BD01"
+ ],
+ "selenium (75se) norcholesterol": [
+  "V09XX03"
+ ],
+ "selenium (75se) tauroselcholic acid": [
+  "V09DX01"
+ ],
+ "selenium compounds": [
+  "D11AC03"
+ ],
+ "selenium sulfide": [
+  "D01AE13"
+ ],
+ "selexipag": [
+  "B01AC27"
+ ],
+ "selinexor": [
+  "L01XX66"
+ ],
+ "selpercatinib": [
+  "L01EX22"
+ ],
+ "selumetinib": [
+  "L01EE04"
+ ],
+ "semaglutide": [
+  "A10BJ06"
+ ],
+ "semustine": [
+  "L01AD03"
+ ],
+ "senega": [
+  "R05CA06"
+ ],
+ "seniprutug": [
+  "L04AG17"
+ ],
+ "senna glycosides": [
+  "A06AB06"
+ ],
+ "senna glycosides, combinations": [
+  "A06AB56"
+ ],
+ "sepofarsen": [
+  "S01XA29"
+ ],
+ "sequifenadine": [
+  "R06AX32"
+ ],
+ "seratrodast": [
+  "R03DX06"
+ ],
+ "serelaxin": [
+  "C01DX21"
+ ],
+ "sermorelin": [
+  "H01AC04",
+  "V04CD03"
+ ],
+ "serplulimab": [
+  "L01FF12"
+ ],
+ "sertaconazole": [
+  "D01AC14",
+  "G01AF19"
+ ],
+ "sertindole": [
+  "N05AE03"
+ ],
+ "sertraline": [
+  "N06AB06"
+ ],
+ "serum gonadotrophin": [
+  "G03GA03"
+ ],
+ "setmelanotide": [
+  "A08AA12"
+ ],
+ "sevelamer": [
+  "V03AE02"
+ ],
+ "sevoflurane": [
+  "N01AB08"
+ ],
+ "sibutramine": [
+  "A08AA10"
+ ],
+ "sildenafil": [
+  "G04BE03"
+ ],
+ "silicones": [
+  "A03AX13"
+ ],
+ "silodosin": [
+  "G04CA04"
+ ],
+ "siltuximab": [
+  "L04AC11"
+ ],
+ "silver": [
+  "D08AL30"
+ ],
+ "silver compounds": [
+  "S01AX02"
+ ],
+ "silver nitrate": [
+  "D08AL01"
+ ],
+ "silver sulfadiazine": [
+  "D06BA01"
+ ],
+ "silver sulfadiazine, combinations": [
+  "D06BA51"
+ ],
+ "silymarin": [
+  "A05BA03"
+ ],
+ "simeprevir": [
+  "J05AP05"
+ ],
+ "simfibrate": [
+  "C10AB06"
+ ],
+ "simvastatin": [
+  "C10AA01"
+ ],
+ "simvastatin and acetylsalicylic acid": [
+  "C10BX01"
+ ],
+ "simvastatin and ezetimibe": [
+  "C10BA02"
+ ],
+ "simvastatin and fenofibrate": [
+  "C10BA04"
+ ],
+ "simvastatin, acetylsalicylic acid and ramipril": [
+  "C10BX04"
+ ],
+ "sincalide": [
+  "V04CC03"
+ ],
+ "sinecatechins": [
+  "D06BB12"
+ ],
+ "sipavibart": [
+  "J06BD09"
+ ],
+ "siponimod": [
+  "L04AE03"
+ ],
+ "sipuleucel-t": [
+  "L03AX17"
+ ],
+ "sirolimus": [
+  "L01EG04",
+  "L04AH01",
+  "S01XA23"
+ ],
+ "sirukumab": [
+  "L04AC15"
+ ],
+ "sisomicin": [
+  "J01GB08"
+ ],
+ "sitafloxacin": [
+  "J01MA21"
+ ],
+ "sitagliptin": [
+  "A10BH01"
+ ],
+ "sitagliptin and dapagliflozin": [
+  "A10BD29"
+ ],
+ "sitagliptin and ertugliflozin": [
+  "A10BD24"
+ ],
+ "sitagliptin and simvastatin": [
+  "A10BH51"
+ ],
+ "sitaxentan": [
+  "C02KX03"
+ ],
+ "sitimagene ceradenovec": [
+  "L01XL01"
+ ],
+ "sitravatinib": [
+  "L01EX26"
+ ],
+ "smallpox and monkeypox vaccines": [
+  "J07BX01"
+ ],
+ "snake venom antiserum": [
+  "J06AA03"
+ ],
+ "sobrerol": [
+  "R05CB07"
+ ],
+ "sodium acetate": [
+  "B05XA08"
+ ],
+ "sodium aminosalicylate": [
+  "J04AA02"
+ ],
+ "sodium apolate": [
+  "C05BA02"
+ ],
+ "sodium aurothiomalate": [
+  "M01CB01"
+ ],
+ "sodium aurotiosulfate": [
+  "M01CB02"
+ ],
+ "sodium benzoate": [
+  "A16AX11"
+ ],
+ "sodium benzoate and sodium phenylacetate": [
+  "A16AX30"
+ ],
+ "sodium bicarbonate": [
+  "B05CB04",
+  "B05XA02"
+ ],
+ "sodium borate": [
+  "S01AX07"
+ ],
+ "sodium cellulose phosphate": [
+  "V03AG01"
+ ],
+ "sodium chloride": [
+  "A12CA01",
+  "B05CB01",
+  "B05XA03"
+ ],
+ "sodium chloride, hypertonic": [
+  "S01XA03"
+ ],
+ "sodium chlorite": [
+  "D03AX11"
+ ],
+ "sodium citrate": [
+  "B05CB02"
+ ],
+ "sodium edetate": [
+  "S01XA05"
+ ],
+ "sodium feredetate": [
+  "B03AB03"
+ ],
+ "sodium fluoride": [
+  "A01AA01",
+  "A12CD01"
+ ],
+ "sodium fluoride (18f)": [
+  "V09IX06"
+ ],
+ "sodium fluoride, combinations": [
+  "A01AA51"
+ ],
+ "sodium folinate": [
+  "V03AF06"
+ ],
+ "sodium glycerophosphate": [
+  "B05XA14"
+ ],
+ "sodium hypochlorite": [
+  "D08AX07"
+ ],
+ "sodium iodide (123i)": [
+  "V09FX02"
+ ],
+ "sodium iodide (124i)": [
+  "V09FX04"
+ ],
+ "sodium iodide (131i)": [
+  "V09FX03",
+  "V10XA01"
+ ],
+ "sodium iodohippurate (123i)": [
+  "V09CX01"
+ ],
+ "sodium iodohippurate (131i)": [
+  "V09CX02"
+ ],
+ "sodium iopodate": [
+  "V08AC08"
+ ],
+ "sodium iothalamate (125i)": [
+  "V09CX03"
+ ],
+ "sodium lauryl sulfoacetate, incl. combinations": [
+  "A06AG11"
+ ],
+ "sodium levofolinate": [
+  "V03AF10"
+ ],
+ "sodium monofluorophosphate": [
+  "A01AA02",
+  "A12CD02"
+ ],
+ "sodium nitrite": [
+  "V03AB08"
+ ],
+ "sodium oxybate": [
+  "N01AX11",
+  "N07XX04"
+ ],
+ "sodium perborate": [
+  "A01AB19"
+ ],
+ "sodium phenylbutyrate": [
+  "A16AX03"
+ ],
+ "sodium phenylbutyrate and ursodoxicoltaurine": [
+  "N07XX19"
+ ],
+ "sodium phosphate": [
+  "A06AD17",
+  "A06AG01",
+  "B05XA09",
+  "V03AG05"
+ ],
+ "sodium phosphate (32p)": [
+  "V10XX01"
+ ],
+ "sodium picosulfate": [
+  "A06AB08"
+ ],
+ "sodium picosulfate, combinations": [
+  "A06AB58"
+ ],
+ "sodium propionate": [
+  "S01AX10"
+ ],
+ "sodium salicylate": [
+  "N02BA04"
+ ],
+ "sodium salicylate and methenamine": [
+  "G04BX17"
+ ],
+ "sodium selenate": [
+  "A12CE01"
+ ],
+ "sodium selenite": [
+  "A12CE02",
+  "B05XA20"
+ ],
+ "sodium stibogluconate": [
+  "P01CB02"
+ ],
+ "sodium sulfate": [
+  "A06AD13",
+  "A12CA02"
+ ],
+ "sodium tartrate": [
+  "A06AD21"
+ ],
+ "sodium tetradecyl sulfate": [
+  "C05BB04"
+ ],
+ "sodium zirconium cyclosilicate": [
+  "V03AE10"
+ ],
+ "sofosbuvir": [
+  "J05AP08"
+ ],
+ "sofosbuvir and ledipasvir": [
+  "J05AP51"
+ ],
+ "sofosbuvir and velpatasvir": [
+  "J05AP55"
+ ],
+ "sofosbuvir, velpatasvir and voxilaprevir": [
+  "J05AP56"
+ ],
+ "solifenacin": [
+  "G04BD08"
+ ],
+ "solithromycin": [
+  "J01FA16"
+ ],
+ "solriamfetol": [
+  "N06BA14"
+ ],
+ "somapacitan": [
+  "H01AC07"
+ ],
+ "somatorelin": [
+  "V04CD05"
+ ],
+ "somatostatin": [
+  "H01CB01"
+ ],
+ "somatrem": [
+  "H01AC02"
+ ],
+ "somatrogon": [
+  "H01AC08"
+ ],
+ "somatropin": [
+  "H01AC01"
+ ],
+ "sonidegib": [
+  "L01XJ02"
+ ],
+ "sorafenib": [
+  "L01EX02"
+ ],
+ "sorbitol": [
+  "A06AD18",
+  "A06AG07",
+  "B05CX02",
+  "V04CC01"
+ ],
+ "sotagliflozin": [
+  "A10BK06"
+ ],
+ "sotalol": [
+  "C07AA07"
+ ],
+ "sotalol and acetylsalicylic acid": [
+  "C07FX02"
+ ],
+ "sotalol and thiazides": [
+  "C07BA07"
+ ],
+ "sotatercept": [
+  "C02KX06"
+ ],
+ "sotorasib": [
+  "L01XX73"
+ ],
+ "sotrovimab": [
+  "J06BD05"
+ ],
+ "spaglumic acid": [
+  "R01AC05",
+  "S01GX03"
+ ],
+ "sparfloxacin": [
+  "J01MA09"
+ ],
+ "sparsentan": [
+  "C09XX01"
+ ],
+ "sparteine": [
+  "C01BA04"
+ ],
+ "spectinomycin": [
+  "J01XX04"
+ ],
+ "spesolimab": [
+  "L04AC22"
+ ],
+ "spiramycin": [
+  "J01FA02"
+ ],
+ "spiramycin and metronidazole": [
+  "J01RA04"
+ ],
+ "spirapril": [
+  "C09AA11"
+ ],
+ "spironolactone": [
+  "C03DA01"
+ ],
+ "stannous fluoride": [
+  "A01AA04"
+ ],
+ "stanozolol": [
+  "A14AA02"
+ ],
+ "staphylococcus immunoglobulin": [
+  "J06BB08"
+ ],
+ "stavudine": [
+  "J05AF04"
+ ],
+ "stavudine and lamivudine": [
+  "J05AR28"
+ ],
+ "stavudine, lamivudine and nevirapine": [
+  "J05AR07"
+ ],
+ "stem cells from umbilical cord blood": [
+  "B05AX04"
+ ],
+ "stepronin": [
+  "R05CB11"
+ ],
+ "sterculia": [
+  "A06AC03"
+ ],
+ "sterculia, combinations": [
+  "A06AC53"
+ ],
+ "stibophen": [
+  "P02BX03"
+ ],
+ "stiripentol": [
+  "N03AX17"
+ ],
+ "stramoni preparations": [
+  "R03BB03"
+ ],
+ "streptoduocin": [
+  "J01GA02"
+ ],
+ "streptokinase": [
+  "B01AD01"
+ ],
+ "streptokinase, combinations": [
+  "B06AA55"
+ ],
+ "streptomycin": [
+  "A07AA04",
+  "J01GA01"
+ ],
+ "streptomycin and isoniazid": [
+  "J04AM01"
+ ],
+ "streptomycin, combinations": [
+  "A07AA54"
+ ],
+ "streptozocin": [
+  "L01AD04"
+ ],
+ "strontium (89sr) chloride": [
+  "V10BX01"
+ ],
+ "strontium ranelate": [
+  "M05BX03"
+ ],
+ "strontium ranelate and colecalciferol": [
+  "M05BX53"
+ ],
+ "styramate": [
+  "M03BA04"
+ ],
+ "succinimide": [
+  "G04BX10"
+ ],
+ "succinylsulfathiazole": [
+  "A07AB04"
+ ],
+ "sucralfate": [
+  "A02BX02"
+ ],
+ "sucroferric oxyhydroxide": [
+  "V03AE05"
+ ],
+ "sufentanil": [
+  "N01AH03"
+ ],
+ "sugammadex": [
+  "V03AB35"
+ ],
+ "sugemalimab": [
+  "L01FF11"
+ ],
+ "sulbactam": [
+  "J01CG01"
+ ],
+ "sulbenicillin": [
+  "J01CA16"
+ ],
+ "sulbentine": [
+  "D01AE09"
+ ],
+ "sulbutiamine": [
+  "A11DA02"
+ ],
+ "sulconazole": [
+  "D01AC09"
+ ],
+ "sulfacetamide": [
+  "D10AF06",
+  "S01AB04"
+ ],
+ "sulfadiazine": [
+  "J01EC02"
+ ],
+ "sulfadiazine and tetroxoprim": [
+  "J01EE06"
+ ],
+ "sulfadiazine and trimethoprim": [
+  "J01EE02"
+ ],
+ "sulfadicramide": [
+  "S01AB03"
+ ],
+ "sulfadimethoxine": [
+  "J01ED01"
+ ],
+ "sulfadimidine": [
+  "J01EB03"
+ ],
+ "sulfadimidine and trimethoprim": [
+  "J01EE05"
+ ],
+ "sulfafenazol": [
+  "S01AB05"
+ ],
+ "sulfafurazole": [
+  "J01EB05",
+  "S01AB02"
+ ],
+ "sulfaguanidine": [
+  "A07AB03"
+ ],
+ "sulfaisodimidine": [
+  "J01EB01"
+ ],
+ "sulfalene": [
+  "J01ED02"
+ ],
+ "sulfamazone": [
+  "J01ED09"
+ ],
+ "sulfamerazine": [
+  "D06BA06",
+  "J01ED07"
+ ],
+ "sulfamerazine and trimethoprim": [
+  "J01EE07"
+ ],
+ "sulfamethizole": [
+  "B05CA04",
+  "D06BA04",
+  "J01EB02",
+  "S01AB01"
+ ],
+ "sulfamethoxazole": [
+  "J01EC01"
+ ],
+ "sulfamethoxazole and trimethoprim": [
+  "J01EE01"
+ ],
+ "sulfamethoxypyridazine": [
+  "J01ED05"
+ ],
+ "sulfametomidine": [
+  "J01ED03"
+ ],
+ "sulfametoxydiazine": [
+  "J01ED04"
+ ],
+ "sulfametrole and trimethoprim": [
+  "J01EE03"
+ ],
+ "sulfamoxole": [
+  "J01EC03"
+ ],
+ "sulfamoxole and trimethoprim": [
+  "J01EE04"
+ ],
+ "sulfanilamide": [
+  "D06BA05",
+  "J01EB06"
+ ],
+ "sulfaperin": [
+  "J01ED06"
+ ],
+ "sulfaphenazole": [
+  "J01ED08"
+ ],
+ "sulfapyridine": [
+  "J01EB04"
+ ],
+ "sulfasalazine": [
+  "A07EC01"
+ ],
+ "sulfathiazole": [
+  "D06BA02",
+  "J01EB07"
+ ],
+ "sulfathiourea": [
+  "J01EB08"
+ ],
+ "sulfatolamide": [
+  "G01AE01"
+ ],
+ "sulfinpyrazone": [
+  "M04AB02"
+ ],
+ "sulfobromophthalein": [
+  "V04CE02"
+ ],
+ "sulfonamides, combinations with other antibacterials (excl. trimethoprim)": [
+  "J01RA02"
+ ],
+ "sulfur": [
+  "D10AB02"
+ ],
+ "sulfur compounds": [
+  "D11AC08"
+ ],
+ "sulfur hexafluoride, phospholipid microspheres": [
+  "V08DA05"
+ ],
+ "sulglicotide": [
+  "A02BX08"
+ ],
+ "sulindac": [
+  "M01AB02"
+ ],
+ "suloctidil": [
+  "C04AX19"
+ ],
+ "sulodexide": [
+  "B01AB11"
+ ],
+ "sulpiride": [
+  "N05AL01"
+ ],
+ "sulprostone": [
+  "G02AD05"
+ ],
+ "sultamicillin": [
+  "J01CR04"
+ ],
+ "sultiame": [
+  "N03AX03"
+ ],
+ "sultopride": [
+  "N05AL02"
+ ],
+ "sumatriptan": [
+  "N02CC01"
+ ],
+ "sumatriptan and naproxen": [
+  "N02CC51"
+ ],
+ "sunitinib": [
+  "L01EX01"
+ ],
+ "suprofen": [
+  "M01AE07"
+ ],
+ "suramin sodium": [
+  "P01CX02"
+ ],
+ "surufatinib": [
+  "L01EX24"
+ ],
+ "susoctocog alfa": [
+  "B02BD14"
+ ],
+ "sutimlimab": [
+  "L04AJ04"
+ ],
+ "suvorexant": [
+  "N05CJ01"
+ ],
+ "suxamethonium": [
+  "M03AB01"
+ ],
+ "suxibuzone": [
+  "M02AA22"
+ ],
+ "syrosingopine and diuretics": [
+  "C02LA09"
+ ],
+ "tabelecleucel": [
+  "L01XL09"
+ ],
+ "tacalcitol": [
+  "D05AX04"
+ ],
+ "tacrine": [
+  "N06DA01"
+ ],
+ "tacrolimus": [
+  "D11AH01",
+  "L04AD02"
+ ],
+ "tadalafil": [
+  "G04BE08"
+ ],
+ "tafamidis": [
+  "N07XX08"
+ ],
+ "tafasitamab": [
+  "L01FX12"
+ ],
+ "tafenoquine": [
+  "P01BA07"
+ ],
+ "tafluprost": [
+  "S01EE05"
+ ],
+ "tagraxofusp": [
+  "L01XX67"
+ ],
+ "talampicillin": [
+  "J01CA15"
+ ],
+ "talastine": [
+  "R06AB07"
+ ],
+ "talazoparib": [
+  "L01XK04"
+ ],
+ "talbutal": [
+  "N05CA07"
+ ],
+ "taliglucerase alfa": [
+  "A16AB11"
+ ],
+ "talimogene laherparepvec": [
+  "L01XL02"
+ ],
+ "talinolol": [
+  "C07AB13"
+ ],
+ "talquetamab": [
+  "L01FX29"
+ ],
+ "tamoxifen": [
+  "L02BA01"
+ ],
+ "tamsulosin": [
+  "G04CA02"
+ ],
+ "tamsulosin and dutasteride": [
+  "G04CA52"
+ ],
+ "tamsulosin and solifenacin": [
+  "G04CA53"
+ ],
+ "tamsulosin and tadalafil": [
+  "G04CA54"
+ ],
+ "tanezumab": [
+  "N02BG12"
+ ],
+ "tapentadol": [
+  "N02AX06"
+ ],
+ "tapinarof": [
+  "D05AX07"
+ ],
+ "tarlatamab": [
+  "L01FX33"
+ ],
+ "tasimelteon": [
+  "N05CH03"
+ ],
+ "tasonermin": [
+  "L03AX11"
+ ],
+ "tasosartan": [
+  "C09CA05"
+ ],
+ "taurolidine": [
+  "B05CA05"
+ ],
+ "tavaborole": [
+  "D01AE24"
+ ],
+ "tazarotene": [
+  "D05AX05"
+ ],
+ "tazarotene and ulobetasol": [
+  "D05AX55"
+ ],
+ "tazemetostat": [
+  "L01XX72"
+ ],
+ "tazobactam": [
+  "J01CG02"
+ ],
+ "tebentafusp": [
+  "L01XX75"
+ ],
+ "tebipenem pivoxil": [
+  "J01DH06"
+ ],
+ "technetium (99mtc) anticarcinoembryonicantigen antibody": [
+  "V09IA01"
+ ],
+ "technetium (99mtc) antigranulocyte antibody": [
+  "V09HA03"
+ ],
+ "technetium (99mtc) antimelanoma antibody": [
+  "V09IA02"
+ ],
+ "technetium (99mtc) apcitide": [
+  "V09GA07"
+ ],
+ "technetium (99mtc) arcitumomab": [
+  "V09IA06"
+ ],
+ "technetium (99mtc) bicisate": [
+  "V09AA02"
+ ],
+ "technetium (99mtc) butedronic acid": [
+  "V09BA04"
+ ],
+ "technetium (99mtc) depreotide": [
+  "V09IA05"
+ ],
+ "technetium (99mtc) disofenin": [
+  "V09DA01"
+ ],
+ "technetium (99mtc) etarfolatide": [
+  "V09IA08"
+ ],
+ "technetium (99mtc) ethylenedicysteine": [
+  "V09CA06"
+ ],
+ "technetium (99mtc) etifenin": [
+  "V09DA02"
+ ],
+ "technetium (99mtc) exametazime": [
+  "V09AA01"
+ ],
+ "technetium (99mtc) exametazime labelled cells": [
+  "V09HA02"
+ ],
+ "technetium (99mtc) furifosmin": [
+  "V09GA05"
+ ],
+ "technetium (99mtc) galtifenin": [
+  "V09DA05"
+ ],
+ "technetium (99mtc) gluceptate": [
+  "V09CA04"
+ ],
+ "technetium (99mtc) gluconate": [
+  "V09CA05"
+ ],
+ "technetium (99mtc) human albumin": [
+  "V09GA04"
+ ],
+ "technetium (99mtc) human immunoglobulin": [
+  "V09HA01"
+ ],
+ "technetium (99mtc) hynic-octreotide": [
+  "V09IA07"
+ ],
+ "technetium (99mtc) lidofenin": [
+  "V09DA03"
+ ],
+ "technetium (99mtc) macrosalb": [
+  "V09EB01"
+ ],
+ "technetium (99mtc) mebrofenin": [
+  "V09DA04"
+ ],
+ "technetium (99mtc) medronic acid": [
+  "V09BA02"
+ ],
+ "technetium (99mtc) mertiatide": [
+  "V09CA03"
+ ],
+ "technetium (99mtc) microcolloid": [
+  "V09DB02"
+ ],
+ "technetium (99mtc) microspheres": [
+  "V09EB02"
+ ],
+ "technetium (99mtc) millimicrospheres": [
+  "V09DB03"
+ ],
+ "technetium (99mtc) nanocolloid": [
+  "V09DB01",
+  "V09EA03"
+ ],
+ "technetium (99mtc) oxidronic acid": [
+  "V09BA01"
+ ],
+ "technetium (99mtc) pentavalent succimer": [
+  "V09IA03"
+ ],
+ "technetium (99mtc) pentetic acid": [
+  "V09CA01",
+  "V09EA01"
+ ],
+ "technetium (99mtc) pertechnetate": [
+  "V09FX01"
+ ],
+ "technetium (99mtc) phytate": [
+  "V09DB07"
+ ],
+ "technetium (99mtc) pyrophosphate": [
+  "V09BA03"
+ ],
+ "technetium (99mtc) rheniumsulfide colloid": [
+  "V09DB06"
+ ],
+ "technetium (99mtc) sestamibi": [
+  "V09GA01"
+ ],
+ "technetium (99mtc) stannous agent labelled cells": [
+  "V09GA06"
+ ],
+ "technetium (99mtc) succimer": [
+  "V09CA02"
+ ],
+ "technetium (99mtc) sulesomab": [
+  "V09HA04"
+ ],
+ "technetium (99mtc) sulfur colloid": [
+  "V09DB05"
+ ],
+ "technetium (99mtc) teboroxime": [
+  "V09GA03"
+ ],
+ "technetium (99mtc) technegas": [
+  "V09EA02"
+ ],
+ "technetium (99mtc) tetrofosmin": [
+  "V09GA02"
+ ],
+ "technetium (99mtc) tilmanocept": [
+  "V09IA09"
+ ],
+ "technetium (99mtc) tin colloid": [
+  "V09DB04"
+ ],
+ "technetium (99mtc) trofolastat chloride": [
+  "V09IA10"
+ ],
+ "technetium (99mtc) votumumab": [
+  "V09IA04"
+ ],
+ "teclistamab": [
+  "L01FX24"
+ ],
+ "teclozan": [
+  "P01AC04"
+ ],
+ "tecovirimat": [
+  "J05AX24"
+ ],
+ "tedisamil": [
+  "C01BD06"
+ ],
+ "tedizolid": [
+  "J01XX11"
+ ],
+ "teduglutide": [
+  "A16AX08"
+ ],
+ "tegafur": [
+  "L01BC03"
+ ],
+ "tegafur, combinations": [
+  "L01BC53"
+ ],
+ "tegaserod": [
+  "A06AX06"
+ ],
+ "tegomil fumarate": [
+  "L04AX10"
+ ],
+ "tegoprazan": [
+  "A02BC09"
+ ],
+ "teicoplanin": [
+  "J01XA02"
+ ],
+ "telaprevir": [
+  "J05AP02"
+ ],
+ "telavancin": [
+  "J01XA03"
+ ],
+ "telbivudine": [
+  "J05AF11"
+ ],
+ "telithromycin": [
+  "J01FA15"
+ ],
+ "telmisartan": [
+  "C09CA07"
+ ],
+ "telmisartan and amlodipine": [
+  "C09DB04"
+ ],
+ "telmisartan and diuretics": [
+  "C09DA07"
+ ],
+ "telmisartan, amlodipine and hydrochlorothiazide": [
+  "C09DX08"
+ ],
+ "telotristat": [
+  "A16AX15"
+ ],
+ "temafloxacin": [
+  "J01MA05"
+ ],
+ "temazepam": [
+  "N05CD07"
+ ],
+ "temocapril": [
+  "C09AA14"
+ ],
+ "temocillin": [
+  "J01CA17"
+ ],
+ "temoporfin": [
+  "L01XD05"
+ ],
+ "temozolomide": [
+  "L01AX03"
+ ],
+ "temsirolimus": [
+  "L01EG01"
+ ],
+ "tenapanor": [
+  "A06AX08"
+ ],
+ "tenecteplase": [
+  "B01AD11"
+ ],
+ "teneligliptin": [
+  "A10BH08"
+ ],
+ "tenidap": [
+  "M01AX23"
+ ],
+ "teniposide": [
+  "L01CB02"
+ ],
+ "tenitramine": [
+  "C01DA38"
+ ],
+ "tenofovir alafenamide": [
+  "J05AF13"
+ ],
+ "tenofovir disoproxil": [
+  "J05AF07"
+ ],
+ "tenofovir disoproxil and emtricitabine": [
+  "J05AR03"
+ ],
+ "tenonitrozole": [
+  "P01AX08"
+ ],
+ "tenoxicam": [
+  "M01AC02"
+ ],
+ "teplizumab": [
+  "A10XX01"
+ ],
+ "tepotinib": [
+  "L01EX21"
+ ],
+ "teprenone": [
+  "A02BX15"
+ ],
+ "teprotumumab": [
+  "L04AG13"
+ ],
+ "terazosin": [
+  "G04CA03"
+ ],
+ "terbinafine": [
+  "D01AE15",
+  "D01BA02"
+ ],
+ "terbutaline": [
+  "R03AC03",
+  "R03CC03"
+ ],
+ "terbutaline, combinations": [
+  "R03CC53"
+ ],
+ "terconazole": [
+  "G01AG02"
+ ],
+ "terfenadine": [
+  "R06AX12"
+ ],
+ "terguride": [
+  "G02CB06"
+ ],
+ "teriflunomide": [
+  "L04AK02"
+ ],
+ "teriparatide": [
+  "H05AA02"
+ ],
+ "terizidone": [
+  "J04AK03"
+ ],
+ "terlipressin": [
+  "H01BA04"
+ ],
+ "terodiline": [
+  "G04BD05"
+ ],
+ "tertatolol": [
+  "C07AA16"
+ ],
+ "tesamorelin": [
+  "H01AC06"
+ ],
+ "testosterone": [
+  "G03BA03"
+ ],
+ "testosterone and estrogen": [
+  "G03EA02"
+ ],
+ "tetanus antitoxin": [
+  "J06AA02"
+ ],
+ "tetanus immunoglobulin": [
+  "J06BB02"
+ ],
+ "tetanus toxoid": [
+  "J07AM01"
+ ],
+ "tetanus toxoid, combinations with diphtheria toxoid": [
+  "J07AM51"
+ ],
+ "tetanus toxoid, combinations with tetanus immunoglobulin": [
+  "J07AM52"
+ ],
+ "tetrabenazine": [
+  "N07XX06"
+ ],
+ "tetracaine": [
+  "C05AD02",
+  "D04AB06",
+  "N01BA03",
+  "S01HA03"
+ ],
+ "tetracaine, combinations": [
+  "N01BA53"
+ ],
+ "tetracosactide": [
+  "H01AA02"
+ ],
+ "tetracycline": [
+  "A01AB13",
+  "D06AA04",
+  "J01AA07",
+  "S01AA09",
+  "S02AA08",
+  "S03AA02"
+ ],
+ "tetracycline and nystatin": [
+  "J01RA19"
+ ],
+ "tetracycline and oleandomycin": [
+  "J01RA08"
+ ],
+ "tetragalacturonic acid hydroxymethylester": [
+  "B02BC03"
+ ],
+ "tetramethrin": [
+  "P03BA04"
+ ],
+ "tetramethylglycoluril": [
+  "N06BX21"
+ ],
+ "tetrazepam": [
+  "M03BX07"
+ ],
+ "tetryzoline": [
+  "R01AA06",
+  "R01AB03",
+  "S01GA02"
+ ],
+ "tetryzoline, combinations": [
+  "S01GA52"
+ ],
+ "textiles": [
+  "V01AA09"
+ ],
+ "tezepelumab": [
+  "R03DX11"
+ ],
+ "thalidomide": [
+  "L04AX02"
+ ],
+ "thallium (201tl) chloride": [
+  "V09GX01"
+ ],
+ "thebacon": [
+  "R05DA10"
+ ],
+ "thenalidine": [
+  "D04AA03",
+  "R06AX03"
+ ],
+ "thenalidine, combinations": [
+  "R06AX53"
+ ],
+ "theobromine": [
+  "C03BD01",
+  "R03DA07"
+ ],
+ "theobromine, combinations": [
+  "R03DA57"
+ ],
+ "theodrenaline": [
+  "C01CA23"
+ ],
+ "theophylline": [
+  "R03DA04"
+ ],
+ "theophylline and adrenergics": [
+  "R03DB04"
+ ],
+ "theophylline, combinations excl. psycholeptics": [
+  "R03DA54"
+ ],
+ "theophylline, combinations with psycholeptics": [
+  "R03DA74"
+ ],
+ "thiamazole": [
+  "H03BB02"
+ ],
+ "thiamazole, combinations": [
+  "H03BB52"
+ ],
+ "thiamine (vit b1)": [
+  "A11DA01"
+ ],
+ "thiamphenicol": [
+  "J01BA02"
+ ],
+ "thiamphenicol, combinations": [
+  "J01BA52"
+ ],
+ "thiazinam": [
+  "R06AD06"
+ ],
+ "thiethylperazine": [
+  "R06AD03"
+ ],
+ "thioacetazone": [
+  "J04AK07"
+ ],
+ "thioacetazone and isoniazid": [
+  "J04AM04"
+ ],
+ "thiocolchicoside": [
+  "M03BX05"
+ ],
+ "thiocolchicoside, combinations": [
+  "M03BX55"
+ ],
+ "thioctic acid": [
+  "A16AX01"
+ ],
+ "thiomersal": [
+  "D08AK06"
+ ],
+ "thiopental": [
+  "N01AF03",
+  "N05CA19"
+ ],
+ "thiopropazate": [
+  "N05AB05"
+ ],
+ "thioproperazine": [
+  "N05AB08"
+ ],
+ "thioridazine": [
+  "N05AC02"
+ ],
+ "thiosulfate": [
+  "V03AB06"
+ ],
+ "thiotepa": [
+  "L01AC01"
+ ],
+ "thiram": [
+  "P03AA05"
+ ],
+ "thonzylamine": [
+  "D04AA01",
+  "R01AC06",
+  "R06AC06"
+ ],
+ "thrombin": [
+  "B02BC06",
+  "B02BD30"
+ ],
+ "thrombocytes": [
+  "B05AX02"
+ ],
+ "thymopentin": [
+  "L03AX09"
+ ],
+ "thyroid gland preparations": [
+  "H03AA05"
+ ],
+ "thyrotropin": [
+  "V04CJ01"
+ ],
+ "thyrotropin alfa": [
+  "H01AB01"
+ ],
+ "tiabendazole": [
+  "D01AC06",
+  "P02CA02"
+ ],
+ "tiadenol": [
+  "C10AX03"
+ ],
+ "tiagabine": [
+  "N03AG06"
+ ],
+ "tianeptine": [
+  "N06AX14"
+ ],
+ "tiapride": [
+  "N05AL03"
+ ],
+ "tiaprofenic acid": [
+  "M01AE11"
+ ],
+ "tiazofurine": [
+  "L01XX18"
+ ],
+ "tiazotic acid": [
+  "C01EB23"
+ ],
+ "tibezonium iodide": [
+  "A01AB15"
+ ],
+ "tibolone": [
+  "G03CX01"
+ ],
+ "ticagrelor": [
+  "B01AC24"
+ ],
+ "ticarcillin": [
+  "J01CA13"
+ ],
+ "ticarcillin and beta-lactamase inhibitor": [
+  "J01CR03"
+ ],
+ "ticlatone": [
+  "D01AE08"
+ ],
+ "ticlopidine": [
+  "B01AC05"
+ ],
+ "tidiacic arginine": [
+  "A05BA07"
+ ],
+ "tiemonium iodide": [
+  "A03AB17"
+ ],
+ "tiemonium iodide and analgesics": [
+  "A03DA07"
+ ],
+ "tienilic acid": [
+  "C03CC02"
+ ],
+ "tigecycline": [
+  "J01AA12"
+ ],
+ "tilactase": [
+  "A09AA04"
+ ],
+ "tilbroquinol": [
+  "P01AA05"
+ ],
+ "tilbroquinol and tiliquinol": [
+  "P01AA30"
+ ],
+ "tildrakizumab": [
+  "L04AC17"
+ ],
+ "tilidine": [
+  "N02AX01"
+ ],
+ "tilidine and naloxone": [
+  "N02AX51"
+ ],
+ "tilorone": [
+  "J05AX19"
+ ],
+ "tiludronic acid": [
+  "M05BA05"
+ ],
+ "timepidium bromide": [
+  "A03AB19"
+ ],
+ "timolol": [
+  "C07AA06",
+  "S01ED01"
+ ],
+ "timolol and thiazides": [
+  "C07BA06"
+ ],
+ "timolol, combinations": [
+  "S01ED51"
+ ],
+ "timolol, thiazides and other diuretics": [
+  "C07DA06"
+ ],
+ "tinidazole": [
+  "G01AF21",
+  "J01XD02",
+  "P01AB02"
+ ],
+ "tinidazole and diloxanide": [
+  "P01AB53"
+ ],
+ "tinzaparin": [
+  "B01AB10"
+ ],
+ "tiocarlide": [
+  "J04AD02"
+ ],
+ "tioclomarol": [
+  "B01AA11"
+ ],
+ "tioconazole": [
+  "D01AC07",
+  "G01AF08"
+ ],
+ "tioguanine": [
+  "L01BB03"
+ ],
+ "tiomolibdic acid": [
+  "A16AX22"
+ ],
+ "tiopronin": [
+  "G04BX16"
+ ],
+ "tiotixene": [
+  "N05AF04"
+ ],
+ "tiotropium bromide": [
+  "R03BB04"
+ ],
+ "tiotropium bromide, combinations": [
+  "R03BB54"
+ ],
+ "tioxolone": [
+  "D10AB03"
+ ],
+ "tipepidine": [
+  "R05DB24"
+ ],
+ "tipranavir": [
+  "J05AE09"
+ ],
+ "tirabrutinib": [
+  "L01EL06"
+ ],
+ "tiracizine": [
+  "C01EB11"
+ ],
+ "tiratricol": [
+  "D11AX08",
+  "H03AA04"
+ ],
+ "tirbanibulin": [
+  "D06BX03"
+ ],
+ "tirilazad": [
+  "N07XX01"
+ ],
+ "tirofiban": [
+  "B01AC17"
+ ],
+ "tiropramide": [
+  "A03AC05"
+ ],
+ "tirzepatide": [
+  "A10BX16"
+ ],
+ "tisagenlecleucel": [
+  "L01XL04"
+ ],
+ "tislelizumab": [
+  "L01FF09"
+ ],
+ "tisopurine": [
+  "M04AA02"
+ ],
+ "tisotumab vedotin": [
+  "L01FX23"
+ ],
+ "tivozanib": [
+  "L01EK03"
+ ],
+ "tixagevimab and cilgavimab": [
+  "J06BD03"
+ ],
+ "tixocortol": [
+  "A07EA05",
+  "R01AD07"
+ ],
+ "tixocortol, combinations": [
+  "R01AD57"
+ ],
+ "tizanidine": [
+  "M03BX02"
+ ],
+ "tobramycin": [
+  "J01GB01",
+  "S01AA12"
+ ],
+ "tocainide": [
+  "C01BB03"
+ ],
+ "tocilizumab": [
+  "L04AC07"
+ ],
+ "tocofersolan": [
+  "A11HA08"
+ ],
+ "tocopherol (vit e)": [
+  "A11HA03"
+ ],
+ "tofacitinib": [
+  "L04AF01"
+ ],
+ "tofersen": [
+  "N07XX22"
+ ],
+ "tofisopam": [
+  "N05BA23"
+ ],
+ "tolazamide": [
+  "A10BB05"
+ ],
+ "tolazoline": [
+  "C04AB02",
+  "M02AX02"
+ ],
+ "tolbutamide": [
+  "A10BB03",
+  "V04CA01"
+ ],
+ "tolcapone": [
+  "N04BX01"
+ ],
+ "tolciclate": [
+  "D01AE19"
+ ],
+ "tolfenamic acid": [
+  "M01AG02"
+ ],
+ "tolmetin": [
+  "M01AB03",
+  "M02AA21"
+ ],
+ "tolnaftate": [
+  "D01AE18"
+ ],
+ "tolonidine": [
+  "C02AC04"
+ ],
+ "toloxatone": [
+  "N06AG03"
+ ],
+ "tolperisone": [
+  "M02AX06",
+  "M03BX04"
+ ],
+ "tolpropamine": [
+  "D04AA12"
+ ],
+ "tolrestat": [
+  "A10XA01"
+ ],
+ "tolterodine": [
+  "G04BD07"
+ ],
+ "tolvaptan": [
+  "C03XA01"
+ ],
+ "topiramate": [
+  "N03AX11"
+ ],
+ "topotecan": [
+  "L01CE01"
+ ],
+ "torasemide": [
+  "C03CA04"
+ ],
+ "toremifene": [
+  "L02BA02"
+ ],
+ "toripalimab": [
+  "L01FF13"
+ ],
+ "tositumomab/iodine (131i) tositumomab": [
+  "V10XA53"
+ ],
+ "tosufloxacin": [
+  "J01MA22",
+  "S01AE09"
+ ],
+ "tosylchloramide sodium": [
+  "D08AX04"
+ ],
+ "trabectedin": [
+  "L01CX01"
+ ],
+ "trafermin": [
+  "D03AX15"
+ ],
+ "tralokinumab": [
+  "D11AH07"
+ ],
+ "tramadol": [
+  "N02AX02"
+ ],
+ "tramadol and celecoxib": [
+  "N02AJ16"
+ ],
+ "tramadol and dexketoprofen": [
+  "N02AJ14"
+ ],
+ "tramadol and other non-opioid analgesics": [
+  "N02AJ15"
+ ],
+ "tramadol and paracetamol": [
+  "N02AJ13"
+ ],
+ "tramazoline": [
+  "R01AA09"
+ ],
+ "trametinib": [
+  "L01EE01"
+ ],
+ "trandolapril": [
+  "C09AA10"
+ ],
+ "trandolapril and verapamil": [
+  "C09BB10"
+ ],
+ "tranexamic acid": [
+  "B02AA02"
+ ],
+ "tranylcypromine": [
+  "N06AF04"
+ ],
+ "trapidil": [
+  "C01DX11"
+ ],
+ "trastuzumab": [
+  "L01FD01"
+ ],
+ "trastuzumab deruxtecan": [
+  "L01FD04"
+ ],
+ "trastuzumab duocarmazine": [
+  "L01FD05"
+ ],
+ "trastuzumab emtansine": [
+  "L01FD03"
+ ],
+ "travoprost": [
+  "S01EE04"
+ ],
+ "trazodone": [
+  "N06AX05"
+ ],
+ "tree pollen": [
+  "V01AA05"
+ ],
+ "tremelimumab": [
+  "L01FX20"
+ ],
+ "treosulfan": [
+  "L01AB02"
+ ],
+ "trepibutone": [
+  "A03AX09"
+ ],
+ "treprostinil": [
+  "B01AC21"
+ ],
+ "tretinoin": [
+  "D10AD01",
+  "L01XF01"
+ ],
+ "tretinoin, combinations": [
+  "D10AD51"
+ ],
+ "tretoquinol": [
+  "R03AC09",
+  "R03CC09"
+ ],
+ "triamcinolone": [
+  "A01AC01",
+  "C05AA12",
+  "D07AB09",
+  "D07XB02",
+  "H02AB08",
+  "R01AD11",
+  "R03BA06",
+  "S01BA05"
+ ],
+ "triamcinolone and antibiotics": [
+  "D07CB01"
+ ],
+ "triamcinolone and antiinfectives": [
+  "S02CA04"
+ ],
+ "triamcinolone and antiseptics": [
+  "D07BB03"
+ ],
+ "triamterene": [
+  "C03DB02"
+ ],
+ "triaziquone": [
+  "L01AC02"
+ ],
+ "triazolam": [
+  "N05CD05"
+ ],
+ "tribenoside": [
+  "C05AX05",
+  "C05CX01"
+ ],
+ "tribromometacresol": [
+  "D01AE03"
+ ],
+ "trichlormethiazide": [
+  "C03AA06"
+ ],
+ "trichlormethiazide and potassium": [
+  "C03AB06"
+ ],
+ "trichlormethiazide and potassium-sparing agents": [
+  "C03EA02"
+ ],
+ "trichloroethylene": [
+  "N01AB05"
+ ],
+ "triclabendazole": [
+  "P02BX04"
+ ],
+ "triclofos": [
+  "N05CM07"
+ ],
+ "triclosan": [
+  "D08AE04",
+  "D09AA06"
+ ],
+ "tridihexethyl": [
+  "A03AB08"
+ ],
+ "trientine": [
+  "A16AX12"
+ ],
+ "trifarotene": [
+  "D10AD06"
+ ],
+ "trifluoperazine": [
+  "N05AB06"
+ ],
+ "trifluperidol": [
+  "N05AD02"
+ ],
+ "triflupromazine": [
+  "N05AA05"
+ ],
+ "trifluridine": [
+  "S01AD02"
+ ],
+ "trifluridine, combinations": [
+  "L01BC59"
+ ],
+ "triflusal": [
+  "B01AC18"
+ ],
+ "triheptanoin": [
+  "A16AX17"
+ ],
+ "trihexyphenidyl": [
+  "N04AA01"
+ ],
+ "trilaciclib": [
+  "V03AF12"
+ ],
+ "trilostane": [
+  "H02CA01"
+ ],
+ "trimazosin": [
+  "C02CA03"
+ ],
+ "trimebutine": [
+  "A03AA05"
+ ],
+ "trimegestone and estrogen": [
+  "G03FA16",
+  "G03FB11"
+ ],
+ "trimetaphan": [
+  "C02BA01"
+ ],
+ "trimetazidine": [
+  "C01EB15"
+ ],
+ "trimethadione": [
+  "N03AC02"
+ ],
+ "trimethobenzamide": [
+  "R06AA10"
+ ],
+ "trimethoprim": [
+  "J01EA01"
+ ],
+ "trimethyldiphenylpropylamine": [
+  "A03AX30"
+ ],
+ "trimetrexate": [
+  "P01AX07"
+ ],
+ "trimipramine": [
+  "N06AA06"
+ ],
+ "trioxysalen": [
+  "D05AD01",
+  "D05BA01"
+ ],
+ "tripelennamine": [
+  "D04AA04",
+  "R06AC04"
+ ],
+ "triprolidine": [
+  "R06AX07"
+ ],
+ "triptorelin": [
+  "L02AE04"
+ ],
+ "triticum (wheat fibre)": [
+  "A06AC07"
+ ],
+ "tritoqualine": [
+  "R06AX21"
+ ],
+ "trofinetide": [
+  "N07XX24"
+ ],
+ "trofosfamide": [
+  "L01AA07"
+ ],
+ "troglitazone": [
+  "A10BG01"
+ ],
+ "trolamine": [
+  "D03AX12"
+ ],
+ "troleandomycin": [
+  "J01FA08"
+ ],
+ "trolnitrate": [
+  "C01DA09"
+ ],
+ "trolnitrate, combinations": [
+  "C01DA59"
+ ],
+ "tromantadine": [
+  "D06BB02",
+  "J05AC03"
+ ],
+ "trometamol": [
+  "B05BB03",
+  "B05XX02"
+ ],
+ "tropatepine": [
+  "N04AA12"
+ ],
+ "tropenzilone and analgesics": [
+  "A03DA01"
+ ],
+ "tropicamide": [
+  "S01FA06"
+ ],
+ "tropicamide, combinations": [
+  "S01FA56"
+ ],
+ "tropisetron": [
+  "A04AA03"
+ ],
+ "troriluzole": [
+  "N07XX23"
+ ],
+ "trospium": [
+  "G04BD09"
+ ],
+ "trospium and analgesics": [
+  "A03DA06"
+ ],
+ "trovafloxacin": [
+  "J01MA13"
+ ],
+ "troxerutin": [
+  "C05CA04"
+ ],
+ "troxerutin, combinations": [
+  "C05CA54"
+ ],
+ "troxipide": [
+  "A02BX11"
+ ],
+ "trypan blue": [
+  "S01KX02"
+ ],
+ "trypsin": [
+  "B06AA07",
+  "D03BA01"
+ ],
+ "trypsin, combinations": [
+  "M09AB52"
+ ],
+ "tryptophan": [
+  "N06AX02"
+ ],
+ "tuaminoheptane": [
+  "R01AA11",
+  "R01AB08"
+ ],
+ "tuberculin": [
+  "V04CF01"
+ ],
+ "tuberculosis, live attenuated": [
+  "J07AN01"
+ ],
+ "tubocurarine": [
+  "M03AA02"
+ ],
+ "tucatinib": [
+  "L01EH03"
+ ],
+ "tucidinostat": [
+  "L01XH06"
+ ],
+ "tulobuterol": [
+  "R03AC11",
+  "R03CC11"
+ ],
+ "tyloxapol": [
+  "R05CA01"
+ ],
+ "tymazoline": [
+  "R01AA13"
+ ],
+ "typhoid, combinations with paratyphi types": [
+  "J07AP10"
+ ],
+ "typhoid, inactivated, whole cell": [
+  "J07AP02"
+ ],
+ "typhoid, oral, live attenuated": [
+  "J07AP01"
+ ],
+ "typhoid, purified polysaccharide antigen": [
+  "J07AP03"
+ ],
+ "typhoid-hepatitis a": [
+  "J07CA10"
+ ],
+ "typhus exanthematicus, inactivated, whole cell": [
+  "J07AR01"
+ ],
+ "tyropanoic acid": [
+  "V08AC09"
+ ],
+ "tyrothricin": [
+  "D06AX08",
+  "R02AB02",
+  "S01AA05"
+ ],
+ "ubidecarenone": [
+  "C01EB09"
+ ],
+ "ublituximab": [
+  "L04AG14"
+ ],
+ "ubrogepant": [
+  "N02CD04"
+ ],
+ "udenafil": [
+  "G04BE11"
+ ],
+ "ulinastatin": [
+  "B02AB05"
+ ],
+ "ulipristal": [
+  "G03AD02",
+  "G03XB02"
+ ],
+ "ulobetasol": [
+  "D07AC21"
+ ],
+ "umbralisib": [
+  "L01EX25"
+ ],
+ "umeclidinium bromide": [
+  "R03BB07"
+ ],
+ "umifenovir": [
+  "J05AX13"
+ ],
+ "undecylenic acid": [
+  "D01AE04"
+ ],
+ "undecylenic acid, combinations": [
+  "D01AE54"
+ ],
+ "unoprostone": [
+  "S01EE02"
+ ],
+ "upadacitinib": [
+  "L04AF03"
+ ],
+ "uramustine": [
+  "L01AD08"
+ ],
+ "urapidil": [
+  "C02CA06"
+ ],
+ "urate oxidase": [
+  "M04AX01"
+ ],
+ "uridine triacetate": [
+  "A16AX13"
+ ],
+ "urofollitropin": [
+  "G03GA04"
+ ],
+ "urokinase": [
+  "B01AD04"
+ ],
+ "ursodeoxycholic acid": [
+  "A05AA02"
+ ],
+ "ursodoxicoltaurine": [
+  "A05AA05"
+ ],
+ "ustekinumab": [
+  "L04AC05"
+ ],
+ "utidelone": [
+  "L01DC05"
+ ],
+ "vaccinia immunoglobulin": [
+  "J06BB07"
+ ],
+ "vadadustat": [
+  "B03XA08"
+ ],
+ "vaginal ring with progestogen": [
+  "G02BB02"
+ ],
+ "vaginal ring with progestogen and estrogen": [
+  "G02BB01"
+ ],
+ "valaciclovir": [
+  "J05AB11"
+ ],
+ "valbenazine": [
+  "N07XX13"
+ ],
+ "valdecoxib": [
+  "M01AH03"
+ ],
+ "valerianae radix": [
+  "N05CM09"
+ ],
+ "valethamate": [
+  "A03AX14"
+ ],
+ "valganciclovir": [
+  "J05AB14"
+ ],
+ "valnoctamide": [
+  "N05CM13"
+ ],
+ "valoctocogene roxaparvovec": [
+  "B02BD15"
+ ],
+ "valproic acid": [
+  "N03AG01"
+ ],
+ "valpromide": [
+  "N03AG02"
+ ],
+ "valrubicin": [
+  "L01DB09"
+ ],
+ "valsartan": [
+  "C09CA03"
+ ],
+ "valsartan and aliskiren": [
+  "C09DX02"
+ ],
+ "valsartan and amlodipine": [
+  "C09DB01"
+ ],
+ "valsartan and diuretics": [
+  "C09DA03"
+ ],
+ "valsartan and lercanidipine": [
+  "C09DB08"
+ ],
+ "valsartan and nebivolol": [
+  "C09DX05"
+ ],
+ "valsartan and sacubitril": [
+  "C09DX04"
+ ],
+ "valsartan, amlodipine and hydrochlorothiazide": [
+  "C09DX01"
+ ],
+ "vamorolone": [
+  "H02AB18"
+ ],
+ "vancomycin": [
+  "A07AA09",
+  "J01XA01",
+  "S01AA28"
+ ],
+ "vandetanib": [
+  "L01EX04"
+ ],
+ "vapreotide": [
+  "H01CB04"
+ ],
+ "vardenafil": [
+  "G04BE09"
+ ],
+ "varenicline": [
+  "N07BA03",
+  "S01XA28"
+ ],
+ "varicella, live attenuated": [
+  "J07BK01"
+ ],
+ "varicella/zoster immunoglobulin": [
+  "J06BB03"
+ ],
+ "various": [
+  "A01AB11",
+  "A01AD11",
+  "M02AX10",
+  "R01AX10",
+  "R02AA20",
+  "V01AA20"
+ ],
+ "various combinations": [
+  "B03AE10",
+  "D10AX30"
+ ],
+ "vasopressin (argipressin)": [
+  "H01BA01"
+ ],
+ "vecuronium": [
+  "M03AC03"
+ ],
+ "vedolizumab": [
+  "L04AG05"
+ ],
+ "velaglucerase alfa": [
+  "A16AB10"
+ ],
+ "veliparib": [
+  "L01XK05"
+ ],
+ "velmanase alfa": [
+  "A16AB15"
+ ],
+ "vemurafenib": [
+  "L01EC01"
+ ],
+ "venetoclax": [
+  "L01XX52"
+ ],
+ "venlafaxine": [
+  "N06AX16"
+ ],
+ "veralipride": [
+  "N05AL06"
+ ],
+ "verapamil": [
+  "C08DA01"
+ ],
+ "verapamil, combinations": [
+  "C08DA51"
+ ],
+ "veratrum": [
+  "C02KA01"
+ ],
+ "veratrum and diuretics": [
+  "C02LK01"
+ ],
+ "vericiguat": [
+  "C01DX22"
+ ],
+ "vernakalant": [
+  "C01BG11"
+ ],
+ "verteporfin": [
+  "S01LA01"
+ ],
+ "vestronidase alfa": [
+  "A16AB18"
+ ],
+ "vibegron": [
+  "G04BD15"
+ ],
+ "vidarabine": [
+  "J05AB03",
+  "S01AD06"
+ ],
+ "vigabatrin": [
+  "N03AG04"
+ ],
+ "vilanterol and fluticasone furoate": [
+  "R03AK10"
+ ],
+ "vilanterol and umeclidinium bromide": [
+  "R03AL03"
+ ],
+ "vilanterol, umeclidinium bromide and fluticasone furoate": [
+  "R03AL08"
+ ],
+ "vilazodone": [
+  "N06AX24"
+ ],
+ "vildagliptin": [
+  "A10BH02"
+ ],
+ "vilobelimab": [
+  "L04AJ10"
+ ],
+ "viloxazine": [
+  "N06AX09"
+ ],
+ "viltolarsen": [
+  "M09AX12"
+ ],
+ "viminol": [
+  "N02BG05"
+ ],
+ "vinbarbital": [
+  "N05CA09"
+ ],
+ "vinblastine": [
+  "L01CA01"
+ ],
+ "vinburnine": [
+  "C04AX17"
+ ],
+ "vincamine": [
+  "C04AX07"
+ ],
+ "vincristine": [
+  "L01CA02"
+ ],
+ "vindesine": [
+  "L01CA03"
+ ],
+ "vinflunine": [
+  "L01CA05"
+ ],
+ "vinorelbine": [
+  "L01CA04"
+ ],
+ "vinpocetine": [
+  "N06BX18"
+ ],
+ "vintafolide": [
+  "L01CA06"
+ ],
+ "vinyl ether": [
+  "N01AA02"
+ ],
+ "vinylbital": [
+  "N05CA08"
+ ],
+ "virginiamycin": [
+  "D06AX10"
+ ],
+ "vismodegib": [
+  "L01XJ01"
+ ],
+ "visnadine": [
+  "C04AX24"
+ ],
+ "vitamin a concentrates": [
+  "V04CB01"
+ ],
+ "voclosporin": [
+  "L04AD03"
+ ],
+ "voglibose": [
+  "A10BF03"
+ ],
+ "volanesorsen": [
+  "C10AX18"
+ ],
+ "von willebrand factor": [
+  "B02BD10"
+ ],
+ "von willebrand factor and coagulation factor viii in combination": [
+  "B02BD06"
+ ],
+ "vonoprazan": [
+  "A02BC08"
+ ],
+ "vonoprazan and amoxicillin": [
+  "A02BD17"
+ ],
+ "vonoprazan, amoxicillin and clarithromycin": [
+  "A02BD14"
+ ],
+ "vonoprazan, amoxicillin and metronidazole": [
+  "A02BD15"
+ ],
+ "vorapaxar": [
+  "B01AC26"
+ ],
+ "vorasidenib": [
+  "L01XM04"
+ ],
+ "voretigene neparvovec": [
+  "S01XA27"
+ ],
+ "voriconazole": [
+  "J02AC03"
+ ],
+ "vorinostat": [
+  "L01XH01"
+ ],
+ "vorozole": [
+  "L02BG05"
+ ],
+ "vortioxetine": [
+  "N06AX26"
+ ],
+ "vosaroxin": [
+  "L01XX53"
+ ],
+ "vosoritide": [
+  "M05BX07"
+ ],
+ "voxelotor": [
+  "B06AX03"
+ ],
+ "vutrisiran": [
+  "N07XX18"
+ ],
+ "warfarin": [
+  "B01AA03"
+ ],
+ "xaliproden": [
+  "N07XX03"
+ ],
+ "xamoterol": [
+  "C01CX07"
+ ],
+ "xantinol nicotinate": [
+  "C04AD02"
+ ],
+ "xenon": [
+  "N01AX15",
+  "V04CX12"
+ ],
+ "xenon (127xe) gas": [
+  "V09EX02"
+ ],
+ "xenon (133xe) gas": [
+  "V09EX03"
+ ],
+ "xenysalate": [
+  "D11AC09"
+ ],
+ "xibornol": [
+  "J01XX02"
+ ],
+ "ximelagatran": [
+  "B01AE05"
+ ],
+ "xipamide": [
+  "C03BA10"
+ ],
+ "xylometazoline": [
+  "R01AA07",
+  "R01AB06",
+  "S01GA03"
+ ],
+ "xylometazoline, combinations": [
+  "S01GA53"
+ ],
+ "yellow fever, live attenuated": [
+  "J07BL01"
+ ],
+ "yohimbine": [
+  "G04BE04"
+ ],
+ "yttrium (90y) citrate colloid": [
+  "V10AA01"
+ ],
+ "yttrium (90y) ferrihydroxide colloid": [
+  "V10AA02"
+ ],
+ "yttrium (90y) silicate colloid": [
+  "V10AA03"
+ ],
+ "zafirlukast": [
+  "R03DC01"
+ ],
+ "zalcitabine": [
+  "J05AF03"
+ ],
+ "zaleplon": [
+  "N05CF03"
+ ],
+ "zanamivir": [
+  "J05AH01"
+ ],
+ "zanidatamab": [
+  "L01FD07"
+ ],
+ "zanubrutinib": [
+  "L01EL03"
+ ],
+ "zavegepant": [
+  "N02CD08"
+ ],
+ "ziconotide": [
+  "N02BG08"
+ ],
+ "zidovudine": [
+  "J05AF01"
+ ],
+ "zidovudine and lamivudine": [
+  "J05AR01"
+ ],
+ "zidovudine, lamivudine and abacavir": [
+  "J05AR04"
+ ],
+ "zidovudine, lamivudine and nevirapine": [
+  "J05AR05"
+ ],
+ "zilucoplan": [
+  "L04AJ06"
+ ],
+ "zimeldine": [
+  "N06AB02"
+ ],
+ "zinc acetate": [
+  "A16AX05"
+ ],
+ "zinc bandage with supplements": [
+  "D09AB02"
+ ],
+ "zinc bandage without supplements": [
+  "D09AB01"
+ ],
+ "zinc chloride": [
+  "B05XA12"
+ ],
+ "zinc compounds": [
+  "S01AX03"
+ ],
+ "zinc gluconate": [
+  "A12CB02"
+ ],
+ "zinc preparations": [
+  "C05AX04"
+ ],
+ "zinc protein complex": [
+  "A12CB03"
+ ],
+ "zinc sulfate": [
+  "A12CB01",
+  "B05XA18"
+ ],
+ "zipeprol": [
+  "R05DB15"
+ ],
+ "ziprasidone": [
+  "N05AE04"
+ ],
+ "zofenopril": [
+  "C09AA15"
+ ],
+ "zofenopril and diuretics": [
+  "C09BA15"
+ ],
+ "zofenopril and nebivolol": [
+  "C09BX07"
+ ],
+ "zolbetuximab": [
+  "L01FX31"
+ ],
+ "zoledronic acid": [
+  "M05BA08"
+ ],
+ "zoledronic acid, calcium and colecalciferol, sequential": [
+  "M05BB08"
+ ],
+ "zolimidine": [
+  "A02BX10"
+ ],
+ "zolmitriptan": [
+  "N02CC03"
+ ],
+ "zolpidem": [
+  "N05CF02"
+ ],
+ "zomepirac": [
+  "M01AB04"
+ ],
+ "zonisamide": [
+  "N03AX15"
+ ],
+ "zopiclone": [
+  "N05CF01"
+ ],
+ "zorubicin": [
+  "L01DB05"
+ ],
+ "zoster, live attenuated": [
+  "J07BK02"
+ ],
+ "zoster, purified antigen": [
+  "J07BK03"
+ ],
+ "zotepine": [
+  "N05AX11"
+ ],
+ "zucapsaicin": [
+  "M02AB02"
+ ],
+ "zuclopenthixol": [
+  "N05AF05"
+ ],
+ "zuranolone": [
+  "N06AX31"
+ ]
 }

--- a/validation_results/atc_cache.json
+++ b/validation_results/atc_cache.json
@@ -1,0 +1,35 @@
+{
+  "acetyldigitoxin": [
+    "C01AA01"
+  ],
+  "alfuzosin": [
+    "G04CA01"
+  ],
+  "ascorbic acid": [
+    "G01AD03",
+    "A11GA01",
+    "S01XA15"
+  ],
+  "atenolol": [
+    "C07AB03",
+    "C07AB11"
+  ],
+  "belzutifan": [
+    "L01XX74"
+  ],
+  "capmatinib": [
+    "L01EX17"
+  ],
+  "imatinib": [
+    "L01EA01"
+  ],
+  "olaparib": [
+    "L01XK01"
+  ],
+  "pazopanib": [
+    "L01EX03"
+  ],
+  "sorafenib": [
+    "L01EX02"
+  ]
+}


### PR DESCRIPTION
Two related changes to Tier 2 repurposing. The first stops it recommending drugs that are not cancer treatments. The second makes sure that when the filter leaves nothing behind, we say so instead of going quiet.

## The problem

Tier 2 asked one question about each candidate: is this drug approved for anything? It never asked whether the drug was an oncology therapy. Any FDA-approved drug with a recorded gene interaction in DGIdb or OpenTargets could be ranked as a cancer treatment.

Here is what that actually produced in the concordance pilot:

| Mutation | Drugs returned |
| --- | --- |
| ATP1A2 | acetyldigitoxin, deslanoside, digitoxin |
| DPYS | atenolol, dexrazoxane |
| ARSB | ascorbic acid, galsulfase |
| ADRA1A | alfuzosin, doxazosin |

Cardiac glycosides, a beta blocker, vitamin C and two BPH drugs, all shown to cancer patients as ranked treatment candidates. Digitoxin is a narrow therapeutic index drug. This is not an edge case either: the 200 patient TCGA benchmark puts 7.5% of patients on Tier 1 and 92.5% on escalation, so Tier 2 is where most people land.

## The gate

Decisions come from WHO ATC classification via ChEMBL, never a drug list typed out by hand. L01 is antineoplastic agents, L02 is endocrine therapy.

The important design choice is which way it fails. A drug is dropped only when there is positive evidence it belongs to a non-oncology class. Unknown drugs are kept.

I wrote it the other way round first, keeping only what could be proven oncology, and it dropped tamoxifen, sunitinib, bevacizumab, trastuzumab and everolimus. ChEMBL's per drug search answers inconsistently and plenty of biologics carry no ATC code there at all. A filter that takes trastuzumab off a patient's list is worse than the noise it was built to remove, so the logic is inverted. Every absurd case above carries a known non-oncology ATC, so they all still go.

Classification comes from ChEMBL's bulk `atc_class` endpoint, paginated once into a committed cache of 4,841 drugs, 374 of them L01/L02. I tried the per drug search endpoint first and gave up on it: digitoxin resolved to C01AA04 on one attempt and returned nothing on later ones even with retries and backoff, which would have quietly made the whole gate inert. The gate runs with `allow_network=False` so there is no live lookup on the request path, and it is wrapped so it can never fail a case.

Rebuild the cache with `python scripts/build_atc_cache.py`.

## Saying nothing, out loud

The gate creates a state that barely existed before: we found a targetable mutation, and after filtering there is no approved cancer drug for it.

That state used to be invisible. The clinician summary rendered it as "Top candidate drugs: currently being analyzed" and the patient template said "Our AI is searching for existing medicines that could be repurposed for your mutation". Both strings get written after the search has finished. They promise a result that is never coming, and a patient reading that will wait for a follow up that does not exist.

So the pipeline now separates three outcomes rather than two:

* no targetable mutation
* a targetable mutation with no approved cancer therapy matching it
* ranked candidates

The middle one says plainly that the search completed and came up empty, names the drugs that were set aside and why, and points at clinical trials and custom discovery. Silence is only an improvement over digitoxin if it is labelled as silence.

The API reports this as `recommendation_state`, and `custom_drug_reason` returns `no_approved_therapy_found` for these cases instead of the generic `target_gene_available`. A confirmed target with nothing approved against it is exactly the population custom discovery was built for, so it is worth naming.

## Audit trail

New `results.excluded_candidates` column storing what the gate withheld along with its ATC codes.

Until now the only trace of an exclusion was an application log line, which means a filter that removes treatment options from a patient's report left no record in the report. Anyone reviewing a case can now check whether it took out something it should not have. The record is kept even when ranked candidates were still found, because that is when a wrong exclusion is hardest to spot.

Migration 0010, nullable JSON, picked up automatically by the GDPR export since that reflects over table columns.

## On coverage

This will lower reported coverage, and that is the intended outcome.

The old "100% coverage, zero empty outputs" figure was partly an artifact of never filtering. The system could always find some approved drug with a gene interaction, so it never had to report that it had found nothing. Any doc still quoting that number needs revisiting.

## Testing

688 backend tests, 9 new. They pin the exact pilot drugs in both directions: 15 of 15 real oncology drugs kept, 9 of 9 non-oncology dropped, and an unknown drug kept rather than dropped. The rest cover the three summary states, the excluded drug names showing up in the empty summary, and the audit trail surviving through to the API.

The seeded fixture in `test_routes` has a target gene and no candidates, so it now reports `no_approved_therapy_found`. That is the fixture describing itself accurately rather than a behaviour change.

## Not included

Backend only, no frontend changes.

`patient_summary.py` already handled the empty case honestly, so I left it alone.
