### PR TITLE
Reach exon 20 duplications, KIT exon 11 point mutations and IHC loss phrasing

### DIFF
--- a/api/services/oncokb_evidence.py
+++ b/api/services/oncokb_evidence.py
@@ -1589,6 +1589,16 @@ _ALTERATION_ALIASES: dict[str, str] = {
     # carrying deletion evidence (scripts/audit_cnv_reachability.py).
     "amplified": "amplification",
     "deleted": "deletion",
+    # Immunohistochemistry phrasing for loss of protein expression. Reports say
+    # "MLH1 absent" or "mismatch repair deficient" far more often than "loss of
+    # expression", and only the last of those resolved. Matters because dMMR is
+    # a tumour-agnostic pembrolizumab indication. These map to the expression
+    # bucket, so they resolve only for genes that carry one and return nothing
+    # elsewhere, exactly as before.
+    "absent": "lossofexpression",
+    "deficient": "lossofexpression",
+    "ihcloss": "lossofexpression",
+    "lossbyihc": "lossofexpression",
     "homdel": "homozygousdeletion",
     "deepdeletion": "homozygousdeletion",
     # Deliberately NOT aliased to amplification: "gain", "copy number gain".
@@ -2597,6 +2607,42 @@ def _is_range_ins_within(alt_norm_upper: str, residue_range: tuple[int, int]) ->
     return lo <= start <= hi and lo <= end <= hi
 
 
+# In-frame duplication: "A767_V769dup" -> "A767V769DUP", "H773dup" -> "H773DUP".
+# Exon 20 insertions are reported both as insertions and as duplications, and a
+# tandem duplication of residues is an in-frame insertion at the protein level.
+# A767_V769dup is one of the more common EGFR exon 20 insertions and returned
+# nothing, because _RANGE_INS_RE requires a literal INS token.
+#
+# Requiring the DUP token is what keeps this safe. T790M sits inside the same
+# codon span but is an EGFR TKI resistance mutation, not an exon 20 insertion,
+# and it carries no DUP token so it cannot reach this bucket.
+_RANGE_DUP_RE = re.compile(r"^([A-Z])(\d+)(?:([A-Z])(\d+))?DUP$")
+
+# Plain missense: "V559D" -> "V559D".
+_RANGE_MISSENSE_RE = re.compile(r"^[A-Z](\d+)[A-Z]$")
+
+
+def _is_range_dup_within(alt_norm_upper: str, residue_range: tuple[int, int]) -> bool:
+    """True if alt_norm_upper is an in-frame duplication, single residue or a
+    span, falling entirely within the given (lo, hi) range."""
+    m = _RANGE_DUP_RE.match(alt_norm_upper)
+    if not m:
+        return False
+    start = int(m.group(2))
+    end = int(m.group(4)) if m.group(4) else start
+    lo, hi = residue_range
+    return lo <= start <= hi and lo <= end <= hi
+
+
+def _is_missense_within(alt_norm_upper: str, residue_range: tuple[int, int]) -> bool:
+    """True if alt_norm_upper is a single-residue substitution inside the range."""
+    m = _RANGE_MISSENSE_RE.match(alt_norm_upper)
+    if not m:
+        return False
+    lo, hi = residue_range
+    return lo <= int(m.group(1)) <= hi
+
+
 def _is_egfr_exon19_range_del(alt_norm_upper: str) -> bool:
     return _is_range_del_within(alt_norm_upper, _EGFR_EXON19_DEL_RANGE)
 
@@ -2605,12 +2651,33 @@ def _is_kit_exon11_range_del(alt_norm_upper: str) -> bool:
     return _is_range_del_within(alt_norm_upper, _KIT_EXON11_DEL_RANGE)
 
 
+def _is_kit_exon11_range_missense(alt_norm_upper: str) -> bool:
+    """KIT exon 11 point mutations, the imatinib-sensitive GIST genotype.
+
+    Only deletions in this span resolved before, so W557_K558del found evidence
+    while V559D found nothing, even though both are exon 11 juxtamembrane
+    mutations and both are the classic imatinib-responsive class. That is what
+    the EXON11MUT bucket is for.
+
+    Scoped to codons 550-592 exactly as the deletion rule is. KIT's resistance
+    mutations live elsewhere: D816V is exon 17 and stays outside this span, so
+    it cannot be routed into an imatinib-sensitive bucket by this rule.
+    """
+    return _is_missense_within(alt_norm_upper, _KIT_EXON11_DEL_RANGE)
+
+
 def _is_egfr_exon20_range_ins(alt_norm_upper: str) -> bool:
-    return _is_range_ins_within(alt_norm_upper, _EGFR_EXON20_INS_RANGE)
+    return (
+        _is_range_ins_within(alt_norm_upper, _EGFR_EXON20_INS_RANGE)
+        or _is_range_dup_within(alt_norm_upper, _EGFR_EXON20_INS_RANGE)
+    )
 
 
 def _is_erbb2_exon20_range_ins(alt_norm_upper: str) -> bool:
-    return _is_range_ins_within(alt_norm_upper, _ERBB2_EXON20_INS_RANGE)
+    return (
+        _is_range_ins_within(alt_norm_upper, _ERBB2_EXON20_INS_RANGE)
+        or _is_range_dup_within(alt_norm_upper, _ERBB2_EXON20_INS_RANGE)
+    )
 
 
 # CALR exon 9 (UniProt P27797) spans roughly codons 359-417; essentially all
@@ -2711,6 +2778,14 @@ def _lof_bucket_for_gene(gene_upper: str) -> Optional[str]:
 _MET_EXON14_RANGE = (963, 1010)
 
 
+# NOT handled here: bare D1010H/N/Y missense. Those substitutions sit at the
+# exon 14 splice donor and are reported in the literature as causing exon 14
+# skipping, so routing them to EXON14SKIP is tempting and would make three more
+# real variants reachable. It is deliberately not done, because whether a given
+# missense change disrupts splicing is a per-variant curation question and this
+# module does not author curation. It belongs in the evidence table as explicit
+# entries, sourced, not inferred by a matching rule. See the negative test in
+# test_oncokb_evidence.py.
 def _is_met_exon14_splice(alt_norm_upper: str) -> bool:
     if "SPLICE" not in alt_norm_upper:
         return False
@@ -2840,6 +2915,8 @@ def _get_all_drugs_for_variant_internal(
         result = _LEVEL_TABLE.get(("EGFR", "EXON19DEL"), {})
     if not result and gene_upper == "KIT" and _is_kit_exon11_range_del(alt_norm):
         result = _LEVEL_TABLE.get(("KIT", "EXON11DEL"), {})
+    if not result and gene_upper == "KIT" and _is_kit_exon11_range_missense(alt_norm):
+        result = _LEVEL_TABLE.get(("KIT", "EXON11MUT"), {})
     if not result and gene_upper == "EGFR" and _is_egfr_exon20_range_ins(alt_norm):
         result = _LEVEL_TABLE.get(("EGFR", "EXON20INS"), {})
     if not result and gene_upper == "ERBB2" and _is_erbb2_exon20_range_ins(alt_norm):

--- a/api/tests/test_oncokb_evidence.py
+++ b/api/tests/test_oncokb_evidence.py
@@ -140,9 +140,23 @@ class TestGetAllDrugsForVariant:
         """V559D is a real KIT exon 11 point mutation (not a deletion) inside
         the same residue range -- the range-del heuristic must only match
         actual deletions, never point substitutions, since a point mutation's
-        drug sensitivity profile isn't necessarily the same as EXON11DEL's."""
+        drug sensitivity profile isn't necessarily the same as EXON11DEL's.
+
+        This originally asserted V559D returned nothing at all, which enforced
+        that property by returning no evidence for a real imatinib-sensitive
+        GIST driver. V559D now resolves through the EXON11MUT bucket instead,
+        so the original requirement is asserted directly: it must not pick up
+        the deletion bucket's profile. EXON11DEL carries imatinib, regorafenib,
+        ripretinib and sunitinib; EXON11MUT carries imatinib and sunitinib only.
+        """
         drugs = get_all_drugs_for_variant("KIT", "V559D")
-        assert drugs == {}
+        deletion_profile = get_all_drugs_for_variant("KIT", "EXON11DEL") or {}
+        assert drugs, "V559D is an exon 11 driver and should reach evidence"
+        assert drugs != deletion_profile, (
+            "a point mutation must not inherit the deletion bucket's drug profile"
+        )
+        assert drugs == (get_all_drugs_for_variant("KIT", "EXON11MUT") or {})
+        assert "regorafenib" not in {k.lower() for k in drugs}
 
     def test_kit_existing_hotspot_entries_unaffected_by_range_del_fallback(self):
         """D816V and V654A are existing named KIT entries outside/unrelated to
@@ -563,3 +577,73 @@ class TestCopyNumberNotation:
         gap rather than a routing bug, pinned here so it stays visible."""
         for gene in ["PTCH1", "VHL"]:
             assert get_all_drugs_for_variant(gene, "loss"), f"{gene} loss regressed"
+
+
+# ── Notation classes found by the reachability sweep ─────────────────────────
+
+class TestExon20DuplicationNotation:
+    """Exon 20 insertions are reported as duplications about as often as they
+    are reported as insertions. Only the INS form resolved, so A767_V769dup,
+    one of the more common EGFR exon 20 insertions, returned nothing.
+    """
+
+    def test_dup_notation_matches_ins_notation(self):
+        canonical = get_all_drugs_for_variant("EGFR", "D770_N771insSVD") or {}
+        assert canonical
+        for alteration in ["A767_V769dup", "H773dup", "p.Ala767_Val769dup"]:
+            assert (get_all_drugs_for_variant("EGFR", alteration) or {}) == canonical, alteration
+
+    def test_resistance_mutations_in_range_are_not_swept_in(self):
+        """The safety property. T790M and C797S sit inside the exon 20 codon
+        span but are EGFR TKI resistance mutations, not insertions. Requiring
+        the DUP or INS token is what keeps them out."""
+        exon20 = get_all_drugs_for_variant("EGFR", "D770_N771insSVD") or {}
+        for alteration in ["T790M", "C797S", "V774M", "R776H"]:
+            assert (get_all_drugs_for_variant("EGFR", alteration) or {}) != exon20, alteration
+
+    def test_t790m_keeps_its_resistance_annotation(self):
+        levels = {str(v) for v in (get_all_drugs_for_variant("EGFR", "T790M") or {}).values()}
+        assert any(level.startswith("LEVEL_R") for level in levels)
+
+
+class TestKitExon11Missense:
+    """Only deletions in KIT exon 11 resolved, so W557_K558del found evidence
+    while V559D found nothing. Both are juxtamembrane exon 11 mutations and
+    both are the imatinib-sensitive GIST genotype.
+    """
+
+    def test_exon11_point_mutations_resolve(self):
+        canonical = get_all_drugs_for_variant("KIT", "EXON11MUT") or {}
+        assert canonical
+        for alteration in ["V559D", "V559A", "L576P", "W557R"]:
+            assert (get_all_drugs_for_variant("KIT", alteration) or {}) == canonical, alteration
+
+    def test_exon17_resistance_mutations_stay_out(self):
+        """D816V is imatinib-resistant and lives in exon 17, outside the 550-592
+        span. It must not be routed into the imatinib-sensitive bucket."""
+        exon11 = get_all_drugs_for_variant("KIT", "EXON11MUT") or {}
+        for alteration in ["D816V", "D820Y", "N822K"]:
+            assert (get_all_drugs_for_variant("KIT", alteration) or {}) != exon11, alteration
+
+    def test_d816v_keeps_its_resistance_annotation(self):
+        levels = {str(v) for v in (get_all_drugs_for_variant("KIT", "D816V") or {}).values()}
+        assert any(level.startswith("LEVEL_R") for level in levels)
+
+
+class TestExpressionLossNotation:
+    """Pathology reports say "absent" or "mismatch repair deficient" far more
+    often than "loss of expression", and only the last of those resolved. dMMR
+    is a tumour-agnostic pembrolizumab indication.
+    """
+
+    def test_ihc_phrasings_resolve(self):
+        canonical = get_all_drugs_for_variant("MLH1", "loss of expression") or {}
+        assert canonical
+        for alteration in ["absent", "deficient", "IHC loss", "loss by IHC"]:
+            assert (get_all_drugs_for_variant("MLH1", alteration) or {}) == canonical, alteration
+
+    def test_expression_phrasings_do_not_invent_evidence_elsewhere(self):
+        """These map to the expression bucket, so they resolve only for genes
+        that carry one and return nothing for genes that do not."""
+        assert not (get_all_drugs_for_variant("KRAS", "deficient") or {})
+        assert not (get_all_drugs_for_variant("TTN", "absent") or {})


### PR DESCRIPTION
Stacked on #82. Merge that first.

I swept all 335 alteration keys in the evidence table, grouped them by notation shape, and probed the classes the earlier LOF, fusion and copy-number audits did not cover. Most were already reachable, which is a good sign. Three were not.

## EGFR and ERBB2 exon 20 insertions written as duplications

Exon 20 insertions get reported as duplications roughly as often as insertions, and only the INS form resolved.

| Notation | Before | After |
| --- | --- | --- |
| `D770_N771insSVD` | 7 | 7 |
| `A767_V769dup` | 0 | 7 |
| `H773dup` | 0 | 7 |

`A767_V769dup` is one of the more common EGFR exon 20 insertions. Amivantamab and mobocertinib sit behind that bucket.

Requiring an explicit DUP token is what makes this safe. T790M and C797S sit inside the same codon span but are TKI resistance mutations, and they carry no DUP token so they cannot reach the insertion bucket. Asserted as negative controls, along with T790M keeping its LEVEL_R annotations.

## KIT exon 11 point mutations

`W557_K558del` resolved, `V559D` returned nothing, though both are juxtamembrane exon 11 mutations and both are the imatinib-sensitive GIST genotype. Point mutations now route to `EXON11MUT`, the bucket that exists for exactly this.

D816V is exon 17, outside the 550-592 span, so the imatinib-**resistant** genotype cannot be routed into an imatinib-sensitive bucket. Asserted, including that D816V keeps its LEVEL_R1 flags.

### This changes an existing test

A test asserted `V559D` returns nothing. Its stated reason was that a point mutation should not inherit `EXON11DEL`'s drug profile. That reasoning is right and still holds:

* `EXON11DEL` carries imatinib, regorafenib, ripretinib, sunitinib
* `V559D` now resolves through `EXON11MUT` to imatinib and sunitinib only

The test now asserts that property directly, rather than enforcing it by returning no evidence at all for a real driver.

## IHC phrasing for loss of expression

Reports say "absent" or "mismatch repair deficient" far more often than "loss of expression", and only the last resolved. dMMR is a tumour-agnostic pembrolizumab indication. These map to the expression bucket, so they resolve only for genes carrying one and return nothing elsewhere, which is asserted.

## Deliberately not fixed: MET D1010H/N/Y

I implemented this and then reverted it.

Those substitutions sit at the exon 14 splice donor, and routing them to `EXON14SKIP` would make three more real variants reachable with capmatinib and tepotinib behind them. But whether a given missense change disrupts splicing is a per-variant curation question, and this module matches notation rather than authoring curation. I have no source in front of me, only recall, and it is the same thing I have declined to do for DDR2 and the other empty buckets.

It belongs in the table as sourced entries. The existing negative test stays, and the reasoning now sits next to the detector so the next attempt does not have to rediscover it.

## Left alone, lower value

FLT3 ITD written as a bare HGVS duplication (`Y572_V592dup`) or spelled out as "internal tandem duplication" still returns nothing. `FLT3-ITD` and `ITD` both work, which is how it is usually reported. The legacy `delE746_A750` form also still misses.

## Empty buckets found by the sweep

Curation gaps, not routing ones. `TERT PROMOTER`, `MGMT METHYLATION` and `ERBB2 OVEREXPRESSION` all carry a key with nothing in it. ERBB2 OVEREXPRESSION is the notable one, since IHC 3+ is how HER2 status is actually reported clinically.

Adding to the running list alongside DDR2, AXL, CCNE1, FGFR4, MDM2, and the PTCH1/VHL missing DELETION bucket. All need sourced curation.

## Testing

564 backend tests pass, 8 new. Backend only.
