### PR TITLE
Re-land the notation reachability sweep, stranded by a stacked merge

### DIFF
--- a/api/services/oncokb_evidence.py
+++ b/api/services/oncokb_evidence.py
@@ -1589,6 +1589,16 @@ _ALTERATION_ALIASES: dict[str, str] = {
     # carrying deletion evidence (scripts/audit_cnv_reachability.py).
     "amplified": "amplification",
     "deleted": "deletion",
+    # Immunohistochemistry phrasing for loss of protein expression. Reports say
+    # "MLH1 absent" or "mismatch repair deficient" far more often than "loss of
+    # expression", and only the last of those resolved. Matters because dMMR is
+    # a tumour-agnostic pembrolizumab indication. These map to the expression
+    # bucket, so they resolve only for genes that carry one and return nothing
+    # elsewhere, exactly as before.
+    "absent": "lossofexpression",
+    "deficient": "lossofexpression",
+    "ihcloss": "lossofexpression",
+    "lossbyihc": "lossofexpression",
     "homdel": "homozygousdeletion",
     "deepdeletion": "homozygousdeletion",
     # Deliberately NOT aliased to amplification: "gain", "copy number gain".
@@ -2597,6 +2607,42 @@ def _is_range_ins_within(alt_norm_upper: str, residue_range: tuple[int, int]) ->
     return lo <= start <= hi and lo <= end <= hi
 
 
+# In-frame duplication: "A767_V769dup" -> "A767V769DUP", "H773dup" -> "H773DUP".
+# Exon 20 insertions are reported both as insertions and as duplications, and a
+# tandem duplication of residues is an in-frame insertion at the protein level.
+# A767_V769dup is one of the more common EGFR exon 20 insertions and returned
+# nothing, because _RANGE_INS_RE requires a literal INS token.
+#
+# Requiring the DUP token is what keeps this safe. T790M sits inside the same
+# codon span but is an EGFR TKI resistance mutation, not an exon 20 insertion,
+# and it carries no DUP token so it cannot reach this bucket.
+_RANGE_DUP_RE = re.compile(r"^([A-Z])(\d+)(?:([A-Z])(\d+))?DUP$")
+
+# Plain missense: "V559D" -> "V559D".
+_RANGE_MISSENSE_RE = re.compile(r"^[A-Z](\d+)[A-Z]$")
+
+
+def _is_range_dup_within(alt_norm_upper: str, residue_range: tuple[int, int]) -> bool:
+    """True if alt_norm_upper is an in-frame duplication, single residue or a
+    span, falling entirely within the given (lo, hi) range."""
+    m = _RANGE_DUP_RE.match(alt_norm_upper)
+    if not m:
+        return False
+    start = int(m.group(2))
+    end = int(m.group(4)) if m.group(4) else start
+    lo, hi = residue_range
+    return lo <= start <= hi and lo <= end <= hi
+
+
+def _is_missense_within(alt_norm_upper: str, residue_range: tuple[int, int]) -> bool:
+    """True if alt_norm_upper is a single-residue substitution inside the range."""
+    m = _RANGE_MISSENSE_RE.match(alt_norm_upper)
+    if not m:
+        return False
+    lo, hi = residue_range
+    return lo <= int(m.group(1)) <= hi
+
+
 def _is_egfr_exon19_range_del(alt_norm_upper: str) -> bool:
     return _is_range_del_within(alt_norm_upper, _EGFR_EXON19_DEL_RANGE)
 
@@ -2605,12 +2651,33 @@ def _is_kit_exon11_range_del(alt_norm_upper: str) -> bool:
     return _is_range_del_within(alt_norm_upper, _KIT_EXON11_DEL_RANGE)
 
 
+def _is_kit_exon11_range_missense(alt_norm_upper: str) -> bool:
+    """KIT exon 11 point mutations, the imatinib-sensitive GIST genotype.
+
+    Only deletions in this span resolved before, so W557_K558del found evidence
+    while V559D found nothing, even though both are exon 11 juxtamembrane
+    mutations and both are the classic imatinib-responsive class. That is what
+    the EXON11MUT bucket is for.
+
+    Scoped to codons 550-592 exactly as the deletion rule is. KIT's resistance
+    mutations live elsewhere: D816V is exon 17 and stays outside this span, so
+    it cannot be routed into an imatinib-sensitive bucket by this rule.
+    """
+    return _is_missense_within(alt_norm_upper, _KIT_EXON11_DEL_RANGE)
+
+
 def _is_egfr_exon20_range_ins(alt_norm_upper: str) -> bool:
-    return _is_range_ins_within(alt_norm_upper, _EGFR_EXON20_INS_RANGE)
+    return (
+        _is_range_ins_within(alt_norm_upper, _EGFR_EXON20_INS_RANGE)
+        or _is_range_dup_within(alt_norm_upper, _EGFR_EXON20_INS_RANGE)
+    )
 
 
 def _is_erbb2_exon20_range_ins(alt_norm_upper: str) -> bool:
-    return _is_range_ins_within(alt_norm_upper, _ERBB2_EXON20_INS_RANGE)
+    return (
+        _is_range_ins_within(alt_norm_upper, _ERBB2_EXON20_INS_RANGE)
+        or _is_range_dup_within(alt_norm_upper, _ERBB2_EXON20_INS_RANGE)
+    )
 
 
 # CALR exon 9 (UniProt P27797) spans roughly codons 359-417; essentially all
@@ -2711,6 +2778,14 @@ def _lof_bucket_for_gene(gene_upper: str) -> Optional[str]:
 _MET_EXON14_RANGE = (963, 1010)
 
 
+# NOT handled here: bare D1010H/N/Y missense. Those substitutions sit at the
+# exon 14 splice donor and are reported in the literature as causing exon 14
+# skipping, so routing them to EXON14SKIP is tempting and would make three more
+# real variants reachable. It is deliberately not done, because whether a given
+# missense change disrupts splicing is a per-variant curation question and this
+# module does not author curation. It belongs in the evidence table as explicit
+# entries, sourced, not inferred by a matching rule. See the negative test in
+# test_oncokb_evidence.py.
 def _is_met_exon14_splice(alt_norm_upper: str) -> bool:
     if "SPLICE" not in alt_norm_upper:
         return False
@@ -2840,6 +2915,8 @@ def _get_all_drugs_for_variant_internal(
         result = _LEVEL_TABLE.get(("EGFR", "EXON19DEL"), {})
     if not result and gene_upper == "KIT" and _is_kit_exon11_range_del(alt_norm):
         result = _LEVEL_TABLE.get(("KIT", "EXON11DEL"), {})
+    if not result and gene_upper == "KIT" and _is_kit_exon11_range_missense(alt_norm):
+        result = _LEVEL_TABLE.get(("KIT", "EXON11MUT"), {})
     if not result and gene_upper == "EGFR" and _is_egfr_exon20_range_ins(alt_norm):
         result = _LEVEL_TABLE.get(("EGFR", "EXON20INS"), {})
     if not result and gene_upper == "ERBB2" and _is_erbb2_exon20_range_ins(alt_norm):

--- a/api/tests/test_oncokb_evidence.py
+++ b/api/tests/test_oncokb_evidence.py
@@ -140,9 +140,23 @@ class TestGetAllDrugsForVariant:
         """V559D is a real KIT exon 11 point mutation (not a deletion) inside
         the same residue range -- the range-del heuristic must only match
         actual deletions, never point substitutions, since a point mutation's
-        drug sensitivity profile isn't necessarily the same as EXON11DEL's."""
+        drug sensitivity profile isn't necessarily the same as EXON11DEL's.
+
+        This originally asserted V559D returned nothing at all, which enforced
+        that property by returning no evidence for a real imatinib-sensitive
+        GIST driver. V559D now resolves through the EXON11MUT bucket instead,
+        so the original requirement is asserted directly: it must not pick up
+        the deletion bucket's profile. EXON11DEL carries imatinib, regorafenib,
+        ripretinib and sunitinib; EXON11MUT carries imatinib and sunitinib only.
+        """
         drugs = get_all_drugs_for_variant("KIT", "V559D")
-        assert drugs == {}
+        deletion_profile = get_all_drugs_for_variant("KIT", "EXON11DEL") or {}
+        assert drugs, "V559D is an exon 11 driver and should reach evidence"
+        assert drugs != deletion_profile, (
+            "a point mutation must not inherit the deletion bucket's drug profile"
+        )
+        assert drugs == (get_all_drugs_for_variant("KIT", "EXON11MUT") or {})
+        assert "regorafenib" not in {k.lower() for k in drugs}
 
     def test_kit_existing_hotspot_entries_unaffected_by_range_del_fallback(self):
         """D816V and V654A are existing named KIT entries outside/unrelated to
@@ -563,3 +577,73 @@ class TestCopyNumberNotation:
         gap rather than a routing bug, pinned here so it stays visible."""
         for gene in ["PTCH1", "VHL"]:
             assert get_all_drugs_for_variant(gene, "loss"), f"{gene} loss regressed"
+
+
+# ── Notation classes found by the reachability sweep ─────────────────────────
+
+class TestExon20DuplicationNotation:
+    """Exon 20 insertions are reported as duplications about as often as they
+    are reported as insertions. Only the INS form resolved, so A767_V769dup,
+    one of the more common EGFR exon 20 insertions, returned nothing.
+    """
+
+    def test_dup_notation_matches_ins_notation(self):
+        canonical = get_all_drugs_for_variant("EGFR", "D770_N771insSVD") or {}
+        assert canonical
+        for alteration in ["A767_V769dup", "H773dup", "p.Ala767_Val769dup"]:
+            assert (get_all_drugs_for_variant("EGFR", alteration) or {}) == canonical, alteration
+
+    def test_resistance_mutations_in_range_are_not_swept_in(self):
+        """The safety property. T790M and C797S sit inside the exon 20 codon
+        span but are EGFR TKI resistance mutations, not insertions. Requiring
+        the DUP or INS token is what keeps them out."""
+        exon20 = get_all_drugs_for_variant("EGFR", "D770_N771insSVD") or {}
+        for alteration in ["T790M", "C797S", "V774M", "R776H"]:
+            assert (get_all_drugs_for_variant("EGFR", alteration) or {}) != exon20, alteration
+
+    def test_t790m_keeps_its_resistance_annotation(self):
+        levels = {str(v) for v in (get_all_drugs_for_variant("EGFR", "T790M") or {}).values()}
+        assert any(level.startswith("LEVEL_R") for level in levels)
+
+
+class TestKitExon11Missense:
+    """Only deletions in KIT exon 11 resolved, so W557_K558del found evidence
+    while V559D found nothing. Both are juxtamembrane exon 11 mutations and
+    both are the imatinib-sensitive GIST genotype.
+    """
+
+    def test_exon11_point_mutations_resolve(self):
+        canonical = get_all_drugs_for_variant("KIT", "EXON11MUT") or {}
+        assert canonical
+        for alteration in ["V559D", "V559A", "L576P", "W557R"]:
+            assert (get_all_drugs_for_variant("KIT", alteration) or {}) == canonical, alteration
+
+    def test_exon17_resistance_mutations_stay_out(self):
+        """D816V is imatinib-resistant and lives in exon 17, outside the 550-592
+        span. It must not be routed into the imatinib-sensitive bucket."""
+        exon11 = get_all_drugs_for_variant("KIT", "EXON11MUT") or {}
+        for alteration in ["D816V", "D820Y", "N822K"]:
+            assert (get_all_drugs_for_variant("KIT", alteration) or {}) != exon11, alteration
+
+    def test_d816v_keeps_its_resistance_annotation(self):
+        levels = {str(v) for v in (get_all_drugs_for_variant("KIT", "D816V") or {}).values()}
+        assert any(level.startswith("LEVEL_R") for level in levels)
+
+
+class TestExpressionLossNotation:
+    """Pathology reports say "absent" or "mismatch repair deficient" far more
+    often than "loss of expression", and only the last of those resolved. dMMR
+    is a tumour-agnostic pembrolizumab indication.
+    """
+
+    def test_ihc_phrasings_resolve(self):
+        canonical = get_all_drugs_for_variant("MLH1", "loss of expression") or {}
+        assert canonical
+        for alteration in ["absent", "deficient", "IHC loss", "loss by IHC"]:
+            assert (get_all_drugs_for_variant("MLH1", alteration) or {}) == canonical, alteration
+
+    def test_expression_phrasings_do_not_invent_evidence_elsewhere(self):
+        """These map to the expression bucket, so they resolve only for genes
+        that carry one and return nothing for genes that do not."""
+        assert not (get_all_drugs_for_variant("KRAS", "deficient") or {})
+        assert not (get_all_drugs_for_variant("TTN", "absent") or {})


### PR DESCRIPTION
Re-lands the notation sweep from #83.

#83 was stacked on the #82 branch and showed as merged, but #82 had already gone into main by then, so `a29f6c1` landed on the feature branch and never reached main. The exon 20 duplication, KIT exon 11 missense and IHC phrasing fixes are currently absent from main despite #83 reading as merged.

No code changes from what was reviewed in #83. Same two commits, retargeted at main.

Verified missing before opening this: `grep -c _RANGE_DUP_RE` against `origin/main:api/services/oncokb_evidence.py` returns 0.
