### PR TITLE
Resolve gene symbols and drug trade names (HER2 and Herceptin reached no evidence at all)

### DIFF
--- a/api/services/oncokb_evidence.py
+++ b/api/services/oncokb_evidence.py
@@ -1547,6 +1547,89 @@ def ensure_oncokb_table_loaded(min_entries: int = 200) -> int:
 _bootstrap_oncokb_public_table()
 
 
+# Gene symbol aliases, so a report naming a gene the way clinicians name it
+# reaches evidence keyed on the HGNC-approved symbol.
+#
+# WHY: the table keys on approved symbols, and nothing normalised the incoming
+# symbol, so "HER2 Amplification" returned nothing while "ERBB2 Amplification"
+# returned 8 drugs including trastuzumab. HER2 is how HER2 status is written in
+# essentially every breast and gastric pathology report, so this is not an edge
+# case. A sweep of 29 common legacy symbols found 26 completely unreachable
+# (scripts/audit_gene_symbols.py).
+#
+# These are HGNC previous and alias symbols, a naming fact, not a clinical
+# claim. Ambiguous ones are deliberately left out: SNF2 maps to more than one
+# gene, and TEP1 is both a PTEN alias and a distinct gene in its own right, so
+# neither is listed. Keys are stored already normalised, meaning uppercase with
+# hyphens, spaces, dots and slashes removed, so "HER-2", "HER2/neu" and "c-KIT"
+# all arrive here as HER2, HER2NEU and CKIT.
+_GENE_ALIASES: dict[str, str] = {
+    # ERBB family
+    "HER1": "EGFR", "ERBB1": "EGFR",
+    "HER2": "ERBB2", "HER2NEU": "ERBB2", "NEU": "ERBB2", "NGL": "ERBB2",
+    "HER3": "ERBB3", "HER4": "ERBB4",
+    # Receptor tyrosine kinases
+    "CKIT": "KIT", "CD117": "KIT", "SCFR": "KIT",
+    "CMET": "MET", "HGFR": "MET",
+    "FLT3": "FLT3", "CD135": "FLT3",
+    "TRKA": "NTRK1", "TRKB": "NTRK2", "TRKC": "NTRK3",
+    "CD246": "ALK",
+    # RAS/RAF
+    "KRAS2": "KRAS", "CMYC": "MYC",
+    # Tumour suppressors
+    "P53": "TP53",
+    "LKB1": "STK11",
+    "P16": "CDKN2A", "INK4A": "CDKN2A", "CDKN2": "CDKN2A", "MTS1": "CDKN2A",
+    "MMAC1": "PTEN",
+    "BRG1": "SMARCA4",
+    "BAF250A": "ARID1A",
+    "RB": "RB1",
+    # Chromatin / fusion partners
+    "MLL": "KMT2A", "HRX": "KMT2A", "ALL1": "KMT2A",
+    # Immune checkpoint
+    "PDL1": "CD274", "B7H1": "CD274",
+    "PD1": "PDCD1",
+    # Kinases written without their numeric suffix. Bare ABL conventionally
+    # means ABL1; ABL2 is always written out, so this is not ambiguous.
+    "ABL": "ABL1",
+}
+
+
+_table_genes_cache: tuple[int, frozenset[str]] = (-1, frozenset())
+
+
+def _known_table_genes() -> frozenset[str]:
+    """Gene symbols the evidence table currently keys on.
+
+    Recomputed when the table changes size, since load_oncokb_flat_file() can
+    extend it at runtime.
+    """
+    global _table_genes_cache
+    size = len(_LEVEL_TABLE)
+    if _table_genes_cache[0] != size:
+        _table_genes_cache = (size, frozenset(g for (g, _alt) in _LEVEL_TABLE))
+    return _table_genes_cache[1]
+
+
+def _normalise_gene(gene: str) -> str:
+    """Uppercase a gene symbol, then resolve HGNC aliases.
+
+    Handles the punctuation clinicians actually type: HER-2, HER2/neu, c-KIT,
+    K-RAS, PD-L1.
+
+    A symbol that already keys the table is returned untouched, before any
+    punctuation is stripped. Some HGNC-approved symbols do contain a hyphen:
+    the histone genes were renamed in 2021, so H3F3A is now H3-3A. Stripping
+    punctuation unconditionally turned that into H33A and silently broke
+    H3-3A K27M, the defining alteration of diffuse midline glioma.
+    """
+    raw = (gene or "").strip().upper()
+    if raw in _known_table_genes():
+        return raw
+    key = re.sub(r"[\-_ ./]", "", raw)
+    return _GENE_ALIASES.get(key, key)
+
+
 # Aliases so variant strings from VCF INFO fields match table keys
 _ALTERATION_ALIASES: dict[str, str] = {
     # exon 19 deletion various representations
@@ -2468,7 +2551,7 @@ def _apply_cancer_context_override(
     if not context:
         return level_map
 
-    gene_upper = gene.upper()
+    gene_upper = _normalise_gene(gene)
     alt_norm = _normalise_alteration(alteration).upper()
     rule = _CANCER_CONTEXT_OVERRIDES.get((gene_upper, alt_norm, context))
     if not rule:
@@ -2807,7 +2890,7 @@ def lookup_oncokb_level(gene: str, alteration: str, drug_name: str) -> Optional[
     Returns None if no entry exists (neither sensitive nor resistant).
     Returns LEVEL_R1/LEVEL_R2 if the drug is a known resistance marker.
     """
-    gene_upper = gene.upper()
+    gene_upper = _normalise_gene(gene)
     alt_norm = _normalise_alteration(alteration).upper()
     drug_norm = _normalise_drug(drug_name)
 
@@ -2880,7 +2963,7 @@ def _get_all_drugs_for_variant_internal(
     alphamissense_score: Optional[float] = None,
 ) -> tuple[dict[str, str], set[str]]:
     """Return all drug→level mappings and fallback provenance for a variant."""
-    gene_upper = gene.upper()
+    gene_upper = _normalise_gene(gene)
     alt_norm = _normalise_alteration(alteration).upper()
 
     # ── Compound variant handling (e.g. "T790M+C797S") ────────────────────
@@ -2974,7 +3057,7 @@ def get_all_drugs_for_variant_with_metadata(
     return {
         "drug_levels": levels,
         "gene_fallback_drugs": sorted(fallback_drugs),
-        "known_actionable_gene": _has_l1_or_l2_actionable_entry(gene.upper()),
+        "known_actionable_gene": _has_l1_or_l2_actionable_entry(_normalise_gene(gene)),
         "alphamissense_score": _coerce_float(alphamissense_score),
     }
 
@@ -3003,7 +3086,7 @@ def get_all_drugs_for_variant_live(
 
     def _merge_live_with_static_safety(live: dict[str, str]) -> dict[str, str]:
         """Merge policy for live mode: resistance always, static gap fill by allowlist."""
-        gene_upper = gene.upper()
+        gene_upper = _normalise_gene(gene)
         alt_norm = _normalise_alteration(alteration)
         allow_gap_fill = (gene_upper, alt_norm) in _STATIC_GAP_FILL_KEYS
 
@@ -3092,7 +3175,7 @@ def get_all_drugs_for_variant_live_with_metadata(
     token = _get_oncokb_token()
 
     def _merge_live_with_static_safety_and_meta(live: dict[str, str]) -> tuple[dict[str, str], set[str]]:
-        gene_upper = gene.upper()
+        gene_upper = _normalise_gene(gene)
         alt_norm = _normalise_alteration(alteration)
         allow_gap_fill = (gene_upper, alt_norm) in _STATIC_GAP_FILL_KEYS
 
@@ -3173,7 +3256,7 @@ def get_all_drugs_for_variant_live_with_metadata(
         return {
             "drug_levels": merged_levels,
             "gene_fallback_drugs": sorted(fallback_drugs),
-            "known_actionable_gene": _has_l1_or_l2_actionable_entry(gene.upper()),
+            "known_actionable_gene": _has_l1_or_l2_actionable_entry(_normalise_gene(gene)),
             "alphamissense_score": _coerce_float(alphamissense_score),
         }
 
@@ -3181,7 +3264,7 @@ def get_all_drugs_for_variant_live_with_metadata(
     return {
         "drug_levels": merged_levels,
         "gene_fallback_drugs": sorted(fallback_drugs),
-        "known_actionable_gene": _has_l1_or_l2_actionable_entry(gene.upper()),
+        "known_actionable_gene": _has_l1_or_l2_actionable_entry(_normalise_gene(gene)),
         "alphamissense_score": _coerce_float(alphamissense_score),
     }
 
@@ -3254,7 +3337,7 @@ def annotate_compound_resistance(
     if len(alterations) < 2:
         return candidates  # Compound resistance requires ≥ 2 alterations
 
-    gene_upper = gene.upper()
+    gene_upper = _normalise_gene(gene)
     alt_norms = frozenset(_normalise_alteration(a).upper() for a in alterations)
 
     compound_drugs: dict[str, str] = {}

--- a/api/tests/test_oncokb_evidence.py
+++ b/api/tests/test_oncokb_evidence.py
@@ -647,3 +647,74 @@ class TestExpressionLossNotation:
         that carry one and return nothing for genes that do not."""
         assert not (get_all_drugs_for_variant("KRAS", "deficient") or {})
         assert not (get_all_drugs_for_variant("TTN", "absent") or {})
+
+
+# ── Gene symbol aliases ──────────────────────────────────────────────────────
+
+class TestGeneSymbolAliases:
+    """Reports name genes the way clinicians name them, not the way HGNC does.
+
+    Nothing normalised the incoming symbol, so "HER2 Amplification" returned
+    nothing while "ERBB2 Amplification" returned 8 drugs including
+    trastuzumab. HER2 is how HER2 status is written in essentially every
+    breast and gastric pathology report. A sweep of 29 common legacy symbols
+    found 26 completely unreachable.
+    """
+
+    ALIASES = [
+        ("HER2", "ERBB2", "Amplification"),
+        ("HER-2", "ERBB2", "Amplification"),
+        ("HER2/neu", "ERBB2", "Amplification"),
+        ("HER1", "EGFR", "L858R"),
+        ("c-KIT", "KIT", "V559D"),
+        ("CD117", "KIT", "V559D"),
+        ("c-MET", "MET", "exon 14 skipping"),
+        ("PD-L1", "CD274", "Amplification"),
+        ("MLL", "KMT2A", "KMT2A-MLLT3"),
+        ("K-RAS", "KRAS", "G12C"),
+        ("B-RAF", "BRAF", "V600E"),
+        ("p16", "CDKN2A", "homozygous deletion"),
+        ("BRG1", "SMARCA4", "Q729fs"),
+        ("TRKA", "NTRK1", "TPM3-NTRK1"),
+    ]
+
+    def test_legacy_symbols_resolve_to_hgnc_evidence(self):
+        for legacy, hgnc, alteration in self.ALIASES:
+            canonical = get_all_drugs_for_variant(hgnc, alteration) or {}
+            assert canonical, f"{hgnc} {alteration} should have evidence to compare against"
+            assert (get_all_drugs_for_variant(legacy, alteration) or {}) == canonical, (
+                f"{legacy} should resolve as {hgnc}"
+            )
+
+    def test_her2_amplification_reaches_trastuzumab(self):
+        """The single case most likely to appear in real reports."""
+        drugs = {k.lower() for k in (get_all_drugs_for_variant("HER2", "Amplification") or {})}
+        assert "trastuzumab" in drugs
+
+    def test_hyphenated_hgnc_symbols_are_not_mangled(self):
+        """Some approved symbols do contain a hyphen: the histone genes were
+        renamed in 2021, so H3F3A is now H3-3A. Stripping punctuation
+        unconditionally turned that into H33A and broke H3-3A K27M, the
+        defining alteration of diffuse midline glioma."""
+        from services.oncokb_evidence import _normalise_gene
+        assert _normalise_gene("H3-3A") == "H3-3A"
+        assert get_all_drugs_for_variant("H3-3A", "K27M")
+
+    def test_every_table_gene_still_normalises_to_itself(self):
+        """Guards the whole table against a future alias hijacking a real
+        symbol, which is how the H3-3A regression happened."""
+        from services.oncokb_evidence import _LEVEL_TABLE, _normalise_gene
+        for gene in {g for (g, _alt) in _LEVEL_TABLE}:
+            assert _normalise_gene(gene) == gene, f"{gene} no longer resolves to itself"
+
+    def test_unknown_symbol_is_passed_through_not_guessed(self):
+        from services.oncokb_evidence import _normalise_gene
+        assert _normalise_gene("NOTAGENE") == "NOTAGENE"
+        assert not (get_all_drugs_for_variant("NOTAGENE", "V600E") or {})
+
+    def test_alias_resolves_even_where_the_gene_has_no_evidence_yet(self):
+        """LKB1 maps to STK11, which currently carries no entries at all. The
+        symbol mapping is still correct and should hold for when it does, so it
+        is asserted on the normaliser rather than on drug output."""
+        from services.oncokb_evidence import _normalise_gene
+        assert _normalise_gene("LKB1") == "STK11"

--- a/scripts/audit_gene_symbols.py
+++ b/scripts/audit_gene_symbols.py
@@ -1,0 +1,111 @@
+"""Audit: can evidence be reached when a report names a gene the way
+clinicians name it rather than the way HGNC does?
+
+The evidence table keys on HGNC-approved symbols. Nothing normalised the
+incoming symbol, so "HER2 Amplification" returned nothing while "ERBB2
+Amplification" returned 8 drugs including trastuzumab. HER2 is how HER2 status
+is written in essentially every breast and gastric pathology report, so this
+was not an edge case.
+
+Same failure mode as the LOF, fusion and copy-number audits: the evidence is
+curated and correct, the notation reaching it is not, and an unrecognised
+symbol is indistinguishable from a gene with no evidence.
+
+Usage:
+    python scripts/audit_gene_symbols.py
+"""
+import sys
+import os
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(_REPO_ROOT, "api"))
+os.environ.setdefault("ENVIRONMENT", "development")
+os.environ.setdefault("SECRET_KEY", "audit-local-only")
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+
+from services.oncokb_evidence import (  # noqa: E402
+    _GENE_ALIASES,
+    _LEVEL_TABLE,
+    _normalise_gene,
+    get_all_drugs_for_variant,
+)
+
+# (symbol as written in reports, HGNC symbol, representative alteration)
+PROBES = [
+    ("HER2", "ERBB2", "Amplification"),
+    ("HER-2", "ERBB2", "Amplification"),
+    ("HER2/neu", "ERBB2", "Amplification"),
+    ("NEU", "ERBB2", "Amplification"),
+    ("HER1", "EGFR", "L858R"),
+    ("ERBB1", "EGFR", "L858R"),
+    ("HER3", "ERBB3", "Amplification"),
+    ("c-KIT", "KIT", "V559D"),
+    ("CKIT", "KIT", "V559D"),
+    ("CD117", "KIT", "V559D"),
+    ("MLL", "KMT2A", "KMT2A-MLLT3"),
+    ("PD-L1", "CD274", "Amplification"),
+    ("PDL1", "CD274", "Amplification"),
+    ("B7-H1", "CD274", "Amplification"),
+    ("c-MET", "MET", "exon 14 skipping"),
+    ("HGFR", "MET", "exon 14 skipping"),
+    ("BRG1", "SMARCA4", "Q729fs"),
+    ("BAF250A", "ARID1A", "Q1334*"),
+    ("TRKA", "NTRK1", "TPM3-NTRK1"),
+    ("K-RAS", "KRAS", "G12C"),
+    ("B-RAF", "BRAF", "V600E"),
+    ("ABL", "ABL1", "T315I"),
+    ("FLT-3", "FLT3", "ITD"),
+    ("p16", "CDKN2A", "homozygous deletion"),
+    ("INK4A", "CDKN2A", "homozygous deletion"),
+    ("MMAC1", "PTEN", "R130Q"),
+]
+
+
+def main() -> None:
+    print("=" * 76)
+    print("GENE SYMBOL REACHABILITY")
+    print("=" * 76)
+    print()
+
+    unreachable, skipped = [], []
+    for legacy, hgnc, alteration in PROBES:
+        canonical = get_all_drugs_for_variant(hgnc, alteration) or {}
+        if not canonical:
+            skipped.append((legacy, hgnc, alteration))
+            continue
+        got = get_all_drugs_for_variant(legacy, alteration) or {}
+        ok = got == canonical
+        if not ok:
+            unreachable.append((legacy, hgnc, len(canonical)))
+        print("  %s %-10s -> %-8s %-22s canonical=%d got=%d"
+              % ("ok  " if ok else "MISS", legacy, hgnc, alteration,
+                 len(canonical), len(got)))
+
+    print()
+    print("unreachable: %d of %d probed" % (len(unreachable), len(PROBES)))
+    for legacy, hgnc, n in unreachable:
+        print("   %-10s should resolve as %-8s (%d drugs lost)" % (legacy, hgnc, n))
+
+    if skipped:
+        print()
+        print("skipped, the HGNC gene itself has no evidence to compare against:")
+        for legacy, hgnc, alteration in skipped:
+            print("   %-10s (%s %s)" % (legacy, hgnc, alteration))
+
+    # Regression guards. An alias that shadows a real symbol silently redirects
+    # every lookup for it, which is how H3-3A broke: stripping punctuation
+    # turned the approved symbol into H33A. Some HGNC symbols do contain a
+    # hyphen, the histone genes having been renamed in 2021.
+    print()
+    print("=" * 76)
+    print("SAFETY")
+    print("=" * 76)
+    table_genes = {g for (g, _a) in _LEVEL_TABLE}
+    shadowed = [k for k in _GENE_ALIASES if k in table_genes and _GENE_ALIASES[k] != k]
+    drifted = [g for g in table_genes if _normalise_gene(g) != g]
+    print("  alias keys shadowing a real table gene : %s" % (shadowed or "none"))
+    print("  table genes not resolving to themselves: %s" % (drifted or "none"))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Two fixes of the same shape: evidence that was curated and correct but unreachable because nothing normalised the name used to look it up.

## Gene symbols

`HER2 Amplification` returned nothing. `ERBB2 Amplification` returned 8 drugs including trastuzumab.

Same alteration, same patient, different spelling of the gene. HER2 is how HER2 status is written in essentially every breast and gastric pathology report.

A sweep of 26 legacy and colloquial symbols found **every one unreachable**:

`HER2` `HER-2` `HER2/neu` `NEU` `HER1` `ERBB1` `HER3` `c-KIT` `CKIT` `CD117` `MLL` `PD-L1` `PDL1` `B7-H1` `c-MET` `HGFR` `BRG1` `BAF250A` `TRKA` `K-RAS` `B-RAF` `ABL` `FLT-3` `p16` `INK4A` `MMAC1`

## Drug trade names

`lookup_oncokb_level("ERBB2", "Amplification", "Herceptin")` returned `None`. With `"trastuzumab"` it returned `LEVEL_1`.

All 20 trade names probed were unreachable: Herceptin, Enhertu, Tagrisso, Iressa, Tarceva, Gleevec, Glivec, Zelboraf, Tafinlar, Mekinist, Xalkori, Alecensa, Lumakras, Lynparza, Piqray, Sutent, Rybrevant, Tabrecta, Retevmo, Vitrakvi.

This one has a second effect worth noting. TCGA's treatment fields carry trade names, and the concordance benchmark scores our recommendations against them, so an unmapped trade name scores a miss on a case we actually got right. The direction of the error is to **understate** accuracy, not overstate it.

Both now resolve completely: 26 of 26 symbols, 20 of 20 trade names.

## Why these are safe for me to fix

HGNC alias symbols and FDA trade names are naming facts, not clinical claims. That is what separates them from the curation gaps I have been deliberately leaving alone. I am not asserting that a variant is actionable, only that two strings name the same thing.

Ambiguous entries are excluded: `SNF2` maps to more than one gene, and `TEP1` is both a PTEN alias and a distinct gene in its own right.

## A bug I introduced and caught

The gene normaliser first stripped punctuation unconditionally, on the stated assumption that no HGNC symbol contains a hyphen.

Wrong. The histone genes were renamed in 2021, so `H3F3A` is now `H3-3A`. Stripping turned it into `H33A` and silently broke `H3-3A K27M`, the defining alteration of diffuse midline glioma.

Both normalisers now return a name the table already carries **before** applying any alias, so an alias can never shadow a real symbol or generic. Tests assert this for all 111 table genes and every table drug. The collision check that caught it ships in both audit scripts.

## Also found

* `STK11` carries no entries at all, so `LKB1` has nothing to resolve to yet. The alias is correct and asserted on the normaliser rather than on drug output.
* 11 trade name aliases point at generics the table lacks. Harmless, and correct for when those are curated.
* `RET PRKAR1A-RET` and `BRCA2 IVS7+1G>A` remain unreachable for unrelated alteration-notation reasons. Both predate this change.

Adds `scripts/audit_gene_symbols.py` and `scripts/audit_drug_names.py`.

574 backend tests pass, 10 new. Backend only.
