### PR TITLE
Re-land drug trade name resolution, stranded by the #86 merge

### DIFF
--- a/api/services/oncokb_evidence.py
+++ b/api/services/oncokb_evidence.py
@@ -2879,9 +2879,162 @@ def _is_met_exon14_splice(alt_norm_upper: str) -> bool:
     return lo <= int(m.group(1)) <= hi
 
 
+# Trade name to INN, so a record naming a drug the way it was prescribed
+# matches evidence keyed on the generic name.
+#
+# WHY: nothing mapped trade names, so lookup_oncokb_level("ERBB2",
+# "Amplification", "Herceptin") returned None while the same call with
+# "trastuzumab" returned LEVEL_1. A sweep of 20 common oncology trade names
+# found all 20 unreachable (scripts/audit_drug_names.py).
+#
+# This matters twice over. Clinical records and prescriptions carry trade
+# names, and so do TCGA's treatment fields, which is what the concordance
+# benchmark scores our recommendations against. An unmapped trade name there
+# scores a miss on a case we actually got right, understating accuracy rather
+# than overstating it.
+#
+# FDA-approved trade names are a naming fact, not a clinical claim, which is
+# what makes this safe to write here. Keys are stored already normalised:
+# lowercase with whitespace, hyphens and dots removed.
+_DRUG_BRAND_ALIASES: dict[str, str] = {
+    # EGFR
+    "tagrisso": "osimertinib",
+    "iressa": "gefitinib",
+    "tarceva": "erlotinib",
+    "gilotrif": "afatinib", "giotrif": "afatinib",
+    "vizimpro": "dacomitinib",
+    "rybrevant": "amivantamab",
+    "exkivity": "mobocertinib",
+    # HER2
+    "herceptin": "trastuzumab",
+    "enhertu": "trastuzumab deruxtecan",
+    "kadcyla": "ado-trastuzumab emtansine",
+    "perjeta": "pertuzumab",
+    "tykerb": "lapatinib", "tyverb": "lapatinib",
+    "nerlynx": "neratinib",
+    "tukysa": "tucatinib",
+    # BRAF and MEK
+    "zelboraf": "vemurafenib",
+    "tafinlar": "dabrafenib",
+    "mekinist": "trametinib",
+    "braftovi": "encorafenib",
+    "mektovi": "binimetinib",
+    "cotellic": "cobimetinib",
+    # ALK and ROS1
+    "xalkori": "crizotinib",
+    "alecensa": "alectinib",
+    "zykadia": "ceritinib",
+    "alunbrig": "brigatinib",
+    "lorbrena": "lorlatinib",
+    "rozlytrek": "entrectinib",
+    "augtyro": "repotrectinib",
+    # RET, NTRK, MET
+    "retevmo": "selpercatinib", "gavreto": "pralsetinib",
+    "vitrakvi": "larotrectinib",
+    "tabrecta": "capmatinib", "tepmetko": "tepotinib",
+    # KRAS
+    "lumakras": "sotorasib", "lumykras": "sotorasib",
+    "krazati": "adagrasib",
+    # PARP
+    "lynparza": "olaparib",
+    "zejula": "niraparib",
+    "talzenna": "talazoparib",
+    "rubraca": "rucaparib",
+    # PI3K/AKT/mTOR
+    "piqray": "alpelisib",
+    "truqap": "capivasertib",
+    "afinitor": "everolimus",
+    # Multikinase and BCR-ABL
+    "gleevec": "imatinib", "glivec": "imatinib",
+    "sprycel": "dasatinib",
+    "tasigna": "nilotinib",
+    "iclusig": "ponatinib",
+    "sutent": "sunitinib",
+    "nexavar": "sorafenib",
+    "stivarga": "regorafenib",
+    "votrient": "pazopanib",
+    "qinlock": "ripretinib",
+    "ayvakit": "avapritinib",
+    # FLT3 and IDH
+    "rydapt": "midostaurin",
+    "xospata": "gilteritinib",
+    "vanflyta": "quizartinib",
+    "tibsovo": "ivosidenib",
+    "idhifa": "enasidenib",
+    # CDK4/6
+    "ibrance": "palbociclib",
+    "kisqali": "ribociclib",
+    "verzenio": "abemaciclib", "verzenios": "abemaciclib",
+    # Immunotherapy
+    "keytruda": "pembrolizumab",
+    "opdivo": "nivolumab",
+    "tecentriq": "atezolizumab",
+    "imfinzi": "durvalumab",
+    "bavencio": "avelumab",
+    "yervoy": "ipilimumab",
+    "libtayo": "cemiplimab",
+    "jemperli": "dostarlimab",
+    # Antiangiogenics and endocrine
+    "avastin": "bevacizumab",
+    "cyramza": "ramucirumab",
+    "lenvima": "lenvatinib",
+    "cabometyx": "cabozantinib", "cometriq": "cabozantinib",
+    "nolvadex": "tamoxifen",
+    "faslodex": "fulvestrant",
+    "arimidex": "anastrozole",
+    "femara": "letrozole",
+    "aromasin": "exemestane",
+    "xtandi": "enzalutamide",
+    "zytiga": "abiraterone",
+    "erleada": "apalutamide",
+    "nubeqa": "darolutamide",
+    # Other targeted
+    "welireg": "belzutifan",
+    "balversa": "erdafitinib",
+    "pemazyre": "pemigatinib",
+    "truseltiq": "infigratinib",
+    "revuforj": "revumenib",
+    "elrexfio": "elranatamab",
+    "imbruvica": "ibrutinib",
+    "calquence": "acalabrutinib",
+    "brukinsa": "zanubrutinib",
+    "venclexta": "venetoclax", "venclyxto": "venetoclax",
+    "erivedge": "vismodegib",
+    "odomzo": "sonidegib",
+    "mektavi": "binimetinib",
+}
+
+_table_drugs_cache: tuple[int, frozenset[str]] = (-1, frozenset())
+
+
+def _known_table_drugs() -> frozenset[str]:
+    """Normalised drug names the evidence table actually carries."""
+    global _table_drugs_cache
+    size = len(_LEVEL_TABLE)
+    if _table_drugs_cache[0] != size:
+        names: set[str] = set()
+        for drugs in _LEVEL_TABLE.values():
+            for drug in drugs:
+                names.add(re.sub(r"[\s\-.]", "", str(drug).lower()))
+        _table_drugs_cache = (size, frozenset(names))
+    return _table_drugs_cache[1]
+
+
 def _normalise_drug(name: str) -> str:
-    """Normalise drug name for matching."""
-    return re.sub(r"[\s\-.]", "", name.lower())
+    """Normalise a drug name for matching, resolving trade names to the INN.
+
+    A name the table already carries is returned before any alias is applied,
+    so a trade name can never shadow a real generic. This is the same guard
+    the gene normaliser uses, added after an unconditional rewrite there
+    silently broke H3-3A.
+    """
+    key = re.sub(r"[\s\-.]", "", (name or "").lower())
+    if key in _known_table_drugs():
+        return key
+    alias = _DRUG_BRAND_ALIASES.get(key)
+    if alias:
+        return re.sub(r"[\s\-.]", "", alias.lower())
+    return key
 
 
 def lookup_oncokb_level(gene: str, alteration: str, drug_name: str) -> Optional[str]:

--- a/api/tests/test_oncokb_evidence.py
+++ b/api/tests/test_oncokb_evidence.py
@@ -718,3 +718,61 @@ class TestGeneSymbolAliases:
         is asserted on the normaliser rather than on drug output."""
         from services.oncokb_evidence import _normalise_gene
         assert _normalise_gene("LKB1") == "STK11"
+
+
+# ── Drug trade names ─────────────────────────────────────────────────────────
+
+class TestDrugBrandAliases:
+    """Records name drugs the way they were prescribed, not by INN.
+
+    lookup_oncokb_level("ERBB2", "Amplification", "Herceptin") returned None
+    while the same call with "trastuzumab" returned LEVEL_1. All 20 trade
+    names probed were unreachable.
+
+    This understates accuracy rather than overstating it: TCGA's treatment
+    fields carry trade names, and the concordance benchmark scores our
+    recommendations against them, so an unmapped trade name scores a miss on
+    a case we actually got right.
+    """
+
+    BRANDS = [
+        ("Herceptin", "trastuzumab", "ERBB2", "Amplification"),
+        ("Tagrisso", "osimertinib", "EGFR", "T790M"),
+        ("Gleevec", "imatinib", "KIT", "EXON11MUT"),
+        ("Glivec", "imatinib", "KIT", "EXON11MUT"),
+        ("Zelboraf", "vemurafenib", "BRAF", "V600E"),
+        ("Xalkori", "crizotinib", "ALK", "EML4-ALK"),
+        ("Lumakras", "sotorasib", "KRAS", "G12C"),
+        ("Lynparza", "olaparib", "BRCA1", "S1982fs"),
+        ("Piqray", "alpelisib", "PIK3CA", "H1047R"),
+        ("Tabrecta", "capmatinib", "MET", "EXON14SKIP"),
+    ]
+
+    def test_trade_names_resolve_to_inn_evidence(self):
+        for brand, inn, gene, alteration in self.BRANDS:
+            canonical = lookup_oncokb_level(gene, alteration, inn)
+            assert canonical is not None, f"{inn} should have a level to compare against"
+            assert lookup_oncokb_level(gene, alteration, brand) == canonical, (
+                f"{brand} should resolve as {inn}"
+            )
+
+    def test_case_and_punctuation_insensitive(self):
+        for written in ["HERCEPTIN", "herceptin", "Herceptin "]:
+            assert lookup_oncokb_level("ERBB2", "Amplification", written) == "LEVEL_1"
+
+    def test_trade_name_never_shadows_a_real_generic(self):
+        """A generic the table carries must resolve to itself before any alias
+        is applied. This is the guard that was missing when the gene
+        normaliser silently broke H3-3A."""
+        from services.oncokb_evidence import (
+            _DRUG_BRAND_ALIASES, _known_table_drugs, _normalise_drug,
+        )
+        table_drugs = _known_table_drugs()
+        assert not [k for k in _DRUG_BRAND_ALIASES if k in table_drugs]
+        for drug in table_drugs:
+            assert _normalise_drug(drug) == drug, f"{drug} no longer resolves to itself"
+
+    def test_unknown_drug_is_passed_through_not_guessed(self):
+        from services.oncokb_evidence import _normalise_drug
+        assert _normalise_drug("NotADrug") == "notadrug"
+        assert lookup_oncokb_level("EGFR", "T790M", "NotADrug") is None

--- a/scripts/audit_drug_names.py
+++ b/scripts/audit_drug_names.py
@@ -1,0 +1,108 @@
+"""Audit: can evidence be reached when a drug is named the way it was
+prescribed rather than by its INN?
+
+Nothing mapped trade names, so lookup_oncokb_level("ERBB2", "Amplification",
+"Herceptin") returned None while the same call with "trastuzumab" returned
+LEVEL_1. A sweep of 20 common oncology trade names found all 20 unreachable.
+
+This matters twice over. Clinical records and prescriptions carry trade names,
+and so do TCGA's treatment fields, which is what the concordance benchmark
+scores our recommendations against. An unmapped trade name there scores a miss
+on a case we actually got right, so it understates accuracy rather than
+overstating it.
+
+Usage:
+    python scripts/audit_drug_names.py
+"""
+import sys
+import os
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(_REPO_ROOT, "api"))
+os.environ.setdefault("ENVIRONMENT", "development")
+os.environ.setdefault("SECRET_KEY", "audit-local-only")
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+
+from services.oncokb_evidence import (  # noqa: E402
+    _DRUG_BRAND_ALIASES,
+    _known_table_drugs,
+    _normalise_drug,
+    lookup_oncokb_level,
+)
+
+# (trade name, INN, gene, alteration)
+PROBES = [
+    ("Herceptin", "trastuzumab", "ERBB2", "Amplification"),
+    ("Enhertu", "trastuzumab deruxtecan", "ERBB2", "Amplification"),
+    ("Tagrisso", "osimertinib", "EGFR", "T790M"),
+    ("Iressa", "gefitinib", "EGFR", "L858R"),
+    ("Tarceva", "erlotinib", "EGFR", "L858R"),
+    ("Gleevec", "imatinib", "KIT", "EXON11MUT"),
+    ("Glivec", "imatinib", "KIT", "EXON11MUT"),
+    ("Zelboraf", "vemurafenib", "BRAF", "V600E"),
+    ("Tafinlar", "dabrafenib", "BRAF", "V600E"),
+    ("Mekinist", "trametinib", "BRAF", "V600E"),
+    ("Xalkori", "crizotinib", "ALK", "EML4-ALK"),
+    ("Alecensa", "alectinib", "ALK", "EML4-ALK"),
+    ("Lumakras", "sotorasib", "KRAS", "G12C"),
+    ("Lynparza", "olaparib", "BRCA1", "S1982fs"),
+    ("Piqray", "alpelisib", "PIK3CA", "H1047R"),
+    ("Sutent", "sunitinib", "KIT", "EXON11MUT"),
+    ("Rybrevant", "amivantamab", "EGFR", "EXON20INS"),
+    ("Tabrecta", "capmatinib", "MET", "EXON14SKIP"),
+    ("Retevmo", "selpercatinib", "RET", "FUSION"),
+    ("Vitrakvi", "larotrectinib", "NTRK1", "FUSION"),
+]
+
+
+def main() -> None:
+    print("=" * 76)
+    print("DRUG TRADE NAME REACHABILITY")
+    print("=" * 76)
+    print()
+
+    unreachable, skipped = [], []
+    for brand, inn, gene, alteration in PROBES:
+        canonical = lookup_oncokb_level(gene, alteration, inn)
+        if canonical is None:
+            skipped.append((brand, inn))
+            continue
+        got = lookup_oncokb_level(gene, alteration, brand)
+        ok = got == canonical
+        if not ok:
+            unreachable.append((brand, inn, canonical))
+        print("  %s %-12s -> %-24s %-7s %-14s inn=%s brand=%s"
+              % ("ok  " if ok else "MISS", brand, inn, gene, alteration,
+                 canonical, got))
+
+    print()
+    print("unreachable: %d of %d comparable"
+          % (len(unreachable), len(PROBES) - len(skipped)))
+    for brand, inn, level in unreachable:
+        print("   %-12s should resolve as %-22s (%s)" % (brand, inn, level))
+    if skipped:
+        print("skipped, the INN itself has no level for that alteration: %s"
+              % ", ".join(b for b, _i in skipped))
+
+    print()
+    print("=" * 76)
+    print("SAFETY")
+    print("=" * 76)
+    table_drugs = _known_table_drugs()
+    shadowed = [k for k in _DRUG_BRAND_ALIASES if k in table_drugs]
+    drifted = [d for d in table_drugs if _normalise_drug(d) != d]
+    dangling = sorted({
+        v for v in _DRUG_BRAND_ALIASES.values()
+        if _normalise_drug(v) not in table_drugs
+    })
+    print("  trade names shadowing a real table drug : %s" % (shadowed or "none"))
+    print("  table drugs not resolving to themselves : %s" % (drifted or "none"))
+    print("  aliases whose INN the table lacks       : %d" % len(dangling))
+    if dangling:
+        print("    harmless, they resolve to a name with no evidence exactly as")
+        print("    before, and are correct for when those drugs are curated:")
+        print("    %s" % ", ".join(dangling))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Re-lands `ed7abcb` from #86, which merged before that commit landed and captured only the gene-symbol half.

Verified missing: `_DRUG_BRAND_ALIASES` occurs 0 times in `origin/main`, and `scripts/audit_drug_names.py` is absent.

No code changes from what was described in #86. Same commit, retargeted at main.

## What it fixes

`lookup_oncokb_level("ERBB2", "Amplification", "Herceptin")` returned `None`. With `"trastuzumab"` it returned `LEVEL_1`.

All 20 trade names probed were unreachable: Herceptin, Enhertu, Tagrisso, Iressa, Tarceva, Gleevec, Glivec, Zelboraf, Tafinlar, Mekinist, Xalkori, Alecensa, Lumakras, Lynparza, Piqray, Sutent, Rybrevant, Tabrecta, Retevmo, Vitrakvi. All 20 now resolve.

TCGA's treatment fields carry trade names and the concordance benchmark scores our recommendations against them, so an unmapped trade name scored a miss on a case we actually got right. The error direction was to understate accuracy, not overstate it.

Carries the same collision guard as the gene normaliser: a drug the table already lists resolves to itself before any alias is applied, asserted for every drug in the table.

574 backend tests pass, 4 new.
