### PR TITLE
Match cancer context on the histology strings registries actually record

### DIFF
--- a/api/services/oncokb_evidence.py
+++ b/api/services/oncokb_evidence.py
@@ -2469,9 +2469,28 @@ def _normalise_cancer_context(cancer_type: Optional[str]) -> Optional[str]:
     s = str(cancer_type).strip().lower()
     if ("non-small cell lung" in s) or ("nsclc" in s):
         return "NSCLC"
+    # Registries name the histology, not the NSCLC umbrella. TCGA's own strings
+    # are "Lung adenocarcinoma" (LUAD) and "Lung squamous cell carcinoma"
+    # (LUSC), and neither matched, so every EGFR, ALK and KRAS context override
+    # silently failed to fire for the entire lung cohort.
+    #
+    # Small cell is deliberately excluded: SCLC is a separate context with
+    # different treatment, so routing it here would be an actively wrong answer
+    # rather than a missing one. The non-small-cell case has already returned
+    # above, so any "small cell" reaching this line is genuinely SCLC. The test
+    # matches on "small cell" rather than "small cell lung" because word order
+    # varies: "Lung small cell carcinoma" slipped through the narrower guard.
+    if "lung" in s and "small cell" not in s:
+        return "NSCLC"
+    if s in ("luad", "lusc"):
+        return "NSCLC"
     if "breast" in s:
         return "BREAST"
-    if "gastric" in s:
+    # Triple-negative is a receptor subtype of breast cancer, and the string
+    # often arrives without the word "breast" at all.
+    if "tnbc" in s:
+        return "BREAST"
+    if "gastric" in s or "stomach" in s:
         return "GASTRIC"
     if "gastroesophageal" in s or "gastro-esophageal" in s or " gej" in s or s.startswith("gej"):
         return "GEJ"
@@ -2529,7 +2548,9 @@ def _normalise_cancer_context(cancer_type: Optional[str]) -> Optional[str]:
         return "BLADDER"
     if "hepatocellular" in s or (" hcc" in s) or s.startswith("hcc"):
         return "HCC"
-    if "small cell lung" in s or "sclc" in s:
+    # Word order varies between registries: "Small cell lung carcinoma" and
+    # "Lung small cell carcinoma" are the same disease.
+    if "sclc" in s or ("small cell" in s and "lung" in s):
         return "SCLC"
     if "cervical" in s:
         return "CERVICAL"

--- a/api/tests/test_oncokb_evidence.py
+++ b/api/tests/test_oncokb_evidence.py
@@ -776,3 +776,53 @@ class TestDrugBrandAliases:
         from services.oncokb_evidence import _normalise_drug
         assert _normalise_drug("NotADrug") == "notadrug"
         assert lookup_oncokb_level("EGFR", "T790M", "NotADrug") is None
+
+
+# ── Cancer type context ──────────────────────────────────────────────────────
+
+class TestCancerContextNormalisation:
+    """Registries name the histology, not the umbrella term.
+
+    The NSCLC rule matched only "non-small cell lung" and "nsclc", so TCGA's
+    own strings, "Lung adenocarcinoma" (LUAD) and "Lung squamous cell
+    carcinoma" (LUSC), resolved to nothing. Every EGFR, ALK and KRAS context
+    override therefore failed to fire for the whole lung cohort.
+    """
+
+    def test_registry_histology_strings_resolve(self):
+        from services.oncokb_evidence import _normalise_cancer_context as ctx
+        for text, expected in [
+            ("Lung adenocarcinoma", "NSCLC"),
+            ("Lung squamous cell carcinoma", "NSCLC"),
+            ("LUAD", "NSCLC"),
+            ("LUSC", "NSCLC"),
+            ("Stomach adenocarcinoma", "GASTRIC"),
+            ("TNBC", "BREAST"),
+        ]:
+            assert ctx(text) == expected, text
+
+    def test_small_cell_is_never_routed_to_nsclc(self):
+        """The safety property. SCLC is a separate context with different
+        treatment, so mapping it to NSCLC would be an actively wrong answer
+        rather than a missing one. Word order varies between registries, which
+        is how "Lung small cell carcinoma" slipped through a narrower guard
+        matching only "small cell lung"."""
+        from services.oncokb_evidence import _normalise_cancer_context as ctx
+        for text in [
+            "Small cell lung cancer",
+            "Small cell lung carcinoma",
+            "Lung small cell carcinoma",
+            "SCLC",
+        ]:
+            assert ctx(text) == "SCLC", text
+
+    def test_established_contexts_unaffected(self):
+        from services.oncokb_evidence import _normalise_cancer_context as ctx
+        for text, expected in [
+            ("Non-small cell lung cancer", "NSCLC"),
+            ("Colorectal adenocarcinoma", "COLORECTAL"),
+            ("Skin cutaneous melanoma", "MELANOMA"),
+            ("Glioblastoma multiforme", "GLIOMA"),
+            ("Breast invasive carcinoma", "BREAST"),
+        ]:
+            assert ctx(text) == expected, text


### PR DESCRIPTION
The NSCLC context rule matched only `non-small cell lung` and `nsclc`.

TCGA records its lung studies as **"Lung adenocarcinoma"** and **"Lung squamous cell carcinoma"**. Neither resolved, so every EGFR, ALK and KRAS tumour-context override silently failed to fire for the entire lung cohort. Lung is the largest actionable group in the benchmark.

| String | Before | After |
| --- | --- | --- |
| `Lung adenocarcinoma` | None | NSCLC |
| `Lung squamous cell carcinoma` | None | NSCLC |
| `LUAD` / `LUSC` | None | NSCLC |
| `Stomach adenocarcinoma` | None | GASTRIC |
| `TNBC` | None | BREAST |

`Stomach adenocarcinoma` is TCGA's string for gastric and did not match the `gastric` test. `TNBC` often arrives without the word breast in it at all.

## The safety property

Small cell is deliberately kept out of NSCLC. It is a separate context with different treatment, so routing it there would be an **actively wrong** answer rather than a missing one, which is a worse failure than the one being fixed.

My first guard tested for `small cell lung` and let `Lung small cell carcinoma` through to NSCLC. I caught it by probing word order. Both the NSCLC exclusion and the SCLC rule now test for `small cell` and `lung` independently, so word order does not matter, and there is a test asserting all four spellings resolve to SCLC.

## Measured effect: none, and that is worth knowing

I replayed the pinned 142 case cohort with every notation fix from today applied.

**Coverage stayed at 104/142. Zero cases changed tier.**

That cohort is eight genes of plain point mutation notation, with no fusions, no amplifications, no legacy gene symbols and no trade names. It cannot exercise any of the work landed today.

So the benchmark not detecting these fixes is a limitation of the benchmark, not evidence the fixes are inert. It says the cohort does not represent the notation diversity of real submitted data, which is worth fixing separately.

577 backend tests pass, 3 new. Backend only.
