### PR TITLE
Match oncologist drug names carrying a salt suffix (9.0% of label mentions)

### DIFF
--- a/scripts/benchmark_oncologist_concordance.py
+++ b/scripts/benchmark_oncologist_concordance.py
@@ -63,8 +63,43 @@ DRUG_EQUIVALENCE_GROUPS: dict[str, list[str]] = {
 }
 
 
+# Salt and formulation suffixes. TCGA's treatment fields record the dispensed
+# product, so the same drug appears both ways: "doxorubicin" and "doxorubicin
+# hydrochloride", "erlotinib" and "erlotinib hydrochloride". The pipeline emits
+# the INN, so every salted spelling scored as a miss on a case that may well
+# have matched.
+#
+# Measured on the 1,713 label set: 23 of 206 distinct drug strings carry one,
+# covering 419 of 4,664 drug mentions, or 9.0%. For 15 of those 23 the bare
+# form also appears in the same labels, which is what shows this is a recording
+# artifact rather than a real distinction. The salt does not change the
+# OncoKB-level indication.
+#
+# Direction of the bug: it understated concordance. Removing it can only move
+# the score up, so treat any large jump with suspicion and check it against
+# these counts.
+_SALT_SUFFIXES = frozenset({
+    "hydrochloride", "hcl", "disodium", "sodium", "calcium", "sulfate",
+    "sulphate", "tartrate", "mesylate", "maleate", "citrate", "acetate",
+    "phosphate", "succinate", "dihydrate", "monohydrate", "potassium",
+    "besylate", "tosylate", "fumarate", "malate", "lactate", "bromide",
+})
+
+
+def _strip_salt_suffix(value: str) -> str:
+    """Drop a trailing salt or hydrate word, keeping the base drug name.
+
+    Only strips when something is left over, so a drug whose whole name is one
+    of these words is untouched.
+    """
+    words = value.split()
+    while len(words) > 1 and words[-1] in _SALT_SUFFIXES:
+        words = words[:-1]
+    return " ".join(words) if words else value
+
+
 def _normalise_drug_name(name: str) -> str:
-    value = (name or "").strip().lower()
+    value = _strip_salt_suffix((name or "").strip().lower())
     return re.sub(r"[^a-z0-9]+", "", value)
 
 


### PR DESCRIPTION
TCGA's treatment fields record the dispensed product, so the same drug appears both ways **in the same label set**: `doxorubicin` and `doxorubicin hydrochloride`, `erlotinib` and `erlotinib hydrochloride`.

The pipeline emits the INN. The concordance scorer normalised only punctuation. So every salted spelling scored as a miss on a case that may well have matched.

## Measured on the 1,713 label set

| | |
|---|---|
| distinct drug strings carrying a salt suffix | 23 of 206 |
| drug mentions affected | **419 of 4,664 (9.0%)** |
| of those 23, base form also present in same labels | 15 |

That last row is what shows this is a recording artifact rather than a real distinction. The salt does not change the OncoKB-level indication.

## This understated the score, which is why I distrust it

Removing this can only move concordance **up**. That makes it exactly the kind of change worth being suspicious of, so I recorded the counts in the code next to the fix. Any jump larger than the affected fraction is a bug, not a win.

I have inflated a benchmark once already this month by grouping PARP with WEE1 in the NCI-MATCH script, and had to revert it. Same discipline applies here.

Only strips when a base name is left over, so a drug whose entire name is one of these words is untouched. Verified `sodium`, `calcium`, `cisplatin`, `carboplatin` and `fluorouracil` all pass through unchanged.

## Correcting myself

In #86 and #87 I said unmapped trade names were depressing this benchmark.

**That is wrong for this dataset.** All 206 oncologist drug strings are generic INNs, and the brand map rewrites none of them. I checked the label contents only after making the claim, which I should have done first.

The trade name work stands on its own for real submitted reports, where brand names genuinely do arrive. It just has no effect on TCGA concordance.

615 backend tests pass.
