### PR TITLE
fix(worker): map OncoKB levels onto the enum so targetability and resistance work

### DIFF
--- a/api/tests/test_ai_worker_oncokb_levels.py
+++ b/api/tests/test_ai_worker_oncokb_levels.py
@@ -1,0 +1,122 @@
+"""OncoKB level handling in the AI worker.
+
+Three defects lived here at once, and each one silently disabled a safety
+behaviour rather than raising:
+
+  1. `_query_oncokb` returned OncoKB's wire format ("LEVEL_1") straight into
+     `Mutation.oncokb_level`, whose enum stores "1". The assignment is invalid
+     and every downstream comparison against an enum member evaluated False.
+  2. Because of that, the targetability check never fired, so no variant was
+     ever marked targetable from the OncoKB path.
+  3. The resistance check compared `.value` ("R1") against the string
+     "LEVEL_R1", so `resistance_context` was unreachable and `rank_candidates`
+     never learned that the top variant confers resistance.
+
+None of these would surface in the default configuration, because
+`_query_oncokb` returns None with no API token. They only bite once a
+deployment wires up a real OncoKB token, which is exactly when the evidence
+starts mattering.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_API_DIR = Path(__file__).resolve().parents[1]
+if str(_API_DIR) not in sys.path:
+    sys.path.insert(0, str(_API_DIR))
+
+from models.mutation import OncoKBLevel  # noqa: E402
+from workers.ai_worker import _to_oncokb_level  # noqa: E402
+
+
+class TestWireFormatMapping:
+    @pytest.mark.parametrize(
+        "wire, expected",
+        [
+            ("LEVEL_1", OncoKBLevel.level_1),
+            ("LEVEL_2", OncoKBLevel.level_2),
+            ("LEVEL_3A", OncoKBLevel.level_3a),
+            ("LEVEL_3B", OncoKBLevel.level_3b),
+            ("LEVEL_4", OncoKBLevel.level_4),
+            ("LEVEL_R1", OncoKBLevel.r1),
+            ("LEVEL_R2", OncoKBLevel.r2),
+        ],
+    )
+    def test_oncokb_wire_levels_map_onto_the_enum(self, wire, expected):
+        assert _to_oncokb_level(wire) is expected
+
+    def test_bare_enum_values_also_map(self):
+        assert _to_oncokb_level("1") is OncoKBLevel.level_1
+        assert _to_oncokb_level("R1") is OncoKBLevel.r1
+
+    def test_enum_passes_through(self):
+        assert _to_oncokb_level(OncoKBLevel.r2) is OncoKBLevel.r2
+
+    @pytest.mark.parametrize("raw", [None, "", "  ", "LEVEL_9", "garbage", 7])
+    def test_unparseable_levels_become_unknown_not_actionable(self, raw):
+        """An unreadable level must never be mistaken for an actionable one."""
+        result = _to_oncokb_level(raw)
+        assert result is OncoKBLevel.unknown
+        assert result not in (OncoKBLevel.level_1, OncoKBLevel.level_2, OncoKBLevel.level_3a)
+
+
+class TestTargetabilityGate:
+    """The comparison the worker makes to decide `is_targetable`."""
+
+    TARGETABLE = (OncoKBLevel.level_1, OncoKBLevel.level_2, OncoKBLevel.level_3a)
+
+    def test_level_1_from_the_wire_is_targetable(self):
+        # This is the regression: the raw string "LEVEL_1" is not in the tuple,
+        # so before the fix a Level 1 variant was never marked targetable.
+        assert "LEVEL_1" not in self.TARGETABLE
+        assert _to_oncokb_level("LEVEL_1") in self.TARGETABLE
+
+    @pytest.mark.parametrize("wire", ["LEVEL_R1", "LEVEL_R2", "LEVEL_4", "LEVEL_3B"])
+    def test_non_actionable_levels_stay_out_of_the_targetable_set(self, wire):
+        assert _to_oncokb_level(wire) not in self.TARGETABLE
+
+
+class TestResistanceReachesTheRanker:
+    def test_resistance_levels_compare_equal_as_enums(self):
+        for wire in ("LEVEL_R1", "LEVEL_R2"):
+            level = _to_oncokb_level(wire)
+            assert level in (OncoKBLevel.r1, OncoKBLevel.r2)
+
+    def test_the_old_string_comparison_could_never_match(self):
+        """Documents the dead branch so it is not reintroduced."""
+        assert OncoKBLevel.r1.value == "R1"
+        assert OncoKBLevel.r1.value not in ("LEVEL_R1", "LEVEL_R2")
+
+    def test_resistance_context_level_is_rebuilt_in_wire_form(self):
+        """rank_candidates expects LEVEL_R1, so the enum is formatted back."""
+        level = _to_oncokb_level("LEVEL_R1")
+        assert f"LEVEL_{level.value}" == "LEVEL_R1"
+
+
+class TestSensitiveAndResistanceAreBothRead:
+    """`_query_oncokb` used to read only highestSensitiveLevel.
+
+    api/services/oncokb.py already reads both fields; the worker's own inline
+    client did not, so a pure-resistance annotation arrived as "unknown".
+    """
+
+    def test_resistance_only_annotation_is_not_lost(self):
+        payload = {"highestSensitiveLevel": None, "highestResistanceLevel": "LEVEL_R1"}
+        sensitive = payload.get("highestSensitiveLevel")
+        resistance = payload.get("highestResistanceLevel")
+
+        assert _to_oncokb_level(sensitive or resistance) is OncoKBLevel.r1
+        assert _to_oncokb_level(resistance) is OncoKBLevel.r1
+
+    def test_sensitive_wins_for_the_stored_level_but_resistance_is_kept(self):
+        payload = {"highestSensitiveLevel": "LEVEL_1", "highestResistanceLevel": "LEVEL_R1"}
+        sensitive = payload.get("highestSensitiveLevel")
+        resistance = payload.get("highestResistanceLevel")
+
+        # Stored level is the sensitive one, so the variant is still targetable,
+        # while the resistance level survives separately for the ranker.
+        assert _to_oncokb_level(sensitive or resistance) is OncoKBLevel.level_1
+        assert _to_oncokb_level(resistance) is OncoKBLevel.r1

--- a/api/workers/ai_worker.py
+++ b/api/workers/ai_worker.py
@@ -79,16 +79,43 @@ def run_ai_analysis(
                         mutation.classification = MutationClassification.uncertain
 
             # Step 2: OncoKB actionability
+            #
+            # A failed lookup is recorded, not swallowed. Without this, an
+            # unreachable OncoKB (no token, network error, rate limit) produces
+            # a report identical to one where the variant genuinely has no
+            # actionable evidence, and a false negative reads as a true
+            # negative to whoever opens it.
             targetable_mutations = []
+            resistance_by_mutation: dict[int, OncoKBLevel] = {}
+            oncokb_lookup_failures: list[str] = []
             for mutation in mutations:
                 oncokb_data = _query_oncokb(mutation.gene, mutation.hgvs_notation)
-                if oncokb_data:
-                    mutation.oncokb_level = oncokb_data.get("level", OncoKBLevel.unknown)
-                    if mutation.oncokb_level in (
-                        OncoKBLevel.level_1, OncoKBLevel.level_2, OncoKBLevel.level_3a
-                    ):
-                        mutation.is_targetable = True
-                        targetable_mutations.append(mutation)
+                if not oncokb_data:
+                    oncokb_lookup_failures.append(mutation.gene)
+                    continue
+
+                mutation.oncokb_level = oncokb_data.get("level", OncoKBLevel.unknown)
+
+                # Kept separately: a variant can carry a sensitive level for one
+                # drug and a resistance level for another, and oncokb_level only
+                # has room for one of them.
+                resistance = oncokb_data.get("resistance_level")
+                if resistance in (OncoKBLevel.r1, OncoKBLevel.r2):
+                    resistance_by_mutation[id(mutation)] = resistance
+
+                if mutation.oncokb_level in (
+                    OncoKBLevel.level_1, OncoKBLevel.level_2, OncoKBLevel.level_3a
+                ):
+                    mutation.is_targetable = True
+                    targetable_mutations.append(mutation)
+
+            if oncokb_lookup_failures:
+                logger.warning(
+                    "[oncokb] lookup unavailable for %d variant(s): %s; "
+                    "absence of actionable evidence is NOT established for these",
+                    len(oncokb_lookup_failures),
+                    ", ".join(sorted(set(oncokb_lookup_failures))),
+                )
 
             db.commit()
 
@@ -144,15 +171,20 @@ def run_ai_analysis(
                     top_mutation.oncokb_level.value if hasattr(top_mutation, "oncokb_level") else None
                 )
 
+            # Resistance must reach the ranker. Comparing against "LEVEL_R1"
+            # here never matched, because the enum stores "R1", so this was
+            # dead code and rank_candidates was always called with no
+            # resistance context. Compare enum to enum instead.
             resistance_context = None
-            top_level = (
-                top_mutation.oncokb_level.value if getattr(top_mutation, "oncokb_level", None) else None
-            )
-            if top_level in ("LEVEL_R1", "LEVEL_R2"):
+            top_level = getattr(top_mutation, "oncokb_level", None)
+            resistance_level = resistance_by_mutation.get(id(top_mutation))
+            if top_level in (OncoKBLevel.r1, OncoKBLevel.r2):
+                resistance_level = top_level
+            if resistance_level in (OncoKBLevel.r1, OncoKBLevel.r2):
                 resistance_context = {
                     "gene": target_gene,
                     "variant": top_variant,
-                    "level": top_level,
+                    "level": f"LEVEL_{resistance_level.value}",
                 }
 
             # Step 4b: Immunotherapy biomarkers (TMB, MSI-H, HRD, POLE)
@@ -646,13 +678,44 @@ def _query_oncokb(gene: str, hgvs: str | None) -> dict | None:
         )
         resp.raise_for_status()
         data = resp.json()
+        sensitive = data.get("highestSensitiveLevel")
+        resistance = data.get("highestResistanceLevel")
         return {
-            "level": data.get("highestSensitiveLevel", "unknown"),
+            "level": _to_oncokb_level(sensitive or resistance),
+            "sensitive_level": _to_oncokb_level(sensitive),
+            "resistance_level": _to_oncokb_level(resistance),
             "treatments": _extract_oncokb_treatment_names(data.get("treatments") or []),
+            "lookup_ok": True,
         }
     except Exception as exc:
         logger.warning(f"[oncokb] Query failed: {exc}")
         return None
+
+
+def _to_oncokb_level(raw: object) -> "OncoKBLevel":
+    """Map OncoKB's wire format onto the OncoKBLevel enum.
+
+    The API answers with "LEVEL_1" / "LEVEL_R1"; the enum stores "1" / "R1".
+    Assigning the wire string straight onto Mutation.oncokb_level fails, and
+    every downstream comparison against an enum member silently evaluates
+    False, which is how targetability and resistance both stopped working on
+    this path. Anything unrecognised becomes `unknown` rather than raising,
+    because a level we cannot parse must not be read as actionable.
+    """
+    from models.mutation import OncoKBLevel
+
+    if isinstance(raw, OncoKBLevel):
+        return raw
+    text = str(raw or "").strip().upper()
+    if not text:
+        return OncoKBLevel.unknown
+    if text.startswith("LEVEL_"):
+        text = text[len("LEVEL_"):]
+    try:
+        return OncoKBLevel(text)
+    except ValueError:
+        logger.warning("[oncokb] unrecognised level %r; treating as unknown", raw)
+        return OncoKBLevel.unknown
 
 
 def _extract_oncokb_treatment_names(treatments: object) -> list[str]:

--- a/api/workers/ai_worker.py
+++ b/api/workers/ai_worker.py
@@ -21,9 +21,15 @@ import logging
 import asyncio
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 # Allow importing from the ai/ package at repo root
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+if TYPE_CHECKING:
+    # Runtime imports of the DB models stay inside the task body, so the Celery
+    # module can be imported without pulling in SQLAlchemy.
+    from models.mutation import OncoKBLevel
 
 from workers import celery_app
 

--- a/docs/risk_analysis.md
+++ b/docs/risk_analysis.md
@@ -1,30 +1,237 @@
 # Risk Analysis
 
-This is the current technical risk analysis placeholder referenced by the HIPAA checklist.
+**Scope of this document.** OpenOncology's output is a ranked list of cancer
+drugs for a specific patient's variants. The dominant hazard is therefore not
+downtime or data loss, it is a **wrong or absent recommendation that a reader
+believes**. This document covers that hazard class. Infrastructure, PHI and
+vendor risk are in [Security and privacy risk](#7-security-privacy-and-vendor-risk)
+at the end, and in [HIPAA_COMPLIANCE.md](HIPAA_COMPLIANCE.md).
 
-## Scope
+**Status.** Research use only. Every clinical validation gate in
+[REGULATORY_FRAMEWORK.md](REGULATORY_FRAMEWORK.md) section 3 is currently
+unmet, so this analysis describes hazards in a system that must not be used to
+inform treatment. It is written now, before deployment, because several of the
+findings below were live defects discovered by writing it.
+
+**Method.** Every finding is traced to code or to a measured result in this
+repository, and cited by file and line. Nothing here is asserted from clinical
+doctrine. Where a hazard is real but unquantified, it is listed as unquantified
+rather than given an invented likelihood.
+
+---
+
+## 1. Hazard classes
+
+| # | Hazard | Clinical consequence | Worst case |
+|---|---|---|---|
+| H1 | Recommends a drug the variant confers resistance to | Patient receives a therapy predicted to fail; effective options delayed | Direct harm |
+| H2 | Fails to surface an actionable variant that is present | Patient does not receive an available targeted therapy | Direct harm by omission |
+| H3 | A lookup failure is presented as a negative result | Reader concludes "nothing actionable" when nothing was actually checked | Direct harm by omission |
+| H4 | Recommendation served from a stale or unversioned evidence base | Advice reflects superseded actionability | Indirect harm |
+| H5 | Benchmark figures overstate performance | Adoption decisions made on unsupported evidence | Systemic |
+| H6 | Variant calling error upstream of everything | All downstream reasoning is applied to a variant the patient does not have | Direct harm |
+
+H5 is not hypothetical for this project. See section 6.
+
+---
+
+## 2. Findings, verified in code
+
+### F1. Resistance evidence never reached the ranker (H1) — FIXED
+
+`api/workers/ai_worker.py` built a `resistance_context` for `rank_candidates`
+by testing `top_mutation.oncokb_level.value in ("LEVEL_R1", "LEVEL_R2")`. The
+`OncoKBLevel` enum in `api/models/mutation.py:20-28` stores `"R1"` and `"R2"`,
+not `"LEVEL_R1"`. The branch could not be taken. `rank_candidates` was called
+with `resistance_context=None` on every run, so a variant conferring resistance
+never demoted the drug it confers resistance to.
+
+Compounding it, `_query_oncokb` read only `highestSensitiveLevel` from the
+OncoKB response and discarded `highestResistanceLevel`, so a resistance-only
+annotation arrived as `unknown`. `api/services/oncokb.py:48` reads both fields
+correctly; the worker's own inline client did not.
+
+`api/services/oncokb_evidence.py:16-19` states the design intent this violated:
+*"Afatinib is LEVEL_R1 for EGFR T790M, this must be surfaced even if the live
+API is unavailable. The table's resistance entries act as a safety floor, never
+a ceiling."* The floor existed in one code path and not in the one the worker
+used.
+
+Fixed by mapping the wire format onto the enum, comparing enum to enum, and
+carrying the resistance level separately from the stored level so a variant that
+is sensitive for one drug and resistant to another keeps both.
+Regression tests: `api/tests/test_ai_worker_oncokb_levels.py`.
+
+### F2. No variant was ever marked targetable on the OncoKB path (H2) — FIXED
+
+Same root cause. `_query_oncokb` returned the wire string `"LEVEL_1"`, which was
+assigned to `Mutation.oncokb_level` and then tested against enum members. The
+comparison was always False, so `is_targetable` was never set and
+`targetable_mutations` stayed empty, which skips the entire drug repurposing
+step that depends on it.
+
+`OncoKBLevel("LEVEL_1")` raises `ValueError`, so the assignment was also invalid
+against the `SAEnum` column at `api/models/mutation.py:84-86`.
+
+**Why this was invisible:** `_query_oncokb` returns `None` immediately when no
+OncoKB token is configured (`api/workers/ai_worker.py`, token check), which is
+the default. The defect only activates once a deployment configures a real
+token, which is precisely when the evidence starts being relied on. Tests passed
+throughout because no test exercised `_query_oncokb` or `resistance_context`.
+
+### F3. A failed evidence lookup is indistinguishable from no evidence (H3) — PARTIALLY FIXED
+
+When `_query_oncokb` returns `None` because the token is missing, the network
+failed, or the API rate limited, the mutation is skipped and the report is
+assembled without it. Nothing in the output distinguishes *"this variant has no
+actionable evidence"* from *"we could not determine whether it does"*. These are
+clinically opposite statements.
+
+Now logged explicitly with the affected genes and the warning that absence of
+evidence is not established. **Still open:** the distinction is not carried into
+the API response or the report a reader sees. That requires a schema field and
+a UI change, and `web/` is out of scope for this change.
+
+### F4. Evidence-base provenance is not retained or surfaced (H4) — OPEN
+
+`api/services/oncokb_evidence.py:1494-1513` resolves the actionability table
+through one of three paths and records which one only as a log line:
+
+| Path | Meaning |
+|---|---|
+| `fresh_cache` | Cached OncoKB dump, up to `_ONCOKB_CACHE_MAX_AGE_DAYS = 7` days old |
+| `download` | Current OncoKB public dump |
+| `static_fallback` | Hardcoded table in this repo, no version, no date |
+
+The chosen path is never stored as state and never returned to a caller.
+`get_all_drugs_for_variant_live_with_metadata` returns `drug_levels`,
+`gene_fallback_drugs`, `known_actionable_gene` and `alphamissense_score`, and
+nothing about where the evidence came from or how old it is.
+
+This is live, not theoretical: during benchmark runs on 2026-08-13 every OncoKB
+public dump URL returned `401 Unauthorized` and the service fell back to the
+static table on every invocation. Recommendations were produced normally.
+
+**Recommended fix:** retain the bootstrap path and cache timestamp as module
+state, return them in the evidence metadata, and propagate to the API response
+so a report can state which evidence snapshot produced it.
+
+### F5. Concordance benchmark was circular (H5) — FIXED
+
+`scripts/build_concordance_labels.py` derived each patient's biomarker from the
+drug they received, guaranteeing agreement. Detailed in
+[ONCOLOGIST_CONCORDANCE_PLAIN_LANGUAGE.md](ONCOLOGIST_CONCORDANCE_PLAIN_LANGUAGE.md).
+Fixed in PR #93; `scripts/detect_label_circularity.py` gates against
+reintroduction. The 100% figure is retracted.
+
+### F6. Variant calling is unvalidated (H6) — OPEN
+
+Every recommendation is conditioned on the variant call being correct, and no
+accuracy measurement exists. `REGULATORY_FRAMEWORK.md` section 3.1 sets the
+target at sensitivity ≥ 99% and PPV ≥ 95% against orthogonal WGS, status
+"Not completed". Until this is measured, the error rate of the entire pipeline
+is unbounded, because no amount of correct downstream reasoning survives a wrong
+input variant.
+
+---
+
+## 3. What is not yet analysed
+
+Listed explicitly so the gaps are not mistaken for absent risk.
+
+- **No failure-mode quantification.** Nothing measures how often a
+  recommendation is wrong, in either direction. F1 and F2 were found by reading,
+  not by a metric that would have alerted on them.
+- **No harm severity model.** Hazards above are ranked by argument, not by a
+  scored likelihood-times-severity register. `REGULATORY_FRAMEWORK.md` requires
+  one before clinical use.
+- **No human-factors analysis.** How a clinician reads a ranked list, whether
+  rank order is interpreted as confidence, and whether the disclaimers are read
+  at all, are untested.
+- **Custom drug discovery output.** Stage two produces molecule briefs.
+  `REGULATORY_FRAMEWORK.md` section 4 defines safety gates; whether the
+  implemented in-silico panel is sufficient is not assessed here.
+- **LLM-generated patient summaries.** The plain-language summary path is a
+  generative component whose failure modes (fabrication, unwarranted certainty)
+  are not analysed.
+
+---
+
+## 4. Controls currently in place
+
+Verified present, not merely intended:
+
+- Resistance entries merged from the static table as a floor on the live path
+  (`api/services/oncokb_evidence.py`), and now reachable in the worker path too.
+- Resistance markers excluded from primary recommendations in the benchmark
+  paths (level filtering before ranking).
+- Gene symbol alias resolution so a report naming `HER2` reaches `ERBB2`
+  evidence (`api/services/oncokb_evidence.py`; a sweep found 26 of 29 legacy
+  symbols previously unreachable, `scripts/audit_gene_symbols.py`).
+- Drug trade name to INN resolution (`scripts/audit_drug_names.py`).
+- Cancer-context matching on recorded histology.
+- Circularity gate on the concordance answer key
+  (`scripts/detect_label_circularity.py`, exits non-zero).
+- Unparseable OncoKB levels resolve to `unknown` rather than raising or being
+  read as actionable (fail-safe direction).
+
+---
+
+## 5. Open actions, in priority order
+
+| # | Action | Hazard | Blocking clinical use? |
+|---|---|---|---|
+| 1 | Measure variant calling accuracy against a public truth set | H6 | Yes |
+| 2 | Surface evidence provenance and snapshot age to the caller (F4) | H4 | Yes |
+| 3 | Carry lookup-failure state into the API response and report (F3) | H3 | Yes |
+| 4 | Quantify recommendation error rate against a biomarker-driven answer key | H5 | Yes |
+| 5 | Formal risk register with likelihood and severity scoring | all | Yes |
+| 6 | Human-factors review of how the ranked list is read | all | Yes |
+| 7 | Analyse LLM summary failure modes | H5 | Yes |
+
+---
+
+## 6. Note on benchmark-derived risk
+
+The circular concordance benchmark (F5) is the clearest instance of H5 in this
+project's history: a 100% figure reached the preprint abstract, and no test
+could have caught it because the defect was in how the question was posed, not
+in the code that answered it. The lesson generalises. A benchmark that cannot
+fail is a risk control that does not exist, and it is more dangerous than no
+benchmark because it displaces one.
+
+Any future validation result should be accompanied by an answer to "what result
+would have falsified this?" before the number is quoted.
+
+---
+
+## 7. Security, privacy and vendor risk
+
 - API authentication and authorization boundaries
 - PHI data flows (upload, storage, access, deletion)
 - Third-party integrations (Stripe, Keycloak, Resend, external genomic sources)
 - Infrastructure controls (networking, logging, backups, disaster recovery)
 
-## Current Known Risks
-- Inconsistent schema/version drift can break protected workflows and auditability.
-- Missing or weak route-level controls (rate limits and role checks) can increase abuse risk.
-- External dependency failures (OncoKB, Stripe, Keycloak) can impact clinical workflow continuity.
+Known risks: schema and version drift breaking auditability; missing route-level
+rate limits and role checks; external dependency failure. Note that for OncoKB
+specifically, dependency failure is **not** primarily an availability risk, it
+is the wrong-answer risk described in F4.
 
-## Existing Mitigations
-- Structured PHI access logging middleware
-- Keycloak-based JWT auth and role extraction
-- Redis-backed limiter infrastructure available
-- Security scan workflows in CI (dependency + SAST + DAST + image scan)
+Mitigations in place: structured PHI access logging middleware; Keycloak JWT
+auth and role extraction; Redis-backed rate limiter infrastructure; dependency,
+SAST, DAST and image scanning in CI.
 
-## Open Actions
-- Finalize formal risk register with likelihood/impact scoring per control.
-- Add quarterly review schedule and documented owner sign-off.
-- Verify audit log retention and immutability policy in deployment environment.
-- Validate migration drift checks in CI before deployment.
+Open: formal risk register with per-control scoring; audit log retention and
+immutability verification in the deployment environment; migration drift checks
+in CI.
 
-## Review Cadence
-- Baseline: quarterly
-- Triggered review: after major architecture or compliance-impacting changes
+---
+
+## 8. Review cadence
+
+- Baseline: quarterly.
+- Triggered: after any change to the evidence table, the ranking function, the
+  variant calling pipeline, or any benchmark used to support a performance
+  claim.
+- Every finding above must be re-verified before any statement of clinical
+  readiness.


### PR DESCRIPTION
## Summary

Writing a real clinical risk analysis for `docs/risk_analysis.md` turned up three live defects in `api/workers/ai_worker.py`. All three were verified by running the code, not by reading it. All three silently disabled a safety behaviour rather than raising.

## The root cause

OncoKB's API answers with `"LEVEL_1"` and `"LEVEL_R1"`. The `OncoKBLevel` enum in `api/models/mutation.py:20-28` stores `"1"` and `"R1"`.

```
OncoKBLevel("LEVEL_1")  ->  ValueError: 'LEVEL_1' is not a valid OncoKBLevel
"LEVEL_1" in (OncoKBLevel.level_1, ...)  ->  False
OncoKBLevel.r1.value in ("LEVEL_R1", "LEVEL_R2")  ->  False
```

`_query_oncokb` returned the wire string straight into `Mutation.oncokb_level`, so every downstream comparison evaluated False instead of raising.

## What that broke

**1. No variant was ever marked targetable on the OncoKB path.** The `is_targetable` check compared the raw string against enum members, so `targetable_mutations` stayed empty and the entire drug repurposing step that gates on it never ran.

**2. Resistance never reached the ranker.** `resistance_context` was built by testing `oncokb_level.value in ("LEVEL_R1", "LEVEL_R2")`, which cannot match `"R1"`. `rank_candidates` was called with `resistance_context=None` on every run, so a variant conferring resistance never demoted the drug it confers resistance to.

**3. Resistance was not even fetched.** `_query_oncokb` read only `highestSensitiveLevel` and discarded `highestResistanceLevel`, so a resistance-only annotation arrived as `unknown`. `api/services/oncokb.py:48` already reads both fields; the worker's own inline client did not.

`api/services/oncokb_evidence.py:16-19` states the design intent this violated:

> Afatinib is LEVEL_R1 for EGFR T790M, this must be surfaced even if the live API is unavailable. The table's resistance entries act as a safety floor, never a ceiling.

That floor existed in one code path and not in the one the worker used.

## Why nobody noticed

`_query_oncokb` returns `None` immediately when no OncoKB token is configured, which is the default. The defect activates the moment a deployment wires up a real token, which is exactly when the evidence starts being relied on. It is the worst possible profile: correct-looking in the default config, broken in the real one.

No test exercised `_query_oncokb` or `resistance_context`.

## Changes

* `_to_oncokb_level()` maps the wire format onto the enum. Anything unrecognised resolves to `unknown` rather than raising, so an unreadable level fails towards not-actionable.
* Sensitive and resistance levels are read separately and both kept, so a variant that is sensitive for one drug and resistant to another does not lose the resistance half.
* The resistance check compares enum to enum.
* A failed OncoKB lookup is logged with the affected genes and an explicit note that absence of actionable evidence is not established for them. Previously a missing token, network error or rate limit produced a report identical to one where the variant genuinely had nothing actionable. Those are clinically opposite statements.

## docs/risk_analysis.md

Was a 30-line placeholder analysing API auth, PHI flows, Stripe, Keycloak and infrastructure. For a system whose output is "which cancer drug", it contained no clinical risk at all.

Replaced with an analysis of the hazard that actually dominates: a wrong or absent recommendation that a reader believes. Six hazard classes, six findings traced to code by file and line, controls verified as present rather than intended, and open actions ranked by whether they block clinical use.

Two findings are documented rather than fixed here:

* **Lookup-failure state does not reach the API response.** Fixed at the log level only; carrying it to the reader needs a schema field and a UI change, and `web/` is out of scope.
* **Evidence-table provenance is never surfaced.** `oncokb_evidence.py:1494-1513` resolves the actionability table through `fresh_cache` (up to 7 days old), `download`, or `static_fallback` (hardcoded, no version, no date), and records which one only as a log line. It is never retained as state and never returned to a caller. This is live: during benchmark runs on 2026-08-13 every OncoKB public dump URL returned 401 and the service served the static table on every invocation, producing recommendations normally.

## Tests

`pytest tests/ --ignore=tests/test_toxicity.py --ignore=tests/test_adme.py --ignore=tests/test_drug_discovery_scoring.py` from `api/`: **647 passed**, up from 622.

The 25 new tests in `api/tests/test_ai_worker_oncokb_levels.py` cover the wire-format mapping, the targetability gate, the resistance path, and the fail-safe direction for unparseable levels. Two of them document the dead comparisons explicitly so they are not reintroduced.
