### PR TITLE
fix(genomic): stop ingesting rejected calls and collapsed multi-allelic sites

### DIFF
--- a/api/tests/test_vcf_ingestion_safety.py
+++ b/api/tests/test_vcf_ingestion_safety.py
@@ -1,0 +1,208 @@
+"""Safety properties of VCF ingestion in the genomic worker.
+
+Found by running the production parser against the Genome in a Bottle HG002
+benchmark VCF (NIST v4.2.1, GRCh38). Three properties were missing, and each
+failed silently rather than raising:
+
+  1. Multi-allelic sites were not split. ALT "GGTTT,GTTTT" was stored verbatim
+     as one mutation, which matches no evidence record. 46 of 8,000 real GIAB
+     records were affected. If one of the alleles is the actionable one, it is
+     lost. Nothing upstream normalises; there is no bcftools norm step in
+     pipeline/.
+  2. FILTER was unpacked and discarded, so calls the variant caller had
+     explicitly rejected (Mutect2 weak_evidence, strand_bias,
+     panel_of_normals) were ingested exactly like PASS calls and could drive a
+     treatment recommendation.
+  3. No allele fraction was carried through, so a low-VAF deamination artefact
+     and a clonal driver were indistinguishable downstream. That also meant the
+     FFPE detector in services/sample_qc.py could not be applied to anything
+     this parser produced.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+for path in (str(_REPO_ROOT), str(_REPO_ROOT / "api")):
+    if path not in sys.path:
+        sys.path.insert(0, path)
+
+from api.workers.genomic_worker import _parse_and_annotate_vcf  # noqa: E402
+
+_HEADER = "##fileformat=VCFv4.2\n#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tSAMPLE\n"
+_HEADER_NO_SAMPLE = "##fileformat=VCFv4.2\n#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n"
+
+
+def _write(tmp_path: Path, body: str, header: str = _HEADER) -> str:
+    path = tmp_path / "variants.vcf"
+    path.write_text(header + body, encoding="utf-8")
+    return str(path)
+
+
+class TestRejectedCallsAreNotIngested:
+    """A call the caller rejected must not become a recommendation."""
+
+    @pytest.mark.parametrize(
+        "filter_value",
+        ["weak_evidence", "strand_bias", "panel_of_normals", "germline",
+         "strand_bias;panel_of_normals", "LowQual", "base_qual"],
+    )
+    def test_rejected_calls_are_dropped(self, tmp_path, filter_value):
+        vcf = _write(
+            tmp_path,
+            f"7\t55191822\t.\tT\tG\t12\t{filter_value}\tGENE=EGFR;HGVS_C=L858R\n",
+            header=_HEADER_NO_SAMPLE,
+        )
+        assert _parse_and_annotate_vcf(vcf) == []
+
+    @pytest.mark.parametrize("filter_value", ["PASS", "pass", ".", ""])
+    def test_accepted_filters_are_kept(self, tmp_path, filter_value):
+        vcf = _write(
+            tmp_path,
+            f"7\t55191822\t.\tT\tG\t99\t{filter_value}\tGENE=EGFR;HGVS_C=L858R\n",
+            header=_HEADER_NO_SAMPLE,
+        )
+        mutations = _parse_and_annotate_vcf(vcf)
+        assert len(mutations) == 1
+        assert mutations[0]["filter_passed"] is True
+
+    def test_rejected_calls_are_retrievable_when_explicitly_asked_for(self, tmp_path):
+        vcf = _write(
+            tmp_path,
+            "7\t55191822\t.\tT\tG\t12\tweak_evidence\tGENE=EGFR;HGVS_C=L858R\n"
+            "7\t55019278\t.\tG\tA\t99\tPASS\tGENE=EGFR;HGVS_C=G719S\n",
+            header=_HEADER_NO_SAMPLE,
+        )
+        mutations = _parse_and_annotate_vcf(vcf, include_filtered=True)
+        assert len(mutations) == 2
+        rejected = next(m for m in mutations if m["hgvs"] == "L858R")
+        assert rejected["filter_passed"] is False
+        assert rejected["filter_status"] == "weak_evidence"
+
+    def test_the_filter_value_is_always_retained(self, tmp_path):
+        """Whatever the decision, it must be inspectable rather than discarded."""
+        vcf = _write(
+            tmp_path,
+            "7\t55019278\t.\tG\tA\t99\tPASS\tGENE=EGFR\n",
+            header=_HEADER_NO_SAMPLE,
+        )
+        assert _parse_and_annotate_vcf(vcf)[0]["filter_status"] == "PASS"
+
+
+class TestMultiAllelicSitesAreSplit:
+    def test_two_alt_alleles_become_two_mutations(self, tmp_path):
+        vcf = _write(
+            tmp_path,
+            "1\t1735008\t.\tG\tGGTTT,GTTTT\t50\tPASS\tGENE=TESTGENE\n",
+            header=_HEADER_NO_SAMPLE,
+        )
+        mutations = _parse_and_annotate_vcf(vcf)
+        assert len(mutations) == 2
+        assert {m["alt"] for m in mutations} == {"GGTTT", "GTTTT"}
+        assert all(m["ref"] == "G" and m["pos"] == 1735008 for m in mutations)
+
+    def test_no_alt_retains_a_comma(self, tmp_path):
+        vcf = _write(
+            tmp_path,
+            "1\t100\t.\tA\tT,C,G\t50\tPASS\tGENE=TESTGENE\n",
+            header=_HEADER_NO_SAMPLE,
+        )
+        mutations = _parse_and_annotate_vcf(vcf)
+        assert len(mutations) == 3
+        assert not any("," in m["alt"] for m in mutations)
+
+    def test_single_allele_is_unchanged(self, tmp_path):
+        vcf = _write(
+            tmp_path,
+            "7\t55191822\t.\tT\tG\t99\tPASS\tGENE=EGFR\n",
+            header=_HEADER_NO_SAMPLE,
+        )
+        mutations = _parse_and_annotate_vcf(vcf)
+        assert len(mutations) == 1
+        assert mutations[0]["alt"] == "G"
+
+
+class TestAlleleFractionIsCarriedThrough:
+    """Without VAF, a 2% artefact and a clonal driver look identical."""
+
+    def test_vaf_derived_from_allelic_depths(self, tmp_path):
+        vcf = _write(tmp_path, "7\t55191822\t.\tT\tG\t99\tPASS\tGENE=EGFR\tGT:DP:AD\t0/1:100:90,10\n")
+        mutation = _parse_and_annotate_vcf(vcf)[0]
+        assert mutation["vaf"] == pytest.approx(0.10)
+        assert mutation["depth"] == 100
+
+    def test_explicit_af_is_preferred(self, tmp_path):
+        vcf = _write(tmp_path, "7\t55191822\t.\tT\tG\t99\tPASS\tGENE=EGFR\tGT:DP:AF\t0/1:200:0.42\n")
+        mutation = _parse_and_annotate_vcf(vcf)[0]
+        assert mutation["vaf"] == pytest.approx(0.42)
+        assert mutation["depth"] == 200
+
+    def test_a_low_vaf_call_is_distinguishable(self, tmp_path):
+        """The property the FFPE detector needs in order to be applicable here."""
+        vcf = _write(
+            tmp_path,
+            "7\t55191822\t.\tC\tT\t99\tPASS\tGENE=EGFR\tGT:DP:AD\t0/1:500:490,10\n"
+            "7\t55019278\t.\tG\tA\t99\tPASS\tGENE=EGFR\tGT:DP:AD\t0/1:500:250,250\n",
+        )
+        mutations = _parse_and_annotate_vcf(vcf)
+        assert mutations[0]["vaf"] == pytest.approx(0.02)
+        assert mutations[1]["vaf"] == pytest.approx(0.50)
+
+    def test_missing_format_columns_do_not_crash(self, tmp_path):
+        vcf = _write(
+            tmp_path,
+            "7\t55191822\t.\tT\tG\t99\tPASS\tGENE=EGFR\n",
+            header=_HEADER_NO_SAMPLE,
+        )
+        mutation = _parse_and_annotate_vcf(vcf)[0]
+        assert mutation["vaf"] is None
+        assert mutation["depth"] is None
+
+    @pytest.mark.parametrize(
+        "fmt, sample",
+        [
+            ("GT:DP:AD", "0/1:.:."),
+            ("GT:DP:AD", "0/1:100:."),
+            ("GT:AF", "0/1:."),
+            ("GT:DP:AD", "0/1:0:0,0"),
+            ("GT", "0/1"),
+        ],
+    )
+    def test_unparseable_depth_fields_yield_none_not_an_exception(self, tmp_path, fmt, sample):
+        vcf = _write(tmp_path, f"7\t55191822\t.\tT\tG\t99\tPASS\tGENE=EGFR\t{fmt}\t{sample}\n")
+        mutations = _parse_and_annotate_vcf(vcf)
+        assert len(mutations) == 1
+        assert mutations[0]["vaf"] is None
+
+    def test_mismatched_format_and_sample_lengths_are_ignored(self, tmp_path):
+        vcf = _write(tmp_path, "7\t55191822\t.\tT\tG\t99\tPASS\tGENE=EGFR\tGT:DP:AD\t0/1:100\n")
+        mutations = _parse_and_annotate_vcf(vcf)
+        assert len(mutations) == 1
+        assert mutations[0]["vaf"] is None
+
+
+class TestExistingBehaviourIsPreserved:
+    def test_annotations_still_extracted(self, tmp_path):
+        vcf = _write(
+            tmp_path,
+            "7\t55174772\t.\tT\tG\t.\tPASS\t"
+            "GENE=EGFR;HGVS_C=p.L858R;SO=missense_variant;CLINVAR_ID=CV1;COSMIC_ID=COSM1\n",
+            header=_HEADER_NO_SAMPLE,
+        )
+        mutation = _parse_and_annotate_vcf(vcf)[0]
+        assert mutation["gene"] == "EGFR"
+        assert mutation["hgvs"] == "p.L858R"
+        assert mutation["mutation_type"] == "missense_variant"
+        assert mutation["clinvar_id"] == "CV1"
+        assert mutation["cosmic_id"] == "COSM1"
+
+    def test_missing_gene_defaults_to_unknown(self, tmp_path):
+        vcf = _write(tmp_path, "1\t100\t.\tA\tT\t.\tPASS\t.\n", header=_HEADER_NO_SAMPLE)
+        assert _parse_and_annotate_vcf(vcf)[0]["gene"] == "UNKNOWN"
+
+    def test_truncated_lines_are_skipped(self, tmp_path):
+        vcf = _write(tmp_path, "1\t100\t.\tA\n", header=_HEADER_NO_SAMPLE)
+        assert _parse_and_annotate_vcf(vcf) == []

--- a/api/workers/genomic_worker.py
+++ b/api/workers/genomic_worker.py
@@ -196,21 +196,94 @@ def _run_nextflow_pipeline(dna_file: str, workdir: str, cancer_type: str) -> str
     raise FileNotFoundError("Annotated VCF not found after pipeline run")
 
 
-def _parse_and_annotate_vcf(vcf_path: str) -> list[dict]:
+# FILTER values that mean "the caller did not reject this call". Anything else
+# is an explicit rejection and must not reach a treatment recommendation.
+# "." and "" mean no filtering was applied rather than a failure, so they pass.
+_ACCEPTED_FILTERS = {"PASS", ".", ""}
+
+
+def _extract_vaf_and_depth(parts: list[str]) -> tuple[float | None, int | None]:
+    """Pull VAF and depth out of the FORMAT/sample columns, if present.
+
+    Without this the mutation dicts carry no allele fraction, which means the
+    FFPE artefact detector in services/sample_qc.py cannot be applied to
+    anything ingested here: a 2% deamination artefact and a clonal driver look
+    identical downstream.
+    """
+    if len(parts) < 10:
+        return None, None
+    keys = parts[8].split(":")
+    values = parts[9].split(":")
+    if len(keys) != len(values):
+        return None, None
+    field = dict(zip(keys, values))
+
+    depth = None
+    raw_depth = field.get("DP")
+    if raw_depth and raw_depth.isdigit():
+        depth = int(raw_depth)
+
+    # AF directly, when the caller emits it.
+    raw_af = field.get("AF")
+    if raw_af and raw_af not in (".", ""):
+        try:
+            return float(raw_af.split(",")[0]), depth
+        except ValueError:
+            pass
+
+    # Otherwise derive it from allelic depths.
+    raw_ad = field.get("AD")
+    if raw_ad and raw_ad not in (".", ""):
+        try:
+            counts = [int(x) for x in raw_ad.split(",") if x not in (".", "")]
+        except ValueError:
+            return None, depth
+        total = sum(counts)
+        if total > 0 and len(counts) >= 2:
+            return sum(counts[1:]) / total, depth or total
+
+    return None, depth
+
+
+def _parse_and_annotate_vcf(vcf_path: str, include_filtered: bool = False) -> list[dict]:
     """
     Parse the OpenCRAVAT-annotated VCF file.
     Returns a list of mutation dicts with gene, hgvs, clinvar, cosmic etc.
+
+    Three properties this must hold, each of which it previously did not:
+
+    * A multi-allelic site is several variants, not one. ALT "GGTTT,GTTTT" used
+      to be stored verbatim as a single alt string, which matches no evidence
+      record, so if one of the alleles was the actionable one it was lost.
+      Nothing upstream normalises: there is no bcftools norm step in
+      pipeline/. Each ALT allele is now emitted as its own mutation.
+    * A call the variant caller rejected must not silently become a
+      recommendation. FILTER was unpacked and discarded, so Mutect2's
+      weak_evidence, strand_bias and panel_of_normals calls were ingested
+      exactly like PASS calls. They are now dropped by default and the value is
+      retained either way so the decision is visible.
+    * VAF and depth are carried through, so low-allele-fraction artefacts are
+      distinguishable downstream.
     """
     mutations = []
     with open(vcf_path, "r") as f:
         for line in f:
             if line.startswith("#"):
                 continue
-            parts = line.strip().split("\t")
+            parts = line.rstrip("\n").split("\t")
             if len(parts) < 8:
                 continue
 
-            chrom, pos, vid, ref, alt, qual, filt, info = parts[:8]
+            chrom, pos, _vid, ref, alt, _qual, filt, info = parts[:8]
+
+            filter_status = (filt or "").strip()
+            passed = filter_status.upper() in {v.upper() for v in _ACCEPTED_FILTERS}
+            if not passed and not include_filtered:
+                logger.info(
+                    "[vcf] dropping %s:%s %s>%s rejected by the caller (FILTER=%s)",
+                    chrom, pos, ref, alt, filter_status,
+                )
+                continue
 
             # Parse INFO field for OpenCRAVAT annotations
             info_dict = dict(
@@ -218,17 +291,27 @@ def _parse_and_annotate_vcf(vcf_path: str) -> list[dict]:
                 for kv in info.split(";")
             )
 
-            mutations.append({
-                "chrom": chrom,
-                "pos": int(pos) if pos.isdigit() else None,
-                "ref": ref,
-                "alt": alt,
-                "gene": info_dict.get("GENE", "UNKNOWN"),
-                "hgvs": info_dict.get("HGVS_C"),
-                "mutation_type": info_dict.get("SO", "unknown"),
-                "clinvar_id": info_dict.get("CLINVAR_ID"),
-                "cosmic_id": info_dict.get("COSMIC_ID"),
-            })
+            vaf, depth = _extract_vaf_and_depth(parts)
+
+            # A multi-allelic record describes several distinct variants.
+            for allele in (a.strip() for a in alt.split(",")):
+                if not allele:
+                    continue
+                mutations.append({
+                    "chrom": chrom,
+                    "pos": int(pos) if pos.isdigit() else None,
+                    "ref": ref,
+                    "alt": allele,
+                    "gene": info_dict.get("GENE", "UNKNOWN"),
+                    "hgvs": info_dict.get("HGVS_C"),
+                    "mutation_type": info_dict.get("SO", "unknown"),
+                    "clinvar_id": info_dict.get("CLINVAR_ID"),
+                    "cosmic_id": info_dict.get("COSMIC_ID"),
+                    "filter_status": filter_status or "PASS",
+                    "filter_passed": passed,
+                    "vaf": vaf,
+                    "depth": depth,
+                })
 
     return mutations
 

--- a/docs/risk_analysis.md
+++ b/docs/risk_analysis.md
@@ -133,6 +133,49 @@ target at sensitivity ≥ 99% and PPV ≥ 95% against orthogonal WGS, status
 is unbounded, because no amount of correct downstream reasoning survives a wrong
 input variant.
 
+### F7. Rejected variant calls were ingested as if they had passed (H1, H6) — FIXED
+
+`_parse_and_annotate_vcf` in `api/workers/genomic_worker.py` unpacked the VCF
+FILTER column and then discarded it. Calls the variant caller had explicitly
+rejected were ingested identically to passing calls, and nothing downstream could
+tell the difference because the value was not retained.
+
+Mutect2 emits `weak_evidence`, `strand_bias`, `base_qual` and `panel_of_normals`
+for calls it believes are artefacts or germline. Those are precisely the calls
+that must not reach a treatment recommendation. Demonstrated with a three-record
+VCF: two rejected calls and one PASS call all arrived as equal mutations.
+
+Rejected calls are now dropped, `PASS` and `.` are accepted, `include_filtered=True`
+retrieves them when a caller genuinely wants them, and the FILTER value is
+retained either way so the decision is inspectable.
+
+### F8. Multi-allelic sites were collapsed into one unusable variant (H2) — FIXED
+
+A multi-allelic record describes several distinct variants. The parser stored the
+ALT column verbatim, so `GGTTT,GTTTT` became a single mutation whose alt allele
+matches no evidence record. Found by running the parser over the Genome in a
+Bottle HG002 benchmark VCF (NIST v4.2.1, GRCh38): 46 of 8,000 real records were
+affected.
+
+Nothing upstream normalises. There is no `bcftools norm` step anywhere in
+`pipeline/`. If one of the two alleles is the actionable one, it was silently
+lost. Each ALT allele is now emitted as its own mutation.
+
+### F9. Allele fraction never reached the mutation record (H1, H3) — FIXED
+
+The parser read no FORMAT fields, so mutations carried no VAF or depth. A 2%
+cytosine-deamination artefact and a 50% clonal driver were indistinguishable
+downstream.
+
+This also made the FFPE detector inapplicable to anything this parser produced:
+`detect_ffpe_artefacts` in `api/services/sample_qc.py` keys on low-VAF
+enrichment, and the production ingestion path supplied no VAF for it to read. So
+the control existed and was validated (`scripts/validate_ffpe_detection.py`)
+while being unreachable from the path that matters. VAF is now derived from
+`AF` or from `AD` allelic depths, with depth carried alongside.
+
+Regression tests for F7, F8 and F9: `api/tests/test_vcf_ingestion_safety.py`.
+
 ---
 
 ## 3. What is not yet analysed


### PR DESCRIPTION
## How these were found

The variant-calling validation gate cannot be run here (no `bwa`, `gatk`, `samtools`). But the truth set it would be scored against is downloadable, so I ran the **production VCF parser** over the Genome in a Bottle HG002 benchmark VCF (NIST v4.2.1, GRCh38) and looked at what came out.

Three properties were missing from `_parse_and_annotate_vcf`. Each failed silently rather than raising.

## 1. Calls the variant caller rejected were ingested as if they passed

The FILTER column was unpacked into a local and then discarded:

```python
chrom, pos, vid, ref, alt, qual, filt, info = parts[:8]   # filt never used again
```

Mutect2 emits `weak_evidence`, `strand_bias`, `base_qual` and `panel_of_normals` for calls it believes are artefacts or germline contamination. Those are exactly the calls that must not reach a treatment recommendation.

Demonstrated with a three-record VCF:

```
VCF had 3 records: 2 FAILED the caller filter, 1 PASS
mutations ingested: 3
    EGFR L858R | filter field retained? False
    EGFR T790M | filter field retained? False
    EGFR G719S | filter field retained? False
```

All three arrived as equal mutations, and nothing downstream could tell, because the value was not retained anywhere.

**Fixed.** Rejected calls are dropped. `PASS` and `.` are accepted, since `.` means no filtering was applied rather than a failure. `include_filtered=True` retrieves them when a caller genuinely wants them, and `filter_status` / `filter_passed` are retained either way so the decision is inspectable rather than implicit.

## 2. Multi-allelic sites were collapsed into one unusable variant

A multi-allelic record describes several distinct variants. The ALT column was stored verbatim, so `GGTTT,GTTTT` became one mutation whose alt allele matches no evidence record.

**46 of 8,000 real GIAB records were affected:**

```
chr1 1735008 G -> 'GGTTT,GTTTT'
chr1 1769969 CAAAACAAAAACA -> 'CAAAACA,C'
chr1 1818305 TAAAAAAA -> 'TAAAAAAAA,T'
```

Nothing upstream normalises this away — there is no `bcftools norm` step anywhere in `pipeline/`. If one of the alleles was the actionable one, it was silently lost.

**Fixed.** Each ALT allele is emitted as its own mutation.

## 3. Allele fraction never reached the mutation record

The parser read no FORMAT fields, so mutations carried no VAF and no depth. A 2% cytosine-deamination artefact and a 50% clonal driver were indistinguishable downstream.

This one compounds: `detect_ffpe_artefacts` in `api/services/sample_qc.py` keys on low-VAF enrichment, and the production ingestion path supplied no VAF for it to read. So the FFPE control existed, and had just been validated in PR #96, while being **unreachable from the path that matters**.

**Fixed.** VAF comes from `AF` when the caller emits it, otherwise derived from `AD` allelic depths, with depth carried alongside.

## Verification against real data

```
--- GIAB real data ---
  mutations from 8000 records: 8046   (multi-allelic now split)
  any comma left in ALT: 0
  VAF extracted for: 8039 of 8046
  VAF median 0.535, range 0.225-1.000
```

A median VAF of 0.535 on a germline benchmark is the expected distribution, which is a useful sanity check that the extraction is reading the right field.

## Tests

29 new tests in `api/tests/test_vcf_ingestion_safety.py`, covering all three properties plus the unparseable-input cases that must yield `None` rather than raise (`AD` of `.`, zero depth, mismatched FORMAT/SAMPLE lengths, absent sample column).

Existing `test_vcf_parsing.py` passes unchanged — all of its fixtures use `PASS`, so dropping rejected calls does not alter them.

Backend suite: **676 passed**, up from 647. Ruff clean.

Also recorded as F7, F8 and F9 in `docs/risk_analysis.md` against the hazard classes that document already defines.
