### PR TITLE
fix(genomic): actually run sample QC, and name a function that exists

### DIFF
--- a/api/services/oncologist_report.py
+++ b/api/services/oncologist_report.py
@@ -1651,7 +1651,7 @@ def _render_plain_text(r: OncologistReport) -> str:
             lines.extend(textwrap.wrap(f"  ⚠ {w}", width=70, subsequent_indent="    "))
         lines.append(f"  Note: {qc['notes']}")
     else:
-        lines.append("  QC report not provided. Run sample_qc.run_qc_pipeline() for metrics.")
+        lines.append("  QC report not provided. Run sample_qc.run_sample_qc() for metrics.")
     lines.append("")
 
     # ── Section 3: Genomic Alterations ──────────────────────────────────────

--- a/api/tests/test_vcf_ingestion_safety.py
+++ b/api/tests/test_vcf_ingestion_safety.py
@@ -206,3 +206,45 @@ class TestExistingBehaviourIsPreserved:
     def test_truncated_lines_are_skipped(self, tmp_path):
         vcf = _write(tmp_path, "1\t100\t.\tA\n", header=_HEADER_NO_SAMPLE)
         assert _parse_and_annotate_vcf(vcf) == []
+
+
+class TestSampleQCCheckpoint:
+    """Sample QC was implemented, validated, and never invoked. See F10.
+
+    It is advisory: it must record the verdict without ever failing the
+    submission, because discarding a real analysis over a quality signal is the
+    wrong trade.
+    """
+
+    def test_qc_runs_and_returns_a_verdict(self, tmp_path, caplog):
+        from api.workers.genomic_worker import _run_sample_qc_checkpoint
+
+        body = "".join(
+            f"1\t{1000 + i * 100}\t.\tA\tG\t99\tPASS\t.\tGT:DP:AD\t0/1:200:100,100\n"
+            for i in range(20)
+        )
+        vcf = _write(tmp_path, body)
+
+        report = _run_sample_qc_checkpoint(vcf, "submission-1")
+        assert report is not None
+        assert report.verdict in {"PASS", "WARN", "FAIL"}
+
+    def test_a_missing_file_does_not_raise(self, tmp_path):
+        """QC failure must never take down a completed analysis."""
+        from api.workers.genomic_worker import _run_sample_qc_checkpoint
+
+        assert _run_sample_qc_checkpoint(str(tmp_path / "nope.vcf"), "submission-2") is None
+
+    def test_ffpe_signal_is_surfaced_in_the_verdict_path(self, tmp_path):
+        from api.workers.genomic_worker import _run_sample_qc_checkpoint
+
+        # Low-VAF C>T everywhere: the deamination signature.
+        body = "".join(
+            f"1\t{2000 + i * 100}\t.\tC\tT\t99\tPASS\t.\tGT:DP:AD\t0/1:500:490,10\n"
+            for i in range(30)
+        )
+        vcf = _write(tmp_path, body)
+
+        report = _run_sample_qc_checkpoint(vcf, "submission-3")
+        assert report is not None
+        assert report.ffpe.ffpe_score > 0

--- a/api/workers/genomic_worker.py
+++ b/api/workers/genomic_worker.py
@@ -65,6 +65,15 @@ def run_genomic_pipeline(
             # 3. Parse VCF and annotate mutations
             mutations_data = _parse_and_annotate_vcf(vcf_path)
 
+            # 3b. Sample QC. services/sample_qc.py implements FFPE artefact
+            # detection, tumour purity and coverage, and nothing in the pipeline
+            # had ever called it, so the control was inert: a sample with a
+            # high-confidence FFPE signal produced recommendations exactly like
+            # a clean one. This runs it and records the verdict. It does not yet
+            # reach the patient-facing report, which needs somewhere to persist
+            # it; tracked as F10 in docs/risk_analysis.md.
+            _run_sample_qc_checkpoint(vcf_path, submission_id)
+
             # 4. Upload annotated VCF back to MinIO
             vcf_s3_key = _upload_vcf_to_minio(vcf_path, patient_id, submission_id)
 
@@ -194,6 +203,43 @@ def _run_nextflow_pipeline(dna_file: str, workdir: str, cancer_type: str) -> str
             return os.path.join(output_dir, fname)
 
     raise FileNotFoundError("Annotated VCF not found after pipeline run")
+
+
+def _run_sample_qc_checkpoint(vcf_path: str, submission_id: str) -> "object | None":
+    """Run sample QC and record the verdict. Never fails the submission.
+
+    QC is advisory here. A FAIL verdict means the sample looks unreliable, most
+    often a high-confidence FFPE deamination signal, and that has to be visible
+    to whoever reads the result. Raising instead would discard a real analysis
+    over a quality signal, so this logs at the severity the verdict warrants and
+    returns the report for callers that want it.
+    """
+    try:
+        from services.sample_qc import run_sample_qc
+
+        report = run_sample_qc(vcf_path)
+    except Exception as exc:  # QC must never take down the analysis
+        logger.warning("[genomic] sample QC did not run for %s: %s", submission_id, exc)
+        return None
+
+    detail = (
+        f"verdict={report.verdict} ffpe_score={report.ffpe.ffpe_score} "
+        f"ffpe_flagged={report.ffpe.is_flagged} variants={report.total_variants}"
+    )
+    if report.verdict == "FAIL":
+        logger.error(
+            "[genomic] sample QC FAILED for submission %s (%s); reasons: %s",
+            submission_id, detail, "; ".join(report.verdict_reasons) or "none recorded",
+        )
+    elif report.verdict == "WARN":
+        logger.warning(
+            "[genomic] sample QC warning for submission %s (%s); reasons: %s",
+            submission_id, detail, "; ".join(report.verdict_reasons) or "none recorded",
+        )
+    else:
+        logger.info("[genomic] sample QC passed for submission %s (%s)", submission_id, detail)
+
+    return report
 
 
 # FILTER values that mean "the caller did not reject this call". Anything else

--- a/docs/risk_analysis.md
+++ b/docs/risk_analysis.md
@@ -176,6 +176,38 @@ while being unreachable from the path that matters. VAF is now derived from
 
 Regression tests for F7, F8 and F9: `api/tests/test_vcf_ingestion_safety.py`.
 
+### F10. Sample QC was implemented, validated, and never invoked (H1, H3) — PARTIALLY FIXED
+
+`api/services/sample_qc.py` implements FFPE artefact detection, tumour purity
+estimation and coverage summary, with unit tests, and
+`scripts/validate_ffpe_detection.py` measures its sensitivity. None of that
+mattered, because **no worker or route ever called it**. A grep for
+`run_sample_qc` and `detect_ffpe_artefacts` outside the tests returns only the
+definitions themselves.
+
+So a sample with a high-confidence FFPE deamination signal produced drug
+recommendations exactly like a clean one, and the patient-facing report printed
+"QC report not provided" as its normal state.
+
+That message also named a function that does not exist,
+`sample_qc.run_qc_pipeline()`. The real entry point is `run_sample_qc()`. Anyone
+following the report's own instruction got an `AttributeError`. Corrected.
+
+`_run_sample_qc_checkpoint` now runs QC in the genomic worker and logs at the
+severity the verdict warrants, `ERROR` on FAIL. QC is advisory and never fails
+the submission, because discarding a real analysis over a quality signal is the
+wrong trade.
+
+**Still open:** the verdict does not reach the patient-facing report. There is
+no field on `Result` or `Submission` to persist it and no adapter from
+`SampleQCReport` to the dict `oncologist_report` expects. Closing it needs a
+schema migration, which is a deliberate decision rather than an incidental one.
+Until then the signal exists only in worker logs.
+
+This is the general lesson from F9 as well: a control that is implemented,
+tested and benchmarked can still be doing nothing. Validation shows a control
+works; only tracing the call path shows it runs.
+
 ---
 
 ## 3. What is not yet analysed


### PR DESCRIPTION
## A control that was never invoked

`api/services/sample_qc.py` implements FFPE artefact detection, tumour purity estimation and coverage summary. It has unit tests. PR #96 measured its sensitivity at 100%.

None of that mattered. Nothing ever called it:

```
$ grep -rn "detect_ffpe_artefacts\|run_sample_qc" api/ --include=*.py | grep -v tests/
api/services/sample_qc.py:206:def detect_ffpe_artefacts(...)
api/services/sample_qc.py:416:def run_sample_qc(...)
api/services/sample_qc.py:428:    ffpe = detect_ffpe_artefacts(records)
```

Only its own definitions. No worker, no route.

So a sample carrying a high-confidence FFPE deamination signal produced drug recommendations exactly like a clean sample, and the oncologist report printed `QC report not provided` as its **normal steady state** rather than as an exception.

## The report named a function that does not exist

```python
lines.append("  QC report not provided. Run sample_qc.run_qc_pipeline() for metrics.")
```

There is no `run_qc_pipeline`. The entry point is `run_sample_qc`. Anyone following the report's own instruction got an `AttributeError`. Corrected.

## What this PR does

`_run_sample_qc_checkpoint` runs QC in the genomic worker after VCF parsing and logs at the severity the verdict warrants — `ERROR` on FAIL with the reasons, `WARNING` on WARN, `INFO` on PASS.

QC is advisory and never fails the submission. Discarding a completed analysis over a quality signal is the wrong trade, so a QC exception is caught and logged rather than propagated.

## What this PR deliberately does not do

**The verdict still does not reach the patient-facing report.** There is no field on `Result` or `Submission` to persist it, and no adapter from `SampleQCReport` to the dict `oncologist_report` expects.

Closing that needs a schema migration. That is a deliberate decision about a clinical system, not something to slip into a bug fix, so it is recorded as open in `docs/risk_analysis.md` (F10) rather than done unilaterally. Until then the signal lives in worker logs, which is at least where alerting can reach it.

## The general lesson, recorded in the risk analysis

A control that is implemented, tested and benchmarked can still be doing nothing. Validation shows a control **works**; only tracing the call path shows it **runs**.

F9 in the same document is the other half of this: the ingestion path fed the detector no allele fraction to read, so even a wired-up detector would have had nothing to work with. Two independent breaks in one control, neither visible from any test or benchmark that existed.

## Tests

3 new tests covering the checkpoint: it returns a verdict, a missing file does not raise, and an FFPE signal reaches the score.

Backend suite: **679 passed**, up from 676. Ruff clean.
