### PR TITLE
feat(qc): persist the sample QC verdict so it reaches the oncologist report

### DIFF
--- a/api/alembic/versions/0011_sample_qc_verdict.py
+++ b/api/alembic/versions/0011_sample_qc_verdict.py
@@ -1,0 +1,37 @@
+"""Add submissions.sample_qc so the QC verdict reaches the report.
+
+api/services/sample_qc.py detects FFPE artefacts, estimates tumour purity and
+summarises coverage, and until now none of that reached anybody. Nothing called
+it, and once it was called there was nowhere to put the answer, so the
+oncologist report printed "QC report not provided" as its normal state rather
+than as an exception. A sample carrying a high-confidence deamination signal
+produced drug recommendations indistinguishable from a clean one.
+
+The column lives on submissions rather than results because QC is a property of
+the submitted sample, and because it is computed in the genomic worker, which
+runs before any Result row exists.
+
+Nullable, so every existing submission keeps reading as "not assessed" rather
+than being retroactively claimed to have passed. Absence of a verdict and a
+passing verdict must not look alike.
+
+Revision ID: 0011
+Revises: 0010
+Create Date: 2026-08-13
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0011"
+down_revision = "0010"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("submissions", sa.Column("sample_qc", sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("submissions", "sample_qc")

--- a/api/models/submission.py
+++ b/api/models/submission.py
@@ -1,7 +1,8 @@
 import uuid
 from datetime import datetime, UTC
+from typing import Any
 
-from sqlalchemy import String, DateTime, ForeignKey, Enum as SAEnum
+from sqlalchemy import String, DateTime, ForeignKey, JSON, Enum as SAEnum
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 import enum
 
@@ -38,6 +39,12 @@ class Submission(Base):
 
     # 0–100 progress percentage updated by workers for live progress bar
     progress_pct: Mapped[int] = mapped_column(default=0)
+
+    # Sample QC verdict from services/sample_qc.py: FFPE artefact signal,
+    # tumour purity, coverage. Written by the genomic worker, read by the
+    # oncologist report. NULL means QC was not assessed, which is deliberately
+    # distinct from a passing verdict.
+    sample_qc: Mapped[Any] = mapped_column(JSON, nullable=True)
 
     submitted_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(UTC).replace(tzinfo=None))
     completed_at: Mapped[datetime] = mapped_column(DateTime, nullable=True)

--- a/api/routes/results.py
+++ b/api/routes/results.py
@@ -134,6 +134,7 @@ async def get_results(
                 ranked_candidates=ranked,
                 mutation_summary=mutation_list,
                 cancer_type=submission.cancer_type,
+                qc_report=submission.sample_qc,
                 patient_id=str(submission.id),
             )
             oncologist_report_data = onc_report.sections
@@ -330,6 +331,7 @@ async def download_oncologist_report_pdf(
         ranked_candidates=ranked,
         mutation_summary=mutation_list,
         cancer_type=submission.cancer_type,
+        qc_report=submission.sample_qc,
         patient_id=str(submission.id),
     )
     pdf_bytes, media_type, ext = generate_oncologist_report_document(onc_report)

--- a/api/services/sample_qc.py
+++ b/api/services/sample_qc.py
@@ -503,3 +503,42 @@ def enrich_qc_with_tmb_msi(report: SampleQCReport, mutations: list[dict]) -> Sam
         tmb_msi.immunotherapy_relevant,
     )
     return report
+
+
+def sample_qc_to_report_dict(report: SampleQCReport) -> dict:
+    """Flatten a SampleQCReport onto the keys the oncologist report reads.
+
+    ``oncologist_report._format_qc`` expects a flat dict. Nothing produced one,
+    so the report's Sample & Quality section printed "QC report not provided"
+    as its normal state rather than as an exception, even on samples where QC
+    had flagged a problem. This is the adapter between the two halves.
+
+    Keys are exactly those ``_format_qc`` reads. Missing values stay ``None``
+    rather than being defaulted to something reassuring: "not measured" and
+    "measured and fine" must not render identically.
+    """
+    warnings: list[str] = list(report.verdict_reasons or [])
+    if report.ffpe.is_flagged and report.ffpe.recommendation:
+        warnings.append(report.ffpe.recommendation)
+    if report.coverage.coverage_adequacy in ("LOW", "VERY_LOW"):
+        warnings.append(
+            f"Coverage {report.coverage.coverage_adequacy.lower().replace('_', ' ')}: "
+            f"{report.coverage.fraction_below_30x:.0%} of variants below 30x"
+        )
+
+    return {
+        "qc_verdict": report.verdict,
+        "tumour_purity_estimate": report.tumour_purity.purity_pct,
+        "ffpe_artefact_rate": report.ffpe.ct_fraction,
+        "ffpe_suspected": bool(report.ffpe.is_flagged),
+        "ti_tv_ratio": report.ffpe.titv_ratio,
+        "median_vaf": report.tumour_purity.vaf_peak,
+        "total_variants": report.total_variants,
+        "pass_variants": report.pass_variants,
+        "mean_depth": report.coverage.mean_depth,
+        "warnings": warnings,
+        # Kept for auditing: the score behind the flag, not just the flag.
+        "ffpe_score": report.ffpe.ffpe_score,
+        "ffpe_confidence": report.ffpe.confidence,
+        "coverage_adequacy": report.coverage.coverage_adequacy,
+    }

--- a/api/tests/test_sample_qc_persistence.py
+++ b/api/tests/test_sample_qc_persistence.py
@@ -1,0 +1,130 @@
+"""The QC verdict has to survive the trip from the worker to the report.
+
+Three separate breaks kept it from doing so, each invisible from the others:
+
+  F9  the ingestion path carried no allele fraction, so the detector had
+      nothing to read
+  F10 nothing called the detector at all
+  this one: there was nowhere to persist the answer and no adapter onto the
+      keys the report reads, so `_format_qc` never received a dict and the
+      Sample & Quality section printed "QC report not provided" as its normal
+      state
+
+These tests pin the last link: the adapter emits exactly the keys the report
+consumes, and a missing verdict never renders as a passing one.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+for path in (str(_REPO_ROOT), str(_REPO_ROOT / "api")):
+    if path not in sys.path:
+        sys.path.insert(0, path)
+
+from services.oncologist_report import _format_qc  # noqa: E402
+from services.sample_qc import run_sample_qc, sample_qc_to_report_dict  # noqa: E402
+
+_HEADER = "##fileformat=VCFv4.2\n#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tSAMPLE\n"
+
+
+def _vcf(tmp_path: Path, body: str) -> str:
+    path = tmp_path / "sample.vcf"
+    path.write_text(_HEADER + body, encoding="utf-8")
+    return str(path)
+
+
+def _clean_sample(tmp_path: Path) -> str:
+    body = "".join(
+        f"1\t{1000 + i * 100}\t.\tA\tG\t99\tPASS\t.\tGT:DP:AD\t0/1:200:100,100\n"
+        for i in range(25)
+    )
+    return _vcf(tmp_path, body)
+
+
+def _ffpe_sample(tmp_path: Path) -> str:
+    """Low-VAF C>T throughout: the cytosine-deamination signature."""
+    body = "".join(
+        f"1\t{2000 + i * 100}\t.\tC\tT\t99\tPASS\t.\tGT:DP:AD\t0/1:500:490,10\n"
+        for i in range(30)
+    )
+    return _vcf(tmp_path, body)
+
+
+class TestAdapterMatchesWhatTheReportReads:
+    """_format_qc reads a fixed key set. The adapter must supply it."""
+
+    REQUIRED = {
+        "qc_verdict", "tumour_purity_estimate", "ffpe_artefact_rate",
+        "ffpe_suspected", "ti_tv_ratio", "median_vaf", "total_variants",
+        "pass_variants", "mean_depth", "warnings",
+    }
+
+    def test_every_key_the_report_reads_is_present(self, tmp_path):
+        qc = sample_qc_to_report_dict(run_sample_qc(_clean_sample(tmp_path)))
+        assert self.REQUIRED <= set(qc)
+
+    def test_the_report_renders_the_adapter_output(self, tmp_path):
+        qc = sample_qc_to_report_dict(run_sample_qc(_clean_sample(tmp_path)))
+        formatted = _format_qc(qc)
+        assert formatted["qc_verdict"] in {"PASS", "WARN", "FAIL"}
+        assert formatted["qc_verdict"] != "UNKNOWN"
+        assert formatted["total_variants"] == 25
+
+    def test_the_audit_fields_survive(self, tmp_path):
+        """The score behind the flag, not just the flag."""
+        qc = sample_qc_to_report_dict(run_sample_qc(_ffpe_sample(tmp_path)))
+        assert "ffpe_score" in qc
+        assert "ffpe_confidence" in qc
+        assert "coverage_adequacy" in qc
+
+
+class TestAnFFPESampleIsVisibleInTheReport:
+    def test_ffpe_signal_reaches_the_rendered_section(self, tmp_path):
+        qc = sample_qc_to_report_dict(run_sample_qc(_ffpe_sample(tmp_path)))
+        formatted = _format_qc(qc)
+        assert formatted["ffpe_suspected"] is True
+        assert formatted["ffpe_artefact_rate"] > 0
+
+    def test_a_flagged_sample_carries_warnings(self, tmp_path):
+        qc = sample_qc_to_report_dict(run_sample_qc(_ffpe_sample(tmp_path)))
+        assert qc["warnings"], "a flagged sample must explain itself"
+
+    def test_clean_and_ffpe_samples_do_not_render_identically(self, tmp_path):
+        """The property that was absent: they used to be indistinguishable."""
+        clean = _format_qc(sample_qc_to_report_dict(run_sample_qc(_clean_sample(tmp_path))))
+        ffpe_dir = tmp_path / "ffpe"
+        ffpe_dir.mkdir()
+        ffpe = _format_qc(sample_qc_to_report_dict(run_sample_qc(_ffpe_sample(ffpe_dir))))
+        assert clean["ffpe_suspected"] != ffpe["ffpe_suspected"]
+
+
+class TestMissingQCIsNotAPass:
+    """NULL means not assessed. It must never read as a clean bill of health."""
+
+    def test_absent_qc_renders_as_unknown(self):
+        assert _format_qc({})["qc_verdict"] == "UNKNOWN"
+
+    def test_absent_qc_does_not_claim_ffpe_was_ruled_out(self):
+        assert _format_qc({})["ffpe_suspected"] is False
+        assert _format_qc({})["ffpe_artefact_rate"] is None
+
+    @pytest.mark.parametrize(
+        "field",
+        ["tumour_purity_estimate", "ffpe_artefact_rate", "ti_tv_ratio",
+         "median_vaf", "total_variants", "mean_depth"],
+    )
+    def test_unmeasured_values_stay_none_rather_than_zero(self, field):
+        """Zero is a measurement. None is the absence of one."""
+        assert _format_qc({})[field] is None
+
+
+class TestSubmissionCarriesTheColumn:
+    def test_model_has_the_field_and_defaults_to_none(self):
+        from models.submission import Submission
+
+        assert hasattr(Submission, "sample_qc")
+        assert Submission.__table__.c.sample_qc.nullable is True

--- a/api/workers/genomic_worker.py
+++ b/api/workers/genomic_worker.py
@@ -69,10 +69,9 @@ def run_genomic_pipeline(
             # detection, tumour purity and coverage, and nothing in the pipeline
             # had ever called it, so the control was inert: a sample with a
             # high-confidence FFPE signal produced recommendations exactly like
-            # a clean one. This runs it and records the verdict. It does not yet
-            # reach the patient-facing report, which needs somewhere to persist
-            # it; tracked as F10 in docs/risk_analysis.md.
-            _run_sample_qc_checkpoint(vcf_path, submission_id)
+            # a clean one. The verdict is persisted on the submission so it
+            # reaches the oncologist report rather than living only in logs.
+            qc_report = _run_sample_qc_checkpoint(vcf_path, submission_id)
 
             # 4. Upload annotated VCF back to MinIO
             vcf_s3_key = _upload_vcf_to_minio(vcf_path, patient_id, submission_id)
@@ -99,6 +98,10 @@ def run_genomic_pipeline(
                 submission = db.get(Submission, submission_id)
                 submission.status = SubmissionStatus.awaiting_ai
                 submission.vcf_s3_key = vcf_s3_key
+                if qc_report is not None:
+                    from services.sample_qc import sample_qc_to_report_dict
+
+                    submission.sample_qc = sample_qc_to_report_dict(qc_report)
                 db.commit()
 
         # 6. Queue AI worker

--- a/docs/risk_analysis.md
+++ b/docs/risk_analysis.md
@@ -176,7 +176,7 @@ while being unreachable from the path that matters. VAF is now derived from
 
 Regression tests for F7, F8 and F9: `api/tests/test_vcf_ingestion_safety.py`.
 
-### F10. Sample QC was implemented, validated, and never invoked (H1, H3) — PARTIALLY FIXED
+### F10. Sample QC was implemented, validated, and never invoked (H1, H3) — FIXED
 
 `api/services/sample_qc.py` implements FFPE artefact detection, tumour purity
 estimation and coverage summary, with unit tests, and
@@ -198,11 +198,14 @@ severity the verdict warrants, `ERROR` on FAIL. QC is advisory and never fails
 the submission, because discarding a real analysis over a quality signal is the
 wrong trade.
 
-**Still open:** the verdict does not reach the patient-facing report. There is
-no field on `Result` or `Submission` to persist it and no adapter from
-`SampleQCReport` to the dict `oncologist_report` expects. Closing it needs a
-schema migration, which is a deliberate decision rather than an incidental one.
-Until then the signal exists only in worker logs.
+The verdict now reaches the report. `submissions.sample_qc` (migration `0011`)
+persists it, `sample_qc_to_report_dict()` maps `SampleQCReport` onto the exact
+keys `oncologist_report._format_qc` reads, and both report call sites in
+`api/routes/results.py` pass it through. The column is nullable, so submissions
+processed before this keep reading as "not assessed" rather than being
+retroactively claimed to have passed: absence of a verdict and a passing verdict
+must not render alike. `_format_qc({})` returns `qc_verdict="UNKNOWN"` with every
+measurement `None`, which is the property the tests pin.
 
 This is the general lesson from F9 as well: a control that is implemented,
 tested and benchmarked can still be doing nothing. Validation shows a control


### PR DESCRIPTION
## Completes F10

Sample QC was broken in three independent places, and each one hid the others:

| | Break | Status |
|---|---|---|
| F9 | Ingestion carried no allele fraction, so the detector had nothing to read | Fixed, PR #97 |
| F10a | Nothing ever called the detector | Fixed, PR #98 |
| F10b | Nowhere to persist the answer, no adapter onto the keys the report reads | **This PR** |

Until now the report's Sample & Quality section printed `QC report not provided` as its **normal steady state**, and both call sites of `generate_oncologist_report` omitted the `qc_report` argument entirely. A sample with a high-confidence FFPE deamination signal rendered exactly like a clean one.

## Schema

Migration `0011` adds `submissions.sample_qc` as nullable JSON.

It lives on `submissions` rather than `results` for two reasons: QC is a property of the submitted sample, and it is computed in the genomic worker, which runs before any `Result` row exists.

**Nullable is deliberate.** Every submission processed before this reads as "not assessed" rather than being retroactively claimed to have passed. Absence of a verdict and a passing verdict must not look alike:

```python
_format_qc({})["qc_verdict"]        == "UNKNOWN"   # not "PASS"
_format_qc({})["ffpe_artefact_rate"] is None       # not 0
```

Zero is a measurement. `None` is the absence of one. There is a parametrised test for that distinction across every numeric field.

Upgrade and downgrade were exercised against a table holding a pre-existing row:

```
after upgrade, columns: ['id', 'progress_pct', 'sample_qc']
pre-existing row sample_qc = None (NULL = not assessed, correct)
after downgrade, columns: ['id', 'progress_pct']
```

Revision chain stays single-headed: `a8bf7eb4833c -> 0010 -> 0011`.

## Adapter

`sample_qc_to_report_dict()` flattens `SampleQCReport` onto exactly the keys `oncologist_report._format_qc` consumes. Nothing produced that shape before, which is why the two halves never met.

It also carries `ffpe_score`, `ffpe_confidence` and `coverage_adequacy` so a reviewer can audit the score behind the flag rather than only the flag. Verdict reasons, the FFPE recommendation and a low-coverage note merge into `warnings`.

## Wiring

The genomic worker persists the dict alongside the status transition it already writes, so there is no extra transaction. Both report call sites in `api/routes/results.py` now pass `qc_report=submission.sample_qc`.

## Tests

15 tests in `api/tests/test_sample_qc_persistence.py` pin the properties that matter:

- The adapter emits every key `_format_qc` reads (checked against the actual key set, so drift breaks the test).
- A clean sample and an FFPE sample **do not render identically** — the property that was absent.
- A missing verdict never reads as a passing one.
- The audit fields survive the flattening.

Backend suite: **694 passed**, up from 679. Ruff clean.

## Note

This closes the last reachable item on F10, but it is worth being plain about what it does and does not do. The QC verdict now appears in the report. Whether a clinician reading that report acts on a `FAIL` verdict is a human-factors question, and `docs/risk_analysis.md` still lists human-factors review as unanalysed and blocking clinical use.
