### PR TITLE
feat(qc): return the sample QC verdict to API callers, and pin the worker's call path

### DIFF
--- a/api/routes/results.py
+++ b/api/routes/results.py
@@ -142,10 +142,15 @@ async def get_results(
         except Exception:
             pass  # never fail the response due to report generation
 
+    from services.sample_qc import qc_payload_for_api
+
     return {
         "submission_id": submission_id,
         "cancer_type": submission.cancer_type,
         "status": "complete",
+        # The QC verdict stopped at the rendered report until now, so no API
+        # consumer could tell a clean sample from a flagged one.
+        "sample_qc": qc_payload_for_api(submission.sample_qc),
         "has_targetable_mutation": result.has_targetable_mutation if result else False,
         "target_gene": result.target_gene if result else None,
         "summary": result.summary_text if result else None,

--- a/api/schemas/responses.py
+++ b/api/schemas/responses.py
@@ -112,6 +112,36 @@ class ExcludedCandidateOut(BaseModel):
     reason: str
 
 
+class SampleQCOut(BaseModel):
+    """Sample quality verdict for the submitted specimen.
+
+    Mirrors ``services.sample_qc.sample_qc_to_report_dict``. Until now this
+    reached the rendered oncologist report and stopped there, so an API consumer
+    (including ``web/``) could not tell a clean sample from one carrying a
+    high-confidence FFPE deamination signal.
+
+    ``qc_verdict`` is never null. A submission processed before QC existed, or
+    one where QC could not run, reports ``NOT_ASSESSED`` — the hazard this guards
+    is a reader taking silence for a pass, so the field is always present and
+    every unmeasured value stays ``None`` rather than defaulting to zero.
+    """
+    qc_verdict: str = "NOT_ASSESSED"
+    assessed: bool = False
+    tumour_purity_estimate: Optional[float] = None
+    ffpe_artefact_rate: Optional[float] = None
+    ffpe_suspected: Optional[bool] = None
+    ti_tv_ratio: Optional[float] = None
+    median_vaf: Optional[float] = None
+    total_variants: Optional[int] = None
+    pass_variants: Optional[int] = None
+    mean_depth: Optional[float] = None
+    warnings: list[str] = Field(default_factory=list)
+    # Audit fields: the score behind the flag, not just the flag.
+    ffpe_score: Optional[float] = None
+    ffpe_confidence: Optional[str] = None
+    coverage_adequacy: Optional[str] = None
+
+
 class ResultsResponse(BaseModel):
     submission_id: str
     cancer_type: Optional[str] = None
@@ -140,3 +170,6 @@ class ResultsResponse(BaseModel):
     # Distinguishes "we looked and found nothing" from "we never looked".
     recommendation_state: Optional[str] = None
     excluded_candidates: list[ExcludedCandidateOut] = Field(default_factory=list)
+    # Always present. NOT_ASSESSED when the submission carries no verdict, so a
+    # consumer cannot render "no QC problems" for a sample nobody checked.
+    sample_qc: SampleQCOut = Field(default_factory=SampleQCOut)

--- a/api/services/sample_qc.py
+++ b/api/services/sample_qc.py
@@ -542,3 +542,27 @@ def sample_qc_to_report_dict(report: SampleQCReport) -> dict:
         "ffpe_confidence": report.ffpe.confidence,
         "coverage_adequacy": report.coverage.coverage_adequacy,
     }
+
+
+# Verdict reported when a submission carries no stored QC at all. Distinct from
+# every real verdict so no consumer can map it onto "PASS" by accident.
+QC_NOT_ASSESSED = "NOT_ASSESSED"
+
+
+def qc_payload_for_api(stored: dict | None) -> dict:
+    """Shape a stored ``submissions.sample_qc`` value for the results API.
+
+    The stored dict already has the right keys; this adds the two things an API
+    consumer needs that the report renderer did not. ``assessed`` says whether
+    anybody actually ran QC, and a missing verdict becomes ``NOT_ASSESSED``
+    rather than absent, so a client that renders "no warnings" for an empty
+    payload cannot present an unchecked sample as a clean one.
+    """
+    if not stored:
+        return {"qc_verdict": QC_NOT_ASSESSED, "assessed": False, "warnings": []}
+
+    payload = dict(stored)
+    payload["assessed"] = True
+    payload.setdefault("qc_verdict", QC_NOT_ASSESSED)
+    payload["warnings"] = list(payload.get("warnings") or [])
+    return payload

--- a/api/tests/test_genomic_worker_qc_persistence.py
+++ b/api/tests/test_genomic_worker_qc_persistence.py
@@ -1,0 +1,232 @@
+"""The genomic worker must actually write the QC verdict to the submission.
+
+`test_sample_qc_persistence.py` pins the adapter and the renderer: given a
+`SampleQCReport`, the right keys come out and a missing verdict never reads as a
+passing one. It does not run the worker, so it cannot see the failure mode that
+produced F10 in the first place — a control that is implemented, unit-tested and
+benchmarked, and never called.
+
+That is the whole lesson of F9/F10: validation shows a control works, only
+tracing the call path shows it runs. So these tests drive `run_genomic_pipeline`
+end to end, with MinIO, Nextflow and the downstream Celery task stubbed and a
+real SQLite session underneath, and assert against the row the worker leaves
+behind. If someone deletes the persistence line, the adapter tests stay green
+and these go red.
+"""
+from __future__ import annotations
+
+import sys
+import types
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+for _path in (str(_REPO_ROOT), str(_REPO_ROOT / "api")):
+    if _path not in sys.path:
+        sys.path.insert(0, _path)
+
+
+def _load_genomic_worker():
+    """Import the worker with a no-op Celery decorator, as ai_worker tests do."""
+    fake_workers = types.ModuleType("workers")
+    mock_celery = MagicMock()
+    mock_celery.task.return_value = lambda fn: fn
+    fake_workers.celery_app = mock_celery
+    sys.modules.setdefault("workers", fake_workers)
+    sys.modules["workers"].celery_app = mock_celery  # type: ignore[assignment]
+
+    import workers.genomic_worker as mod  # noqa: PLC0415
+    return mod
+
+
+_gw = _load_genomic_worker()
+
+from database import Base  # noqa: E402
+from models.submission import Submission, SubmissionStatus  # noqa: E402
+from services.oncologist_report import _format_qc  # noqa: E402
+from services.sample_qc import qc_payload_for_api  # noqa: E402
+
+_HEADER = "##fileformat=VCFv4.2\n#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tSAMPLE\n"
+
+
+def _write_vcf(tmp_path: Path, body: str, name: str = "out.vcf") -> str:
+    path = tmp_path / name
+    path.write_text(_HEADER + body, encoding="utf-8")
+    return str(path)
+
+
+def _clean_vcf(tmp_path: Path) -> str:
+    """Balanced substitutions at clonal VAF — nothing for QC to complain about."""
+    rows = []
+    for i in range(30):
+        ref, alt = ("A", "G") if i % 2 == 0 else ("A", "T")
+        rows.append(f"1\t{1000 + i * 100}\t.\t{ref}\t{alt}\t99\tPASS\t.\tGT:DP:AD\t0/1:200:100,100\n")
+    return _write_vcf(tmp_path, "".join(rows), "clean.vcf")
+
+
+def _ffpe_vcf(tmp_path: Path) -> str:
+    """Low-VAF C>T throughout: the cytosine-deamination signature FFPE leaves."""
+    rows = [
+        f"1\t{2000 + i * 100}\t.\tC\tT\t99\tPASS\t.\tGT:DP:AD\t0/1:500:490,10\n"
+        for i in range(40)
+    ]
+    return _write_vcf(tmp_path, "".join(rows), "ffpe.vcf")
+
+
+@pytest.fixture()
+def db_sessionmaker(tmp_path):
+    """A real SQLite DB with the real schema, so the JSON column is exercised."""
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'worker.db'}",
+        connect_args={"check_same_thread": False},
+    )
+    Base.metadata.create_all(engine)
+    yield sessionmaker(bind=engine, autocommit=False, autoflush=False, expire_on_commit=False)
+    engine.dispose()
+
+
+@pytest.fixture()
+def run_pipeline(monkeypatch, db_sessionmaker, tmp_path):
+    """Drive run_genomic_pipeline with everything external stubbed out.
+
+    Returns a callable taking the VCF the "pipeline" produced, and giving back
+    the persisted Submission row.
+    """
+    @contextmanager
+    def _session():
+        session = db_sessionmaker()
+        try:
+            yield session
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+    fake_db_sync = types.ModuleType("workers._db_sync")
+    fake_db_sync.get_sync_session = _session
+    monkeypatch.setitem(sys.modules, "workers._db_sync", fake_db_sync)
+
+    fake_ai_worker = types.ModuleType("workers.ai_worker")
+    fake_ai_worker.run_ai_analysis = MagicMock()
+    fake_ai_worker.run_ai_analysis.apply_async.return_value = MagicMock(id="ai-job-1")
+    monkeypatch.setitem(sys.modules, "workers.ai_worker", fake_ai_worker)
+
+    monkeypatch.setattr(_gw, "_download_from_minio", lambda *a, **k: str(tmp_path / "in.dna"))
+    monkeypatch.setattr(_gw, "_upload_vcf_to_minio", lambda *a, **k: "s3/annotated.vcf")
+
+    def _run(vcf_path: str, submission_id: str = "sub-1") -> Submission:
+        monkeypatch.setattr(_gw, "_run_nextflow_pipeline", lambda *a, **k: vcf_path)
+
+        with _session() as db:
+            db.add(
+                Submission(
+                    id=submission_id,
+                    patient_id="pt-1",
+                    cancer_type="Lung Adenocarcinoma",
+                    status=SubmissionStatus.queued,
+                )
+            )
+
+        # No `self`: whether the task is a bound Celery task or the bare
+        # function, the caller passes only the business arguments.
+        _gw.run_genomic_pipeline(
+            submission_id=submission_id,
+            patient_id="pt-1",
+            biopsy_s3_key="s3/biopsy.txt",
+            dna_s3_key="s3/dna.vcf",
+            cancer_type="Lung Adenocarcinoma",
+        )
+
+        with _session() as db:
+            return db.get(Submission, submission_id)
+
+    return _run
+
+
+class TestTheWorkerPersistsTheVerdict:
+    def test_a_verdict_is_written_at_all(self, run_pipeline, tmp_path):
+        submission = run_pipeline(_clean_vcf(tmp_path))
+        assert submission.sample_qc is not None, (
+            "the worker ran QC but persisted nothing — this is exactly F10, where "
+            "the control ran and no reader could ever see the answer"
+        )
+        assert submission.sample_qc["qc_verdict"] in {"PASS", "WARN", "FAIL"}
+
+    def test_the_submission_still_advances(self, run_pipeline, tmp_path):
+        """QC is advisory: it records a verdict without derailing the analysis."""
+        submission = run_pipeline(_clean_vcf(tmp_path))
+        assert submission.status == SubmissionStatus.awaiting_ai
+        assert submission.vcf_s3_key == "s3/annotated.vcf"
+
+    def test_the_persisted_dict_has_every_key_the_report_reads(self, run_pipeline, tmp_path):
+        submission = run_pipeline(_ffpe_vcf(tmp_path))
+        required = {
+            "qc_verdict", "tumour_purity_estimate", "ffpe_artefact_rate",
+            "ffpe_suspected", "ti_tv_ratio", "median_vaf", "total_variants",
+            "pass_variants", "mean_depth", "warnings",
+        }
+        assert required <= set(submission.sample_qc)
+
+    def test_the_persisted_value_survives_a_json_round_trip(self, run_pipeline, tmp_path):
+        """It goes through a real JSON column, so it must contain no exotic types."""
+        submission = run_pipeline(_clean_vcf(tmp_path))
+        assert isinstance(submission.sample_qc, dict)
+        assert isinstance(submission.sample_qc["warnings"], list)
+
+
+class TestTheFFPESignalReachesTheReader:
+    """The point of the whole chain: a bad sample must not look like a good one."""
+
+    def test_an_ffpe_sample_is_flagged_in_the_persisted_row(self, run_pipeline, tmp_path):
+        submission = run_pipeline(_ffpe_vcf(tmp_path))
+        assert submission.sample_qc["ffpe_suspected"] is True
+
+    def test_clean_and_ffpe_submissions_do_not_persist_identically(self, run_pipeline, tmp_path):
+        clean = run_pipeline(_clean_vcf(tmp_path), submission_id="sub-clean")
+        ffpe = run_pipeline(_ffpe_vcf(tmp_path), submission_id="sub-ffpe")
+        assert clean.sample_qc != ffpe.sample_qc
+
+    def test_the_flag_survives_all_the_way_into_the_rendered_section(self, run_pipeline, tmp_path):
+        clean = run_pipeline(_clean_vcf(tmp_path), submission_id="sub-clean")
+        ffpe = run_pipeline(_ffpe_vcf(tmp_path), submission_id="sub-ffpe")
+        assert _format_qc(clean.sample_qc) != _format_qc(ffpe.sample_qc)
+
+    def test_the_flag_survives_into_the_api_payload(self, run_pipeline, tmp_path):
+        submission = run_pipeline(_ffpe_vcf(tmp_path))
+        payload = qc_payload_for_api(submission.sample_qc)
+        assert payload["assessed"] is True
+        assert payload["ffpe_suspected"] is True
+
+
+class TestFailureNeverReadsAsAPass:
+    def test_qc_blowing_up_leaves_the_column_null(self, run_pipeline, monkeypatch, tmp_path):
+        """A crashed check must persist nothing, not an empty passing-looking dict."""
+        def _boom(_path):
+            raise RuntimeError("detector exploded")
+
+        monkeypatch.setattr("services.sample_qc.run_sample_qc", _boom)
+        submission = run_pipeline(_clean_vcf(tmp_path))
+
+        assert submission.sample_qc is None
+        assert submission.status == SubmissionStatus.awaiting_ai, (
+            "QC is advisory — a QC failure must not discard a real analysis"
+        )
+
+    def test_a_null_column_reports_as_not_assessed(self, run_pipeline, monkeypatch, tmp_path):
+        def _boom(_path):
+            raise RuntimeError("detector exploded")
+
+        monkeypatch.setattr("services.sample_qc.run_sample_qc", _boom)
+        submission = run_pipeline(_clean_vcf(tmp_path))
+
+        payload = qc_payload_for_api(submission.sample_qc)
+        assert payload["qc_verdict"] == "NOT_ASSESSED"
+        assert payload["assessed"] is False
+        assert payload["qc_verdict"] != "PASS"

--- a/api/workers/genomic_worker.py
+++ b/api/workers/genomic_worker.py
@@ -43,6 +43,7 @@ def run_genomic_pipeline(
     from workers._db_sync import get_sync_session
     from models.submission import Submission, SubmissionStatus
     from models.mutation import Mutation, MutationClassification, OncoKBLevel
+    from services.sample_qc import sample_qc_to_report_dict
 
     logger.info(f"[genomic] Starting pipeline for submission {submission_id}")
 
@@ -99,8 +100,6 @@ def run_genomic_pipeline(
                 submission.status = SubmissionStatus.awaiting_ai
                 submission.vcf_s3_key = vcf_s3_key
                 if qc_report is not None:
-                    from services.sample_qc import sample_qc_to_report_dict
-
                     submission.sample_qc = sample_qc_to_report_dict(qc_report)
                 db.commit()
 

--- a/docs/risk_analysis.md
+++ b/docs/risk_analysis.md
@@ -252,6 +252,13 @@ Verified present, not merely intended:
   (`scripts/detect_label_circularity.py`, exits non-zero).
 - Unparseable OncoKB levels resolve to `unknown` rather than raising or being
   read as actionable (fail-safe direction).
+- Sample QC verdict returned to API callers as well as to the rendered report
+  (`submissions.sample_qc`, `ResultsResponse.sample_qc`), with "not assessed"
+  rendered distinctly from "passed" in `web/components/SampleQCCard.tsx`.
+- The genomic worker's QC call path is pinned by an integration test that drives
+  `run_genomic_pipeline` and asserts on the persisted row
+  (`api/tests/test_genomic_worker_qc_persistence.py`), so a control that stops
+  being invoked fails a test rather than going quiet.
 
 ---
 

--- a/web/app/results/[id]/page.tsx
+++ b/web/app/results/[id]/page.tsx
@@ -10,6 +10,7 @@ import ResultsSkeleton from "@/components/ResultsSkeleton";
 import ImmunoPanel from "@/components/ImmunoPanel";
 import SignatureCard from "@/components/SignatureCard";
 import CombinationTable from "@/components/CombinationTable";
+import SampleQCCard, { type SampleQC } from "@/components/SampleQCCard";
 import { DEMO_RESULTS, DEMO_REPURPOSING, DEMO_ID } from "@/lib/demo-data";
 
 type MutationRow = {
@@ -145,6 +146,9 @@ export default function ResultsPage({ params }: { params: { id: string } }) {
 	const trialMatches = (trialQuery.data?.trials || []) as TrialRow[];
 	const repurposingFailed = !repurposingQuery.isLoading && candidates.length === 0;
 	const hasActionable = Boolean(data.has_targetable_mutation || mutations.some((m) => m.is_targetable));
+	// Always rendered. The API always sends this, and an absent verdict must be
+	// stated rather than omitted — silence reads as "no problems found".
+	const sampleQC = (data.sample_qc || { qc_verdict: "NOT_ASSESSED", assessed: false }) as SampleQC;
 
 	const patientSummary = (data as {
 		patient_summary?: {
@@ -232,6 +236,9 @@ export default function ResultsPage({ params }: { params: { id: string } }) {
 						</p>
 					</div>
 				</section>
+
+				{/* Sample quality qualifies every finding below it, so it comes first. */}
+				<SampleQCCard qc={sampleQC} />
 
 				<section className="clinical-surface p-6">
 					<h2 className="text-lg font-semibold text-gray-900 mb-3">Mutations</h2>

--- a/web/components/SampleQCCard.tsx
+++ b/web/components/SampleQCCard.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import {
+  presentSampleQC,
+  formatPct,
+  formatNum,
+  TONE_CLASSES,
+  type SampleQC,
+} from "@/lib/sample-qc";
+
+export type { SampleQC };
+
+/** "—" when the value was never measured. Zero is a measurement; null is not. */
+function Metric({ label, value }: { label: string; value: string | null }) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white px-3 py-2 dark:bg-slate-900/50">
+      <p className="text-[11px] uppercase tracking-wide text-slate-500">{label}</p>
+      <p className="text-sm font-semibold text-slate-900 dark:text-slate-100">{value ?? "—"}</p>
+    </div>
+  );
+}
+
+export default function SampleQCCard({ qc }: { qc: SampleQC | null | undefined }) {
+  const { tone, label, assessed, warnings } = presentSampleQC(qc);
+  const meanDepth = formatNum(qc?.mean_depth);
+
+  return (
+    <section className="clinical-surface p-6">
+      <div className="flex items-center justify-between gap-3 mb-4 flex-wrap">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-slate-100">Sample Quality</h2>
+        <span
+          className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold ${TONE_CLASSES[tone]}`}
+        >
+          {label}
+        </span>
+      </div>
+
+      {!assessed ? (
+        <p className="text-sm text-slate-600 dark:text-slate-400">
+          No quality check was recorded for this sample. This is <strong>not</strong> a clean
+          result — artefact, purity and coverage problems were never ruled out, so the findings
+          below rest on an unverified specimen.
+        </p>
+      ) : (
+        <>
+          {qc?.ffpe_suspected && (
+            <div className="mb-4 rounded-xl border border-red-200 bg-red-50 p-4">
+              <p className="text-sm font-semibold text-red-900">FFPE artefact signal detected</p>
+              <p className="text-xs text-red-700 mt-1">
+                Fixation-induced cytosine deamination can imitate low-frequency somatic variants.
+                Confirm any low-VAF finding on an orthogonal assay before acting on it.
+                {qc.ffpe_confidence ? ` Detector confidence: ${qc.ffpe_confidence}.` : ""}
+              </p>
+            </div>
+          )}
+
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mb-4">
+            <Metric label="Tumour purity" value={formatPct(qc?.tumour_purity_estimate)} />
+            <Metric label="Median VAF" value={formatPct(qc?.median_vaf, 1)} />
+            <Metric label="Mean depth" value={meanDepth === null ? null : `${meanDepth}x`} />
+            <Metric label="Ti/Tv ratio" value={formatNum(qc?.ti_tv_ratio, 2)} />
+            <Metric label="C>T fraction" value={formatPct(qc?.ffpe_artefact_rate, 1)} />
+            <Metric label="Coverage" value={qc?.coverage_adequacy ?? null} />
+          </div>
+
+          {qc?.pass_variants !== null && qc?.pass_variants !== undefined && (
+            <p className="text-xs text-slate-500 mb-3">
+              {qc.pass_variants} of {qc.total_variants ?? "?"} variants passed caller filters
+              {qc.ffpe_score !== null && qc.ffpe_score !== undefined
+                ? ` · FFPE score ${qc.ffpe_score.toFixed(2)}`
+                : ""}
+            </p>
+          )}
+
+          {warnings.length > 0 && (
+            <div className="rounded-xl border border-amber-200 bg-amber-50 p-4">
+              <p className="text-sm font-semibold text-amber-900 mb-1">Quality warnings</p>
+              <ul className="list-disc list-inside text-sm text-amber-800 space-y-1">
+                {warnings.map((w, i) => (
+                  <li key={i}>{w}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </>
+      )}
+    </section>
+  );
+}

--- a/web/lib/__tests__/sample-qc.test.ts
+++ b/web/lib/__tests__/sample-qc.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import {
+  presentSampleQC,
+  formatPct,
+  formatNum,
+  TONE_CLASSES,
+  type SampleQC,
+} from "@/lib/sample-qc";
+
+describe("presentSampleQC", () => {
+  it("maps each real verdict onto its own tone", () => {
+    expect(presentSampleQC({ qc_verdict: "PASS", assessed: true }).tone).toBe("pass");
+    expect(presentSampleQC({ qc_verdict: "WARN", assessed: true }).tone).toBe("warn");
+    expect(presentSampleQC({ qc_verdict: "FAIL", assessed: true }).tone).toBe("fail");
+  });
+
+  it("accepts a lowercase verdict", () => {
+    expect(presentSampleQC({ qc_verdict: "fail", assessed: true }).tone).toBe("fail");
+  });
+
+  // The safety property. Everything below is a way of not having run QC, and
+  // none of them may look like a sample that passed.
+  describe("an unchecked sample never reads as a clean one", () => {
+    const unchecked: Array<[string, SampleQC | null | undefined]> = [
+      ["missing payload", null],
+      ["undefined payload", undefined],
+      ["empty payload", {}],
+      ["explicit NOT_ASSESSED", { qc_verdict: "NOT_ASSESSED", assessed: false }],
+      ["UNKNOWN verdict", { qc_verdict: "UNKNOWN" }],
+      ["unrecognised verdict", { qc_verdict: "SOMETHING_NEW", assessed: true }],
+      ["verdict says PASS but assessed is false", { qc_verdict: "PASS", assessed: false }],
+    ];
+
+    it.each(unchecked)("%s is not assessed and not styled as a pass", (_name, qc) => {
+      const p = presentSampleQC(qc);
+      expect(p.assessed).toBe(false);
+      expect(p.tone).not.toBe("pass");
+      expect(p.label).toBe("Sample QC not assessed");
+      expect(TONE_CLASSES[p.tone]).not.toContain("green");
+    });
+  });
+
+  it("does not claim FFPE was ruled out when nothing was measured", () => {
+    const qc: SampleQC = {};
+    expect(qc.ffpe_suspected).toBeUndefined();
+    expect(presentSampleQC(qc).warnings).toEqual([]);
+  });
+
+  it("carries warnings through unchanged", () => {
+    const warnings = ["Coverage low: 40% of variants below 30x"];
+    expect(presentSampleQC({ qc_verdict: "WARN", assessed: true, warnings }).warnings).toEqual(warnings);
+  });
+
+  it("gives a pass its green treatment only when QC actually ran", () => {
+    const p = presentSampleQC({ qc_verdict: "PASS", assessed: true });
+    expect(p.assessed).toBe(true);
+    expect(TONE_CLASSES[p.tone]).toContain("green");
+  });
+});
+
+describe("formatters keep unmeasured distinct from zero", () => {
+  it("renders null and undefined as null, not as 0", () => {
+    expect(formatPct(null)).toBeNull();
+    expect(formatPct(undefined)).toBeNull();
+    expect(formatNum(null)).toBeNull();
+    expect(formatNum(undefined)).toBeNull();
+  });
+
+  it("renders a real zero as a measurement", () => {
+    expect(formatPct(0)).toBe("0%");
+    expect(formatNum(0)).toBe("0.0");
+  });
+
+  it("formats values at the requested precision", () => {
+    expect(formatPct(0.4237, 1)).toBe("42.4%");
+    expect(formatNum(2.345, 2)).toBe("2.35");
+  });
+});

--- a/web/lib/sample-qc.ts
+++ b/web/lib/sample-qc.ts
@@ -1,0 +1,94 @@
+/**
+ * Sample QC presentation rules.
+ *
+ * The logic lives here rather than in the component because one rule is a
+ * safety property, not a styling choice: a sample nobody checked must never
+ * render like a sample that passed. Keeping it in lib/ puts it inside the
+ * Vitest boundary so that property is pinned by a test.
+ */
+
+export type SampleQC = {
+  qc_verdict?: string;
+  assessed?: boolean;
+  tumour_purity_estimate?: number | null;
+  ffpe_artefact_rate?: number | null;
+  ffpe_suspected?: boolean | null;
+  ti_tv_ratio?: number | null;
+  median_vaf?: number | null;
+  total_variants?: number | null;
+  pass_variants?: number | null;
+  mean_depth?: number | null;
+  warnings?: string[];
+  ffpe_score?: number | null;
+  ffpe_confidence?: string | null;
+  coverage_adequacy?: string | null;
+};
+
+export type QCTone = "pass" | "warn" | "fail" | "unassessed";
+
+export type QCPresentation = {
+  verdict: string;
+  tone: QCTone;
+  label: string;
+  /** False whenever QC did not actually run, so the UI shows the caveat instead of metrics. */
+  assessed: boolean;
+  warnings: string[];
+};
+
+const TONE_BY_VERDICT: Record<string, QCTone> = {
+  PASS: "pass",
+  WARN: "warn",
+  FAIL: "fail",
+  NOT_ASSESSED: "unassessed",
+  UNKNOWN: "unassessed",
+};
+
+const LABEL_BY_TONE: Record<QCTone, string> = {
+  pass: "Sample QC passed",
+  warn: "Sample QC warning",
+  fail: "Sample QC failed",
+  unassessed: "Sample QC not assessed",
+};
+
+/** Tailwind classes per tone. `unassessed` is deliberately neutral, never green. */
+export const TONE_CLASSES: Record<QCTone, string> = {
+  pass: "bg-green-100 text-green-800 border-green-200",
+  warn: "bg-amber-100 text-amber-800 border-amber-200",
+  fail: "bg-red-100 text-red-800 border-red-200",
+  unassessed: "bg-slate-100 text-slate-600 border-slate-300",
+};
+
+/**
+ * Resolve a stored QC payload into what the UI should say about it.
+ *
+ * An unrecognised verdict resolves to `unassessed`, not to `pass`: failing
+ * towards "we do not know" is the safe direction when the sample's quality
+ * qualifies every treatment recommendation shown beneath it.
+ */
+export function presentSampleQC(qc: SampleQC | null | undefined): QCPresentation {
+  const verdict = (qc?.qc_verdict || "NOT_ASSESSED").toUpperCase();
+  const verdictTone = TONE_BY_VERDICT[verdict] ?? "unassessed";
+  // `assessed: false` from the API wins over the verdict string. A payload can
+  // carry a stale or default "PASS" while saying QC never ran, and the tone has
+  // to follow the weaker of the two claims, not the more reassuring one.
+  const assessed = verdictTone !== "unassessed" && qc?.assessed !== false;
+  const tone: QCTone = assessed ? verdictTone : "unassessed";
+
+  return {
+    verdict,
+    tone,
+    label: LABEL_BY_TONE[tone],
+    assessed,
+    warnings: qc?.warnings ?? [],
+  };
+}
+
+/** Percentage, or null when the value was never measured. Zero is a measurement. */
+export function formatPct(v?: number | null, digits = 0): string | null {
+  return v === null || v === undefined ? null : `${(v * 100).toFixed(digits)}%`;
+}
+
+/** Fixed-point number, or null when never measured. */
+export function formatNum(v?: number | null, digits = 1): string | null {
+  return v === null || v === undefined ? null : v.toFixed(digits);
+}


### PR DESCRIPTION
Follow-up to #99, which persisted the QC verdict. It reached `generate_oncologist_report` and stopped there.

A grep for `sample_qc` outside the model and the service found exactly two call sites, both passing it into the report generator, and **nothing** in `api/schemas/`, the GraphQL layer, or `web/`. So the PDF could say a sample carried a high-confidence FFPE deamination signal while every API consumer  including our own results page  had no way to know.

## API

`ResultsResponse.sample_qc` is always present. A submission with no stored QC returns `qc_verdict: "NOT_ASSESSED"` rather than `null`. A client that renders "no warnings" for an empty payload would otherwise present an unchecked sample as a clean one the same hazard the nullable column was chosen to avoid, reintroduced one layer up.

## UI

`SampleQCCard` renders above the mutations table, because sample quality qualifies every finding beneath it. The not-assessed state gets its own copy saying artefact, purity and coverage were never ruled out, and a neutral treatment that is never green.

The verdict→tone rule lives in `web/lib/sample-qc.ts`, not in the component: vitest only collects `lib/**`, and this is a safety property that needs a test rather than a styling choice.

**Writing that test found a real defect.** Tone was derived from the verdict string alone, so a payload carrying `qc_verdict: "PASS"` with `assessed: false` rendered **green**. `assessed` now gates the tone, and an unrecognised verdict resolves to not-assessed rather than to pass.

## The second commit: pinning the call path

`test_sample_qc_persistence.py` checks the adapter. It never runs the worker, so it cannot see the failure mode that created F10 in the first place a control that is implemented, unit-tested, benchmarked, and never called.

**That gap is measurable.** Deleting the persistence assignment from `run_genomic_pipeline` leaves all 15 adapter tests green. The verdict silently stops reaching the report and nothing fails.

The 10 new tests drive `run_genomic_pipeline` end to end (MinIO, Nextflow and the downstream Celery task stubbed, real SQLite underneath) and assert on the row the worker leaves behind including that a crashed detector leaves the column NULL rather than an empty dict that reads as a pass. Re-running the deletion now turns **7 of them red**.

## Verification

- 40 backend tests green (worker + adapter + routes), ruff clean
- 15 vitest tests, `tsc --noEmit` and eslint clean

. **#103 stacks on this**