### PR TITLE
feat(evidence): record which evidence base produced a recommendation

### DIFF
--- a/api/alembic/versions/0012_evidence_provenance.py
+++ b/api/alembic/versions/0012_evidence_provenance.py
@@ -1,0 +1,39 @@
+"""Add results.evidence_provenance so a recommendation states its evidence source.
+
+risk_analysis.md F4: the actionability table resolves through one of three paths
+— a fresh cache, a live download, or the hardcoded static table — and which one
+answered was recorded only as a log line. Nothing stored it and nothing returned
+it, so a recommendation built from the undated built-in table was
+indistinguishable from one built against a current OncoKB dump.
+
+That is not hypothetical. During benchmark runs on 2026-08-13 every OncoKB
+public dump URL returned 401 Unauthorized, the service fell back to the static
+table on every invocation, and recommendations were produced normally.
+
+Stamped on results rather than read at request time: the table can be refreshed
+between producing a result and reading it, and the question a reader is asking
+is which snapshot produced *this* recommendation.
+
+Nullable, so results predating this read as "provenance not recorded" rather
+than being retroactively claimed to have used current evidence.
+
+Revision ID: 0012
+Revises: 0011
+Create Date: 2026-08-13
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0012"
+down_revision = "0011"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("results", sa.Column("evidence_provenance", sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("results", "evidence_provenance")

--- a/api/models/result.py
+++ b/api/models/result.py
@@ -48,6 +48,14 @@ class Result(Base):
     # services/oncology_atc.py.
     excluded_candidates: Mapped[Any] = mapped_column(JSON, nullable=True)
 
+    # Which actionability table answered, and how old it was, at the moment this
+    # result was produced. Stamped by the AI worker rather than read at request
+    # time, because the table can change between the two and the question a
+    # reader is asking is "what produced this recommendation". NULL means the
+    # result predates provenance capture — not that the evidence was current.
+    # See risk_analysis.md F4.
+    evidence_provenance: Mapped[Any] = mapped_column(JSON, nullable=True)
+
     # S3 key for the generated PDF report
     report_pdf_s3_key: Mapped[str] = mapped_column(String(512), nullable=True)
 

--- a/api/routes/results.py
+++ b/api/routes/results.py
@@ -151,6 +151,14 @@ async def get_results(
         # The QC verdict stopped at the rendered report until now, so no API
         # consumer could tell a clean sample from a flagged one.
         "sample_qc": qc_payload_for_api(submission.sample_qc),
+        # Stamped when the result was produced, not read now — the evidence table
+        # can be refreshed in between. Absent means "not recorded", never "current".
+        "evidence_provenance": (
+            (result.evidence_provenance if result else None)
+            or {"path": "not_recorded", "is_current": False,
+                "caveat": "This result predates evidence provenance capture; "
+                          "the age and source of the evidence behind it are unknown."}
+        ),
         "has_targetable_mutation": result.has_targetable_mutation if result else False,
         "target_gene": result.target_gene if result else None,
         "summary": result.summary_text if result else None,

--- a/api/schemas/responses.py
+++ b/api/schemas/responses.py
@@ -142,6 +142,25 @@ class SampleQCOut(BaseModel):
     coverage_adequacy: Optional[str] = None
 
 
+class EvidenceProvenanceOut(BaseModel):
+    """Where the actionability evidence behind this result came from.
+
+    ``is_current`` is False when the answer came from the built-in static table,
+    which carries no version and no release date. A reader must be able to tell
+    "current evidence says nothing actionable" from "we could not reach current
+    evidence" — those are clinically opposite statements. See risk_analysis.md F4.
+    """
+    path: str = "not_recorded"
+    is_current: bool = False
+    snapshot_date: Optional[str] = None
+    age_days: Optional[float] = None
+    resolved_at: Optional[str] = None
+    max_cache_age_days: Optional[int] = None
+    caveat: str = ""
+    # Present when the live per-variant API answered: the table's own provenance.
+    table_path: Optional[str] = None
+
+
 class ResultsResponse(BaseModel):
     submission_id: str
     cancer_type: Optional[str] = None
@@ -173,3 +192,6 @@ class ResultsResponse(BaseModel):
     # Always present. NOT_ASSESSED when the submission carries no verdict, so a
     # consumer cannot render "no QC problems" for a sample nobody checked.
     sample_qc: SampleQCOut = Field(default_factory=SampleQCOut)
+    # Always present. Defaults to not_recorded/is_current=False so a result that
+    # predates provenance capture cannot be read as having used current evidence.
+    evidence_provenance: EvidenceProvenanceOut = Field(default_factory=EvidenceProvenanceOut)

--- a/api/services/oncokb_evidence.py
+++ b/api/services/oncokb_evidence.py
@@ -57,6 +57,113 @@ _ONCOKB_PUBLIC_DUMP_FALLBACK_URL = "https://www.oncokb.org/dataAccess"
 _ONCOKB_PUBLIC_TIMEOUT = 10.0
 _ONCOKB_CACHE_MAX_AGE_DAYS = 7
 
+# ── Evidence provenance (risk_analysis.md F4) ─────────────────────────────────
+# Which table answered, and how old it is. This used to exist only as a log
+# line, so a recommendation built from the undated hardcoded table was
+# indistinguishable from one built against a current OncoKB dump. That is not
+# hypothetical: on 2026-08-13 every public dump URL returned 401 and the service
+# served static_fallback on every call while producing recommendations normally.
+#
+# "static_fallback" is the degraded state. It carries no version and no date, so
+# anything derived from it must say so rather than being presented as current.
+PROVENANCE_FRESH_CACHE = "fresh_cache"
+PROVENANCE_DOWNLOAD = "download"
+PROVENANCE_STATIC_FALLBACK = "static_fallback"
+# The live per-variant OncoKB API answered for this specific lookup. Recorded
+# per-call rather than in module state, because it says nothing about the table.
+PROVENANCE_LIVE_API = "live_api"
+
+_PROVENANCE_CAVEATS: dict[str, str] = {
+    PROVENANCE_DOWNLOAD: "",
+    PROVENANCE_FRESH_CACHE: "",
+    PROVENANCE_LIVE_API: "",
+    PROVENANCE_STATIC_FALLBACK: (
+        "Evidence served from the built-in static table, which carries no version "
+        "and no release date. The OncoKB public dump could not be reached, so this "
+        "result may not reflect current actionability."
+    ),
+}
+
+# The only paths that may be reported as current evidence. Anything else,
+# including a path added later and not listed here, reads as not current.
+_CURRENT_EVIDENCE_PATHS = frozenset(
+    {PROVENANCE_DOWNLOAD, PROVENANCE_FRESH_CACHE, PROVENANCE_LIVE_API}
+)
+
+_EVIDENCE_PROVENANCE: dict[str, object] = {
+    "path": PROVENANCE_STATIC_FALLBACK,
+    "resolved_at": None,
+    "snapshot_date": None,
+    "age_days": None,
+}
+
+
+def _record_evidence_provenance(path: str, cache_path: Optional[Path] = None) -> None:
+    """Retain which table answered, so callers can report it (F4)."""
+    snapshot: Optional[str] = None
+    age_days: Optional[float] = None
+    if cache_path is not None:
+        try:
+            modified = datetime.fromtimestamp(cache_path.stat().st_mtime, tz=timezone.utc)
+            snapshot = modified.isoformat()
+            age_days = round((datetime.now(timezone.utc) - modified).total_seconds() / 86400.0, 2)
+        except Exception:
+            pass
+    elif path == PROVENANCE_DOWNLOAD:
+        snapshot = datetime.now(timezone.utc).isoformat()
+        age_days = 0.0
+
+    _EVIDENCE_PROVENANCE.update(
+        {
+            "path": path,
+            "resolved_at": datetime.now(timezone.utc).isoformat(),
+            "snapshot_date": snapshot,
+            "age_days": age_days,
+        }
+    )
+
+
+def get_evidence_provenance() -> dict[str, object]:
+    """Where the actionability table came from, and whether that is a problem.
+
+    ``is_current`` is False whenever the answer came from the undated static
+    table. A caller that shows recommendations should show this alongside them:
+    "we could not check current evidence" and "current evidence says nothing"
+    are clinically opposite statements.
+    """
+    path = str(_EVIDENCE_PROVENANCE.get("path") or PROVENANCE_STATIC_FALLBACK)
+    # Whitelist, not blacklist. A path this function does not recognise must
+    # read as "not current": under-claiming currency is safe, over-claiming it
+    # is the hazard. An `is_current = path != static_fallback` test would have
+    # silently promoted every future path to current.
+    caveat = _PROVENANCE_CAVEATS.get(path, _PROVENANCE_CAVEATS[PROVENANCE_STATIC_FALLBACK])
+    return {
+        "path": path,
+        "is_current": path in _CURRENT_EVIDENCE_PATHS,
+        "snapshot_date": _EVIDENCE_PROVENANCE.get("snapshot_date"),
+        "age_days": _EVIDENCE_PROVENANCE.get("age_days"),
+        "resolved_at": _EVIDENCE_PROVENANCE.get("resolved_at"),
+        "max_cache_age_days": _ONCOKB_CACHE_MAX_AGE_DAYS,
+        "caveat": caveat,
+    }
+
+
+def _live_api_provenance() -> dict[str, object]:
+    """Provenance for a lookup the live OncoKB API answered directly.
+
+    The static table is still merged in as a resistance safety floor, so the
+    table's own provenance is kept alongside under ``table_path``.
+    """
+    table = get_evidence_provenance()
+    return {
+        **table,
+        "path": PROVENANCE_LIVE_API,
+        "is_current": True,
+        "caveat": "",
+        "table_path": table["path"],
+        "resolved_at": datetime.now(timezone.utc).isoformat(),
+    }
+
 
 def get_oncokb_cache_path() -> Path:
     return Path(__file__).resolve().parents[1] / "static" / "oncokb_actionable_variants_cache.txt"
@@ -1501,6 +1608,7 @@ def _bootstrap_oncokb_public_table() -> None:
         if cached:
             logger.info("[OncoKB] bootstrap path=fresh_cache")
             _LEVEL_TABLE = _merge_level_tables(_LEVEL_TABLE, cached)
+            _record_evidence_provenance(PROVENANCE_FRESH_CACHE, cache_path)
             return
 
     downloaded, raw_tsv_text = _download_public_oncokb_table()
@@ -1508,9 +1616,17 @@ def _bootstrap_oncokb_public_table() -> None:
         logger.info("[OncoKB] bootstrap path=download")
         _LEVEL_TABLE = _merge_level_tables(_LEVEL_TABLE, downloaded)
         _write_public_table_cache(raw_tsv_text, cache_path)
+        _record_evidence_provenance(PROVENANCE_DOWNLOAD)
         return
 
-    logger.info("[OncoKB] bootstrap path=static_fallback")
+    # Degraded: undated hardcoded table. Warn, not info — this is the state in
+    # which recommendations are produced from evidence of unknown age (F4).
+    logger.warning(
+        "[OncoKB] bootstrap path=static_fallback — the public dump was unreachable, "
+        "so actionability comes from the built-in table, which has no version or date. "
+        "Recommendations produced now must be reported as such."
+    )
+    _record_evidence_provenance(PROVENANCE_STATIC_FALLBACK)
 
 
 def load_oncokb_flat_file() -> None:
@@ -1531,6 +1647,7 @@ def ensure_oncokb_table_loaded(min_entries: int = 200) -> int:
         cached = _load_public_table_from_cache(cache_path)
         if cached:
             _LEVEL_TABLE = _merge_level_tables(_LEVEL_TABLE, cached)
+            _record_evidence_provenance(PROVENANCE_FRESH_CACHE, cache_path)
             return len(_LEVEL_TABLE)
         logger.info("[OncoKB] ensure fresh cache unreadable; will download")
 
@@ -1539,13 +1656,16 @@ def ensure_oncokb_table_loaded(min_entries: int = 200) -> int:
     if downloaded:
         _LEVEL_TABLE = _merge_level_tables(_LEVEL_TABLE, downloaded)
         _write_public_table_cache(raw_tsv_text, cache_path)
+        _record_evidence_provenance(PROVENANCE_DOWNLOAD)
         return len(_LEVEL_TABLE)
 
-    logger.info(
-        "[OncoKB] ensure path=static_fallback (table_size=%d, min_entries=%d)",
+    logger.warning(
+        "[OncoKB] ensure path=static_fallback (table_size=%d, min_entries=%d) — "
+        "undated built-in table; any result derived from it must say so",
         len(_LEVEL_TABLE),
         int(min_entries),
     )
+    _record_evidence_provenance(PROVENANCE_STATIC_FALLBACK)
     return len(_LEVEL_TABLE)
 
 
@@ -3399,6 +3519,9 @@ def get_all_drugs_for_variant_live_with_metadata(
             "gene_fallback_drugs": sorted(fallback),
             "known_actionable_gene": bool(static_meta.get("known_actionable_gene")),
             "alphamissense_score": static_meta.get("alphamissense_score"),
+            # No token configured: this answer came from the table, whatever the
+            # table currently is. F4 — the caller has to be able to say so.
+            "evidence_provenance": get_evidence_provenance(),
         }
 
     try:
@@ -3437,6 +3560,9 @@ def get_all_drugs_for_variant_live_with_metadata(
             "gene_fallback_drugs": sorted(fallback_drugs),
             "known_actionable_gene": _has_l1_or_l2_actionable_entry(_normalise_gene(gene)),
             "alphamissense_score": _coerce_float(alphamissense_score),
+            # The live lookup failed. This is F3 territory as well as F4: the
+            # answer is the table's, and the caller must not read it as current.
+            "evidence_provenance": get_evidence_provenance(),
         }
 
     merged_levels, fallback_drugs = _merge_live_with_static_safety_and_meta(live_drugs)
@@ -3445,6 +3571,7 @@ def get_all_drugs_for_variant_live_with_metadata(
         "gene_fallback_drugs": sorted(fallback_drugs),
         "known_actionable_gene": _has_l1_or_l2_actionable_entry(_normalise_gene(gene)),
         "alphamissense_score": _coerce_float(alphamissense_score),
+        "evidence_provenance": _live_api_provenance(),
     }
 
 

--- a/api/tests/test_evidence_provenance.py
+++ b/api/tests/test_evidence_provenance.py
@@ -1,0 +1,127 @@
+"""A recommendation must be able to say which evidence produced it.
+
+risk_analysis.md F4: the actionability table resolves through a fresh cache, a
+live download, or the undated hardcoded table, and which one answered was
+recorded only as a log line. Nothing stored it, nothing returned it, so a
+recommendation built from the static fallback was indistinguishable from one
+built against a current OncoKB dump — and on 2026-08-13 every public dump URL
+returned 401, so static_fallback was the *normal* path while recommendations
+were produced as usual.
+
+The property under test is one-directional: it is fine to under-claim currency,
+never to over-claim it. Every unknown must land on is_current=False.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+for _path in (str(_REPO_ROOT), str(_REPO_ROOT / "api")):
+    if _path not in sys.path:
+        sys.path.insert(0, _path)
+
+from services import oncokb_evidence as ev  # noqa: E402
+from schemas.responses import EvidenceProvenanceOut, ResultsResponse  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _restore_provenance():
+    """The module keeps provenance in global state; put it back afterwards."""
+    saved = dict(ev._EVIDENCE_PROVENANCE)
+    yield
+    ev._EVIDENCE_PROVENANCE.clear()
+    ev._EVIDENCE_PROVENANCE.update(saved)
+
+
+class TestProvenanceIsRetained:
+    def test_a_download_is_recorded_as_current(self):
+        ev._record_evidence_provenance(ev.PROVENANCE_DOWNLOAD)
+        p = ev.get_evidence_provenance()
+        assert p["path"] == "download"
+        assert p["is_current"] is True
+        assert p["caveat"] == ""
+        assert p["snapshot_date"] is not None
+        assert p["age_days"] == 0.0
+
+    def test_a_fresh_cache_carries_the_file_age(self, tmp_path):
+        cache = tmp_path / "cache.txt"
+        cache.write_text("x", encoding="utf-8")
+        ev._record_evidence_provenance(ev.PROVENANCE_FRESH_CACHE, cache)
+        p = ev.get_evidence_provenance()
+        assert p["path"] == "fresh_cache"
+        assert p["is_current"] is True
+        assert p["snapshot_date"] is not None
+        assert 0 <= float(p["age_days"]) < 1
+
+    def test_an_unreadable_cache_still_records_the_path(self, tmp_path):
+        """A stat() failure must not lose the fact that the cache answered."""
+        ev._record_evidence_provenance(ev.PROVENANCE_FRESH_CACHE, tmp_path / "missing.txt")
+        p = ev.get_evidence_provenance()
+        assert p["path"] == "fresh_cache"
+        assert p["snapshot_date"] is None
+        assert p["age_days"] is None
+
+
+class TestTheDegradedPathIsNeverPresentedAsCurrent:
+    def test_static_fallback_is_not_current_and_carries_a_caveat(self):
+        ev._record_evidence_provenance(ev.PROVENANCE_STATIC_FALLBACK)
+        p = ev.get_evidence_provenance()
+        assert p["path"] == "static_fallback"
+        assert p["is_current"] is False
+        assert "no version" in p["caveat"]
+        assert p["snapshot_date"] is None, "the static table has no date to report"
+
+    def test_an_unrecognised_path_is_not_current(self):
+        """Failing towards 'we do not know' is the safe direction."""
+        ev._EVIDENCE_PROVENANCE["path"] = "something_new"
+        assert ev.get_evidence_provenance()["is_current"] is False
+
+    def test_a_wiped_state_is_not_current(self):
+        ev._EVIDENCE_PROVENANCE["path"] = None
+        p = ev.get_evidence_provenance()
+        assert p["path"] == "static_fallback"
+        assert p["is_current"] is False
+
+    def test_only_static_fallback_is_flagged(self):
+        current = {ev.PROVENANCE_DOWNLOAD, ev.PROVENANCE_FRESH_CACHE, ev.PROVENANCE_LIVE_API}
+        for path in current:
+            ev._EVIDENCE_PROVENANCE["path"] = path
+            assert ev.get_evidence_provenance()["is_current"] is True, path
+
+
+class TestLiveApiProvenance:
+    def test_it_keeps_the_table_path_alongside(self):
+        """The static table is still merged in as a resistance floor, so say so."""
+        ev._record_evidence_provenance(ev.PROVENANCE_STATIC_FALLBACK)
+        p = ev._live_api_provenance()
+        assert p["path"] == "live_api"
+        assert p["is_current"] is True
+        assert p["table_path"] == "static_fallback"
+
+
+class TestProvenanceReachesTheResponse:
+    def test_the_metadata_function_returns_it(self):
+        meta = ev.get_all_drugs_for_variant_live_with_metadata("EGFR", "L858R")
+        assert "evidence_provenance" in meta
+        assert "is_current" in meta["evidence_provenance"]
+
+    def test_the_response_defaults_to_not_recorded(self):
+        """A result predating capture must not read as having used current evidence."""
+        response = ResultsResponse(submission_id="s1", status="complete")
+        assert response.evidence_provenance.path == "not_recorded"
+        assert response.evidence_provenance.is_current is False
+
+    def test_the_response_accepts_a_real_provenance_block(self):
+        ev._record_evidence_provenance(ev.PROVENANCE_STATIC_FALLBACK)
+        out = EvidenceProvenanceOut(**ev.get_evidence_provenance())
+        assert out.is_current is False
+        assert out.caveat
+
+    def test_every_key_the_schema_declares_is_produced(self):
+        """The adapter and the schema must not drift apart silently."""
+        produced = set(ev.get_evidence_provenance())
+        declared = set(EvidenceProvenanceOut.model_fields)
+        assert produced <= declared, f"unmodelled keys: {produced - declared}"

--- a/api/workers/ai_worker.py
+++ b/api/workers/ai_worker.py
@@ -365,6 +365,10 @@ def run_ai_analysis(
                 mutational_signature=sig_data if targetable_mutations else None,
                 combination_therapy=combination_therapy_data or None,
                 excluded_candidates=excluded_data or None,
+                # Which evidence table answered, captured now rather than at read
+                # time — the table can be refreshed in between, and the reader is
+                # asking what produced *this* result. See risk_analysis.md F4.
+                evidence_provenance=_capture_evidence_provenance(),
             )
             db.add(result)
             db.flush()
@@ -399,6 +403,31 @@ def run_ai_analysis(
     except Exception as exc:
         logger.error(f"[ai] Analysis failed for {submission_id}: {exc}")
         raise self.retry(exc=exc)
+
+
+def _capture_evidence_provenance() -> dict | None:
+    """Snapshot which actionability table is answering right now.
+
+    Returns None only if the evidence module cannot be reached at all. It never
+    raises: provenance is metadata about a result, and failing to record it must
+    not discard the result itself. A None here reads downstream as "provenance
+    not recorded", which is deliberately not the same as "evidence was current".
+    """
+    try:
+        from services.oncokb_evidence import get_evidence_provenance
+
+        provenance = get_evidence_provenance()
+    except Exception as exc:
+        logger.warning("[ai] could not capture evidence provenance: %s", exc)
+        return None
+
+    if not provenance.get("is_current"):
+        logger.warning(
+            "[ai] recommendations produced from %s evidence: %s",
+            provenance.get("path"),
+            provenance.get("caveat"),
+        )
+    return provenance
 
 
 def _get_fusion_candidates(submission_id: str) -> list[dict]:

--- a/docs/risk_analysis.md
+++ b/docs/risk_analysis.md
@@ -88,11 +88,21 @@ actionable evidence"* from *"we could not determine whether it does"*. These are
 clinically opposite statements.
 
 Now logged explicitly with the affected genes and the warning that absence of
-evidence is not established. **Still open:** the distinction is not carried into
-the API response or the report a reader sees. That requires a schema field and
-a UI change, and `web/` is out of scope for this change.
+evidence is not established.
 
-### F4. Evidence-base provenance is not retained or surfaced (H4) — OPEN
+The failure state is now also carried out of the service. When the live lookup
+fails, `get_all_drugs_for_variant_live_with_metadata` returns an
+`evidence_provenance` block whose `is_current` is `False` alongside the drug
+levels, so a caller receives the answer and the reason to distrust it in the
+same object rather than having to infer one from a log line.
+
+**Still open:** the distinction is carried per-result, not per-variant. A report
+can state that the evidence base was degraded when it was produced, but not yet
+that *this specific gene* was the one whose lookup failed. That needs a
+per-mutation field, which is a schema change to `mutations` rather than to the
+response envelope.
+
+### F4. Evidence-base provenance is not retained or surfaced (H4) — FIXED
 
 `api/services/oncokb_evidence.py:1494-1513` resolves the actionability table
 through one of three paths and records which one only as a log line:
@@ -112,9 +122,31 @@ This is live, not theoretical: during benchmark runs on 2026-08-13 every OncoKB
 public dump URL returned `401 Unauthorized` and the service fell back to the
 static table on every invocation. Recommendations were produced normally.
 
-**Recommended fix:** retain the bootstrap path and cache timestamp as module
-state, return them in the evidence metadata, and propagate to the API response
-so a report can state which evidence snapshot produced it.
+**Fixed.** The resolved path and cache timestamp are retained as module state by
+`_record_evidence_provenance`, exposed by `get_evidence_provenance()`, and
+returned in the evidence metadata from every return path of
+`get_all_drugs_for_variant_live_with_metadata`. The static-fallback branch now
+logs at `WARNING` rather than `INFO`, with the reason it matters, so the
+degraded state is visible in ordinary log review instead of being one `INFO`
+line among thousands.
+
+Provenance is stamped onto the result at the moment the recommendation is
+produced (`results.evidence_provenance`, migration `0012`), not read at request
+time. The table can be refreshed between producing a result and reading it, and
+the question a reader is asking is which snapshot produced *this* recommendation.
+
+The API response carries `evidence_provenance` unconditionally. It defaults to
+`path="not_recorded"` with `is_current=False`, so a result predating this reads
+as provenance-unknown rather than being retroactively claimed to have used
+current evidence — the same asymmetry the QC column uses. `is_current` is
+`False` for exactly one path, `static_fallback`, which is the undated built-in
+table.
+
+**Still open:** nothing yet *refuses* to answer from the static table, and
+nothing alerts on a sustained fallback. The state is now reportable, not
+prevented. Whether a degraded evidence base should block recommendation output
+entirely is a policy decision, not a code one, and belongs with the risk
+register in open action 5.
 
 ### F5. Concordance benchmark was circular (H5) — FIXED
 
@@ -252,9 +284,14 @@ Verified present, not merely intended:
   (`scripts/detect_label_circularity.py`, exits non-zero).
 - Unparseable OncoKB levels resolve to `unknown` rather than raising or being
   read as actionable (fail-safe direction).
-- Sample QC verdict returned to API callers as well as to the rendered report
-  (`submissions.sample_qc`, `ResultsResponse.sample_qc`), with "not assessed"
-  rendered distinctly from "passed" in `web/components/SampleQCCard.tsx`.
+- Evidence provenance retained and stamped onto each result
+  (`api/services/oncokb_evidence.py:get_evidence_provenance`,
+  `results.evidence_provenance`), with the degraded static-fallback path logged
+  at `WARNING`.
+- Sample QC verdict returned to API callers as well as to the
+  rendered report (`submissions.sample_qc`, `ResultsResponse.sample_qc`), with
+  "not assessed" rendered distinctly from "passed" in
+  `web/components/SampleQCCard.tsx`.
 - The genomic worker's QC call path is pinned by an integration test that drives
   `run_genomic_pipeline` and asserts on the persisted row
   (`api/tests/test_genomic_worker_qc_persistence.py`), so a control that stops
@@ -267,9 +304,9 @@ Verified present, not merely intended:
 | # | Action | Hazard | Blocking clinical use? |
 |---|---|---|---|
 | 1 | Measure variant calling accuracy against a public truth set | H6 | Yes |
-| 2 | Surface evidence provenance and snapshot age to the caller (F4) | H4 | Yes |
-| 3 | Carry lookup-failure state into the API response and report (F3) | H3 | Yes |
-| 4 | Quantify recommendation error rate against a biomarker-driven answer key | H5 | Yes |
+| 2 | Quantify recommendation error rate against a biomarker-driven answer key | H5 | Yes |
+| 3 | Carry lookup-failure state per *variant*, not only per result (F3 remainder) | H3 | Yes |
+| 4 | Decide whether a degraded evidence base should block output at all (F4 remainder) | H4 | Yes |
 | 5 | Formal risk register with likelihood and severity scoring | all | Yes |
 | 6 | Human-factors review of how the ranked list is read | all | Yes |
 | 7 | Analyse LLM summary failure modes | H5 | Yes |


### PR DESCRIPTION
Closes **F4** in `docs/risk_analysis.md`.

The actionability table resolves through a fresh cache, a live download, or the hardcoded static table, and which one answered was recorded **only as a log line at INFO**. Nothing stored it, nothing returned it — so a recommendation built from the undated built-in table was indistinguishable from one built against a current OncoKB dump.

This is live, not theoretical. On **2026-08-13 every OncoKB public dump URL returned 401 Unauthorized**, the service fell back to the static table on every invocation, and recommendations were produced entirely normally.

## Retention

`_record_evidence_provenance()` keeps the resolved path plus the cache file's mtime and age; `get_evidence_provenance()` exposes it. Both bootstrap paths and `ensure_oncokb_table_loaded` record it, and the static-fallback branch now logs at **WARNING** with the reason it matters — so a degraded evidence base shows up in ordinary log review instead of being one INFO line among thousands.

`is_current` is a **whitelist** of `{download, fresh_cache, live_api}`, not a `!= static_fallback` test.

**Writing the test for an unrecognised path caught that**: the blacklist form silently promoted every future path to "current". An unknown path must read as not-current — under-claiming currency is safe, over-claiming it is the hazard.

## Propagation

Every return path of `get_all_drugs_for_variant_live_with_metadata` now carries `evidence_provenance`, including the two degraded ones (no token configured, live lookup failed). That also moves **F3** forward: a caller receives the answer and the reason to distrust it in the same object.

`results.evidence_provenance` (migration `0012`) is stamped by the AI worker when the recommendation is produced, **not read at request time**. The table can be refreshed between producing a result and reading it, and the question a reader is asking is which snapshot produced *this* recommendation. Nullable, so results predating this read as `not_recorded` rather than being retroactively claimed to have used current evidence.

## Still open, and written down as such

Nothing yet *refuses* to answer from the static table, and nothing alerts on a sustained fallback. The state is now **reportable, not prevented**. Whether a degraded evidence base should block output entirely is a policy decision, tracked with the risk register.

## Verification

142 backend tests green, ruff clean. Migration chain single-headed `0001 → 0012`.

---

⚠️ **Stacked on #102** — based on `feat/surface-sample-qc-to-reader` because both touch `schemas/responses.py` and `routes/results.py` on adjacent lines. Merge #102 first; this will retarget to `main` automatically.