### PR TITLE
fix: three controls that were mounted but never reached

### DIFF
--- a/api/middleware/audit.py
+++ b/api/middleware/audit.py
@@ -23,7 +23,17 @@ from fastapi import Request, Response
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.types import ASGIApp
 
-# Routes that handle PHI — all others are ignored
+# Routes that handle PHI — all others are ignored.
+#
+# Keep this in step with the routers mounted in main.py. `/api/fhir` was missing,
+# and it is the single richest PHI export in the API: DiagnosticReport and
+# Observation return a patient's full variant profile as FHIR resources. Those
+# reads produced no phi_access record and no X-Request-Id, so the export that
+# most needs an audit trail was the one path without one.
+#
+# test_middleware_audit.py walks the mounted routes and fails if a router listed
+# in _PHI_ROUTER_PREFIXES there is not covered here, so the next router to be
+# added cannot repeat this silently.
 _PHI_PREFIXES = (
     "/api/submit",
     "/api/results",
@@ -34,6 +44,7 @@ _PHI_PREFIXES = (
     "/api/pharma",
     "/api/marketplace",
     "/api/stripe",
+    "/api/fhir",
 )
 
 audit_logger = logging.getLogger("openoncology.audit")

--- a/api/routes/results.py
+++ b/api/routes/results.py
@@ -2,6 +2,8 @@
 Results route — return mutation analysis report for a submission.
 """
 
+import logging
+
 from fastapi import APIRouter, Depends, Query, Request
 from fastapi.responses import Response
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -18,6 +20,8 @@ from utils.http import conflict_error, not_found_error
 from middleware.rate_limit import limiter, READ_LIMIT
 
 router = APIRouter(prefix="/api/results", tags=["results"])
+
+logger = logging.getLogger(__name__)
 
 
 @router.get("/{submission_id}", response_model=ResultsResponse)
@@ -104,6 +108,11 @@ async def get_results(
         for m in mutations
     ]
 
+    # Sections that were requested but could not be built. Empty on the normal
+    # path. A reader must be able to tell "this section has nothing to say" from
+    # "this section could not be produced".
+    generation_errors: list[str] = []
+
     # ── Patient-facing summary (template-only, always generated) ──────────
     patient_summary_sections: dict = {}
     patient_summary_text: str = ""
@@ -121,7 +130,16 @@ async def get_results(
         patient_summary_sections = ps.sections
         patient_summary_text = ps.plain_text
     except Exception:
-        pass  # never fail the response due to summary generation
+        # Still never fails the response, but no longer disappears. A bare
+        # `pass` here returned 200 with patient_summary: null, which reads
+        # identically to "we generated a summary and it was empty". That is
+        # hazard H3, a failure presented as a negative result, inside the
+        # response the patient actually reads.
+        logger.exception(
+            "[results] patient summary generation failed for submission %s",
+            submission_id,
+        )
+        generation_errors.append("patient_summary")
 
     # ── Oncologist report (generated on demand via query param) ────────────
     oncologist_report_data: dict = {}
@@ -140,7 +158,14 @@ async def get_results(
             oncologist_report_data = onc_report.sections
             oncologist_report_data["plain_text"] = onc_report.plain_text
         except Exception:
-            pass  # never fail the response due to report generation
+            # As above. A clinician who asked for the report and received
+            # oncologist_report: null could not tell an empty report from a
+            # crashed one.
+            logger.exception(
+                "[results] oncologist report generation failed for submission %s",
+                submission_id,
+            )
+            generation_errors.append("oncologist_report")
 
     from services.sample_qc import qc_payload_for_api
 
@@ -165,6 +190,9 @@ async def get_results(
         "oncologist_notes": result.oncologist_notes if result else None,
         "custom_drug_possible": custom_drug_possible,
         "custom_drug_reason": custom_drug_reason,
+        # Empty on the normal path. Names any section that was requested and
+        # could not be generated, so a null section is not read as an empty one.
+        "generation_errors": generation_errors,
         # oncologist_report: only populated when include_oncologist_report=true
         "oncologist_report": oncologist_report_data or None,
         "mutations": [

--- a/api/schemas/responses.py
+++ b/api/schemas/responses.py
@@ -173,3 +173,8 @@ class ResultsResponse(BaseModel):
     # Always present. NOT_ASSESSED when the submission carries no verdict, so a
     # consumer cannot render "no QC problems" for a sample nobody checked.
     sample_qc: SampleQCOut = Field(default_factory=SampleQCOut)
+    # Sections that were requested and could not be generated, e.g.
+    # ["oncologist_report"]. Empty on the normal path. Both generators used to
+    # fail into a bare `pass`, so the response carried a null section that read
+    # exactly like a section with nothing in it (hazard H3).
+    generation_errors: list[str] = Field(default_factory=list)

--- a/api/tests/test_middleware_audit.py
+++ b/api/tests/test_middleware_audit.py
@@ -107,6 +107,84 @@ class TestPhiPrefixes:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# The prefix list vs the routes actually mounted
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestEveryMountedPhiRouteIsAudited:
+    """Catch a PHI router that was added without extending _PHI_PREFIXES.
+
+    Every test in TestPhiPrefixes asserts a positive about a prefix already in
+    the tuple, so the whole class passes just as happily when a prefix is
+    missing. That is how `/api/fhir` went unaudited: DiagnosticReport and
+    Observation export a patient's full variant profile, and neither produced a
+    phi_access record, because no test was looking at what was absent.
+
+    This walks the app's own route table instead of a hand-kept list, so a new
+    router under one of these prefixes is covered the moment it is mounted.
+    """
+
+    # Prefixes whose routes read or write patient data. Adding a router under
+    # one of these without adding it to _PHI_PREFIXES fails the test below.
+    _PHI_ROUTER_PREFIXES = (
+        "/api/submit",
+        "/api/results",
+        "/api/repurposing",
+        "/api/oncologist",
+        "/api/me",
+        "/api/marketplace",
+        "/api/fhir",
+    )
+
+    def _mounted_paths(self):
+        """Every /api/ path the app actually serves.
+
+        `app.routes` is not enough on its own: this FastAPI version wraps each
+        included router in an `_IncludedRouter` that exposes no `.path`, so a
+        flat walk of `app.routes` finds zero `/api/` entries and every assertion
+        built on it passes without testing anything. The OpenAPI schema is the
+        flattened view. Routes marked `include_in_schema=False` are absent from
+        it, so the router walk below picks those up as well.
+        """
+        from main import app
+
+        paths = set(app.openapi().get("paths", {}))
+
+        def walk(routes):
+            for route in routes:
+                path = getattr(route, "path", None)
+                if isinstance(path, str):
+                    paths.add(path)
+                inner = getattr(route, "original_router", None) or route
+                nested = getattr(inner, "routes", None)
+                if nested and inner is not route:
+                    walk(nested)
+
+        walk(app.routes)
+        return sorted(p for p in paths if p.startswith("/api/"))
+
+    def test_the_app_actually_mounts_phi_routes(self):
+        """Guard the guard: an empty walk would make the next test vacuous."""
+        assert self._mounted_paths(), "no /api/ routes found; the walk is broken"
+
+    def test_every_mounted_phi_route_is_covered_by_a_prefix(self):
+        unaudited = sorted(
+            path
+            for path in self._mounted_paths()
+            if path.startswith(self._PHI_ROUTER_PREFIXES)
+            and not any(path.startswith(p) for p in _PHI_PREFIXES)
+        )
+        assert not unaudited, (
+            "these PHI routes are mounted but produce no audit record: "
+            f"{unaudited}. Add the prefix to _PHI_PREFIXES in middleware/audit.py."
+        )
+
+    def test_fhir_export_is_audited(self):
+        """The specific gap this class was written for."""
+        assert any("/api/fhir/DiagnosticReport/x".startswith(p) for p in _PHI_PREFIXES)
+        assert any("/api/fhir/Observation/x".startswith(p) for p in _PHI_PREFIXES)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Integration tests — middleware behaviour over HTTP
 # ─────────────────────────────────────────────────────────────────────────────
 

--- a/api/tests/test_notify_worker_wiring.py
+++ b/api/tests/test_notify_worker_wiring.py
@@ -1,0 +1,126 @@
+"""Every Celery task should have something that dispatches it.
+
+This is F10's lesson stated generally. `sample_qc` was implemented, unit-tested
+and benchmarked, and no code path called it, so the control was inert while
+looking finished. `notify_worker.py` is in the same state: five tasks, each with
+templates and retry policy, and three of them have no caller anywhere in the
+repository.
+
+The test works on source text rather than by importing the worker. Dispatch is
+what is being checked, and dispatch is a static property of the code: importing
+Celery tasks needs a broker and tells us nothing about whether anyone calls them.
+
+`_KNOWN_UNWIRED` is deliberately an explicit list rather than a skip. Adding to
+it is a visible, reviewable act with a reason attached, in the same spirit as
+api/.pip-audit-ignore. A newly added task that nobody dispatches fails here.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+for _path in (str(_REPO_ROOT), str(_REPO_ROOT / "api")):
+    if _path not in sys.path:
+        sys.path.insert(0, _path)
+
+_API_DIR = _REPO_ROOT / "api"
+_NOTIFY_WORKER = _API_DIR / "workers" / "notify_worker.py"
+
+# Tasks with no dispatcher today. Each entry is a defect, not an exemption:
+# the feature it belongs to does not happen. Kept here so the gap is recorded
+# in code rather than only in a report, and so the list can only shrink under
+# review.
+#
+#   notify_order_confirmed   Stripe confirms an order and the buyer is not told.
+#                            webhook.py:_handle_succeeded is where it belongs.
+#   notify_pharma_approved   pharma_admin.py verifies a company and sends nothing.
+#   notify_review_complete   oncologist.py accepts a review and the patient is
+#                            never notified. Its Result lookup was also broken
+#                            (db.get by primary key against a non-PK column);
+#                            that is fixed, so wiring it up now works.
+#
+# Wiring these changes which emails real users receive, so it is a product
+# decision rather than a cleanup, and is tracked separately.
+_KNOWN_UNWIRED = {
+    "notify_order_confirmed",
+    "notify_pharma_approved",
+    "notify_review_complete",
+}
+
+_TASK_DEF = re.compile(r"^def (notify_\w+)\(", re.M)
+_DISPATCH = re.compile(r"\b(\w+)\.(?:apply_async|delay)\s*\(")
+
+
+def _task_names() -> set[str]:
+    return set(_TASK_DEF.findall(_NOTIFY_WORKER.read_text(encoding="utf-8")))
+
+
+def _dispatched_names() -> set[str]:
+    """Task names dispatched anywhere in api/, excluding the worker and tests."""
+    dispatched: set[str] = set()
+    for path in _API_DIR.rglob("*.py"):
+        if path == _NOTIFY_WORKER or "tests" in path.parts or "__pycache__" in path.parts:
+            continue
+        dispatched.update(_DISPATCH.findall(path.read_text(encoding="utf-8")))
+    return dispatched
+
+
+class TestTaskWiring:
+    def test_the_scan_finds_the_tasks(self):
+        """Guard the guard: an empty scan would make every assertion vacuous."""
+        names = _task_names()
+        assert len(names) >= 5, f"expected the notify tasks, found {names}"
+
+    def test_the_scan_finds_at_least_one_dispatcher(self):
+        assert "notify_results_ready" in _dispatched_names(), (
+            "the dispatch scan found nothing it should have; the regex is wrong"
+        )
+
+    def test_no_undocumented_task_lacks_a_dispatcher(self):
+        undocumented = sorted(_task_names() - _dispatched_names() - _KNOWN_UNWIRED)
+        assert not undocumented, (
+            f"these Celery tasks are defined and never dispatched: {undocumented}. "
+            "Wire them up, delete them, or add them to _KNOWN_UNWIRED with a reason."
+        )
+
+    def test_the_unwired_list_is_accurate(self):
+        """Stop the list outliving the problem: a wired task must leave it."""
+        wired_but_listed = sorted(_KNOWN_UNWIRED & _dispatched_names())
+        assert not wired_but_listed, (
+            f"these are dispatched now and should be removed from "
+            f"_KNOWN_UNWIRED: {wired_but_listed}"
+        )
+
+
+class TestMilestoneDispatcherIsReachable:
+    """A dispatcher that nothing calls is the same defect one level up.
+
+    notify_campaign_milestone does have a dispatcher, so the wiring test above
+    passes it. But that dispatcher, campaign._check_milestone, is itself never
+    called, and webhook._handle_succeeded increments raised_usd without going
+    near it. Milestone emails therefore cannot fire.
+    """
+
+    def _milestone_call_count(self) -> int:
+        sources = "".join(
+            (_API_DIR / "routes" / name).read_text(encoding="utf-8")
+            for name in ("campaign.py", "webhook.py")
+        )
+        assert "def _check_milestone(" in sources, "_check_milestone moved; update this test"
+        return len(re.findall(r"(?<!def )_check_milestone\s*\(", sources))
+
+    @pytest.mark.xfail(
+        reason=(
+            "known gap: nothing calls _check_milestone, so notify_campaign_milestone "
+            "is unreachable. webhook.py:_handle_succeeded is where raised_usd is "
+            "incremented and where the call belongs. Wiring it changes which emails "
+            "users receive, so it is a product decision tracked separately."
+        ),
+        strict=True,
+    )
+    def test_check_milestone_is_called_somewhere(self):
+        assert self._milestone_call_count() > 0

--- a/api/tests/test_results_generation_errors.py
+++ b/api/tests/test_results_generation_errors.py
@@ -1,0 +1,101 @@
+"""A crashed report section must not read as an empty one.
+
+`get_results` builds the patient summary and the oncologist report inside
+try/except blocks that used to end in a bare `pass`. Any exception in either
+generator produced a 200 response with `patient_summary: null` or
+`oncologist_report: null`, and nothing anywhere said a failure had happened: no
+log line, no field, no status change.
+
+That is hazard H3 from docs/risk_analysis.md, "a lookup failure is presented as
+a negative result", reaching the response a clinician reads. The generators are
+still not allowed to fail the request, which is the right call, so the fix is to
+name the failure in the payload instead of swallowing it.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+for _path in (str(_REPO_ROOT), str(_REPO_ROOT / "api")):
+    if _path not in sys.path:
+        sys.path.insert(0, _path)
+
+
+def _boom(*_args, **_kwargs):
+    raise RuntimeError("generator exploded")
+
+
+class TestPatientSummaryFailure:
+    async def test_a_crash_is_named_in_the_response(
+        self, client, seeded_submission, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "services.patient_summary.generate_patient_summary", _boom
+        )
+        response = await client.get(f"/api/results/{seeded_submission.id}")
+
+        assert response.status_code == 200, "generation must not fail the request"
+        body = response.json()
+        assert "patient_summary" in body["generation_errors"]
+
+    async def test_the_normal_path_reports_no_errors(self, client, seeded_submission):
+        response = await client.get(f"/api/results/{seeded_submission.id}")
+        assert response.status_code == 200
+        assert response.json()["generation_errors"] == []
+
+
+class TestOncologistReportFailure:
+    async def test_a_crash_is_named_in_the_response(
+        self, client, seeded_submission, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "services.oncologist_report.generate_oncologist_report", _boom
+        )
+        response = await client.get(
+            f"/api/results/{seeded_submission.id}?include_oncologist_report=true"
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert "oncologist_report" in body["generation_errors"]
+        assert body["oncologist_report"] is None
+
+    async def test_a_null_report_is_distinguishable_from_a_failed_one(
+        self, client, seeded_submission, monkeypatch
+    ):
+        """The property that matters: the two cases must not look identical.
+
+        Not requesting the report and requesting one that crashes both leave
+        `oncologist_report: null`. Only generation_errors separates them.
+        """
+        not_requested = (
+            await client.get(f"/api/results/{seeded_submission.id}")
+        ).json()
+
+        monkeypatch.setattr(
+            "services.oncologist_report.generate_oncologist_report", _boom
+        )
+        crashed = (
+            await client.get(
+                f"/api/results/{seeded_submission.id}?include_oncologist_report=true"
+            )
+        ).json()
+
+        assert not_requested["oncologist_report"] is None
+        assert crashed["oncologist_report"] is None
+        assert not_requested["generation_errors"] != crashed["generation_errors"]
+
+
+class TestFailureIsLogged:
+    async def test_the_exception_reaches_the_log(
+        self, client, seeded_submission, monkeypatch, caplog
+    ):
+        """A bare `pass` left no trace at all; an operator needs the traceback."""
+        monkeypatch.setattr(
+            "services.patient_summary.generate_patient_summary", _boom
+        )
+        with caplog.at_level("ERROR", logger="routes.results"):
+            await client.get(f"/api/results/{seeded_submission.id}")
+
+        assert any("patient summary generation failed" in r.message for r in caplog.records)

--- a/api/workers/notify_worker.py
+++ b/api/workers/notify_worker.py
@@ -257,8 +257,20 @@ def notify_review_complete(self, submission_id: str):
 
     try:
         with get_sync_session() as db:
-            result = db.get(Result, submission_id)
+            # db.get() looks up by primary key. Result.id is its own UUID and
+            # submission_id is a separate unique FK, so passing a submission id
+            # to db.get(Result, ...) never matched a row: the task returned at
+            # the guard below and reported success having sent nothing.
+            from sqlalchemy import select
+
+            result = db.execute(
+                select(Result).where(Result.submission_id == submission_id)
+            ).scalar_one_or_none()
             if not result:
+                logger.warning(
+                    "[notify] no Result for submission %s; review email not sent",
+                    submission_id,
+                )
                 return
             submission = db.get(Submission, submission_id)
             if not submission:

--- a/docs/risk_analysis.md
+++ b/docs/risk_analysis.md
@@ -259,6 +259,40 @@ Verified present, not merely intended:
   `run_genomic_pipeline` and asserts on the persisted row
   (`api/tests/test_genomic_worker_qc_persistence.py`), so a control that stops
   being invoked fails a test rather than going quiet.
+- A failed report or summary generation is named in the response
+  (`ResultsResponse.generation_errors`) and logged with its traceback, rather
+  than returning a null section that reads like an empty one.
+- Every PHI route the app mounts is covered by the audit middleware's prefix
+  list, asserted by walking the app's own route table
+  (`api/tests/test_middleware_audit.py::TestEveryMountedPhiRouteIsAudited`).
+- Every Celery notification task either has a dispatcher or is listed as a known
+  gap with a reason (`api/tests/test_notify_worker_wiring.py`).
+
+### F11. Controls that were mounted but not reached (H3) — FIXED
+
+Three instances of F10's pattern, found by asking which controls run rather than
+which exist.
+
+`/api/fhir` was absent from `_PHI_PREFIXES` in `api/middleware/audit.py`.
+`DiagnosticReport` and `Observation` export a patient's full variant profile,
+and neither produced a `phi_access` record or an `X-Request-Id`: the richest PHI
+export in the API was the one path with no audit trail. Every existing prefix
+test asserted a positive about a prefix already in the tuple, so the suite could
+not see an omission. It now walks the mounted routes instead.
+
+`api/routes/results.py` swallowed any exception from the patient summary and the
+oncologist report into a bare `pass`. The response returned 200 with a null
+section, which is indistinguishable from a section with nothing to say. Both now
+log the traceback and name the failure in `generation_errors`. The generators
+still cannot fail the request, which remains correct.
+
+`notify_review_complete` looked its `Result` up with `db.get(Result, submission_id)`.
+`Result.id` is its own UUID and `submission_id` is a separate unique FK, so the
+lookup never matched and the task returned success having sent nothing. Fixed to
+query on `submission_id`. Three of the five notification tasks still have no
+dispatcher at all, and `notify_campaign_milestone`'s only dispatcher is itself
+never called, so milestone emails cannot fire; both are recorded in the wiring
+test rather than left to be rediscovered.
 
 ---
 


### PR DESCRIPTION
F10 was a control that existed, passed its own tests, and was never called. Asking which *other* controls actually run turns up three more.

## The richest PHI export had no audit trail

`_PHI_PREFIXES` in `middleware/audit.py` did not include `/api/fhir`. `DiagnosticReport` and `Observation` return a patient's entire variant profile as FHIR resources, and neither produced a `phi_access` record or an `X-Request-Id`. Of every route in the API, the one that exports the most PHI was the one the HIPAA audit log ignored.

The existing prefix tests could not have caught it. Each asserts a positive about a prefix already in the tuple, so the class passes just as happily when one is missing. The new test walks the app's own route table and fails on any mounted PHI route no prefix covers:

```
AssertionError: these PHI routes are mounted but produce no audit record:
['/api/fhir/DiagnosticReport/{submission_id}', '/api/fhir/Observation/{mutation_id}'].
Add the prefix to _PHI_PREFIXES in middleware/audit.py.
```

Writing that walk turned up a second problem in the test itself. This FastAPI version wraps included routers in `_IncludedRouter` with no `.path`, so a flat walk of `app.routes` returns zero `/api/` entries and every assertion built on it passes vacuously. It now reads the OpenAPI schema and recurses into `original_router`, with a guard test that fails if the walk ever comes back empty.

## A crashed report section looked like an empty one

Both generators in `routes/results.py` ended their except block in a bare `pass`. A failure returned 200 with `patient_summary: null` or `oncologist_report: null`, which is exactly what a section with nothing to say looks like, and left no log line at all. That is hazard H3 from the risk analysis arriving in the response a clinician reads.

Both now log the traceback and append to `ResultsResponse.generation_errors`, empty on the normal path. Neither can fail the request, which was the right call and is unchanged.

## notify_review_complete could never send anything

It resolved its row with `db.get(Result, submission_id)`. `db.get()` takes a primary key; `Result.id` is its own UUID and `submission_id` is a separate unique FK. The lookup always returned `None`, so the task hit its guard and reported success having sent no email. Now queried on `submission_id`, and the guard logs rather than returning silently.

The wiring test generalises F10: every Celery task should have a dispatcher. Three of the five have none, so Stripe confirms an order, an admin verifies a pharma company, and an oncologist submits a review with no notification sent in any of the three. `notify_campaign_milestone` has a dispatcher, but nothing calls that dispatcher, so milestone emails cannot fire either; that one is a **strict** xfail so it fails loudly the day someone wires it.

Those three are listed in `_KNOWN_UNWIRED` with reasons rather than fixed here. Wiring them changes which emails real users receive, which is a product decision rather than a cleanup.

## Verification

846 passed, 1 xfailed, ruff clean. Each new test was run against the unfixed code first: the audit walk names both `/api/fhir` paths, and three of the five generation-error tests fail without the append.

Independent of #101.