### PR TITLE
ci: measure and gate the things these checks claimed to

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,12 @@ name: CI
 on:
   push:
     branches: [main, develop]
+  # No base-branch filter on pull_request. With `branches: [main]` a PR opened
+  # against another topic branch ran nothing at all: not tests, not lint, not the
+  # migration gate. That is the normal shape of a stacked PR, where the second
+  # change is based on the first while it is still in review, and it silently got
+  # zero coverage from every gate in this file.
   pull_request:
-    branches: [main]
 
 jobs:
   # ── Frontend ──────────────────────────────────────────────────────────────
@@ -171,16 +175,26 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: python scripts/check_migration_chain.py
 
-      # Non-blocking, deliberately. `alembic check` reports substantial
-      # pre-existing drift between the migration chain and the current
-      # SQLAlchemy models (repurposing_candidates, campaigns, submissions
-      # columns) that predates this branch and needs a dedicated reconciliation
-      # migration, not a rushed autogenerate. Tracked as open action 8 in
-      # docs/risk_analysis.md. Until that lands this step reports only, which is
-      # why the blocking gate above exists rather than nothing gating migrations.
-      - name: Detect uncommitted model changes (reporting only — see open action 8)
+      # Blocking. This step carried `continue-on-error: true` and a comment
+      # claiming substantial drift in repurposing_candidates, campaigns and
+      # submissions. Every table it named was reconciled by a8bf7eb4833c in July
+      # 2026; the comment predates that migration and was copied forward twice
+      # without being re-read against it. Against a real Postgres this step has
+      # been answering "No new upgrade operations detected." while being told its
+      # answer did not count.
+      #
+      # Two real gaps survive, and neither is visible here, which is why turning
+      # this on does not close them (both tracked as open action 8):
+      #   - 11 columns where 0001 used a bare sa.String and the model specifies a
+      #     length. alembic's DefaultImpl._column_args_match does not flag a
+      #     reflected type for being less specific than the metadata type, so a
+      #     String(128) model field backed by an unbounded VARCHAR reads as a
+      #     match. Fixing it means hand-written alter_column calls.
+      #   - 19 indexes dropped by a8bf7eb4833c because no model declares
+      #     index=True. Chain and models agree, so this step is silent, but the
+      #     database lost every FK join-column index.
+      - name: Detect uncommitted model changes
         run: alembic check
-        continue-on-error: true
 
       # The api/tests and ai/tests suites cannot share one interpreter: both the
       # FastAPI app (api/ai/) and the top-level ai/ package claim the import name
@@ -193,20 +207,25 @@ jobs:
         env:
           PYTHONPATH: ${{ github.workspace }}
 
-      # Coverage threshold. Re-measured 2026-08-13 against a real (non-mocked)
-      # run of the full suite: 856/856 api tests + 42/42 ai tests pass with 71%
-      # combined coverage.
+      # Coverage threshold. The number this gate measures changed, so read the
+      # sequence before reading 52 as a regression:
       #
-      # The gate is 69, not 63. A floor four points under the real number cannot
-      # detect a four-point regression, which made the previous gate decorative.
-      # Two points of margin are kept for one specific reason and not as general
-      # slack: the measurement above was taken on Windows, where a few optional
-      # imports (weasyprint, rdkit paths) resolve differently than on the Linux
-      # runner, so the two platforms do not report an identical total. Tighten
-      # this to the measured value once it has been confirmed on Linux.
+      #   63 gate / 67 reported    counted api/tests and ai/tests themselves
+      #   69 gate / 70 reported    same measurement, tightened
+      #   52 gate / 54 reported    production code only
+      #
+      # pyproject.toml now omits */tests/* from coverage. A test module is ~100%
+      # covered by the act of running it, and 34 of them were being averaged into
+      # the headline. On identical coverage data the same suite reads 70% with
+      # tests counted and 53.93% without. Coverage did not fall by 17 points; the
+      # earlier figures were partly measuring the tests.
+      #
+      # 53.93% over 8,353 production statements, 844 api + 42 ai tests passing.
+      # Gate at 52 leaves about a point, which is the spread observed between this
+      # runner and a local Windows run.
       - name: Run backend tests (ai suite)
         working-directory: ${{ github.workspace }}
-        run: pytest ai/tests/ -v --tb=short --cov=ai --cov=api --cov-append --cov-report=term-missing --cov-report=xml:coverage.xml --cov-fail-under=69
+        run: pytest ai/tests/ -v --tb=short --cov=ai --cov=api --cov-append --cov-report=term-missing --cov-report=xml:coverage.xml --cov-fail-under=52
         env:
           PYTHONPATH: ${{ github.workspace }}
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,10 @@ name: CodeQL
 on:
   push:
     branches: [main]
+  # Unfiltered, so a PR based on another topic branch is analysed too. With
+  # `branches: [main]` a stacked PR got no CodeQL run, which mattered more here
+  # than elsewhere: CodeQL was the only SAST that ran before a merge at all.
   pull_request:
-    branches: [main]
   schedule:
     # Weekly, Monday 03:00 UTC (offset from the Security Scan cron at 02:00)
     - cron: "0 3 * * 1"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -6,6 +6,17 @@ on:
     - cron: "0 2 * * 1"
   push:
     branches: [main]
+  # Until now this workflow had no pull_request trigger, so none of it ran before a
+  # merge. A dependency CVE or a new Bandit finding was caught after it had already
+  # landed on main, or up to a week later on the cron above. docs/risk_analysis.md
+  # section 7 lists dependency, SAST and image scanning as a mitigation in place,
+  # which was true of the repository and not of the review path.
+  #
+  # Only the fast jobs run on PRs. zap-scan and trivy each build a Docker image and
+  # zap-scan additionally boots Postgres, Redis and the API; both stay on push/cron
+  # so PR feedback stays quick.
+  pull_request:
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -140,6 +151,10 @@ jobs:
     name: OWASP ZAP API baseline scan
     runs-on: ubuntu-latest
     needs: []   # Run independently — API starts in Docker
+    # Builds an image and boots Postgres, Redis and the API, so it is too slow for
+    # PR feedback. Stays on push to main, the weekly cron, and manual dispatch.
+    # (trivy skips on PRs already via its `github.ref` check.)
+    if: github.event_name != 'pull_request'
     permissions:
       contents: read
       issues: write          # ZAP action creates/updates a GitHub Issue with scan results

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ install:
 # would reject.
 test-backend:
 	$(PYTEST) api/tests/ $(COV) --cov-report= --cov-fail-under=0
-	$(PYTEST) ai/tests/ $(COV) --cov-append --cov-report=term-missing --cov-fail-under=69
+	$(PYTEST) ai/tests/ $(COV) --cov-append --cov-report=term-missing --cov-fail-under=52
 
 test-frontend:
 	cd web && npm run test:run
@@ -44,7 +44,7 @@ test: test-backend test-frontend test-e2e
 
 coverage:
 	$(PYTEST) api/tests/ $(COV) --cov-report= --cov-fail-under=0
-	$(PYTEST) ai/tests/ $(COV) --cov-append --cov-report=term-missing --cov-report=xml:coverage.xml --cov-fail-under=69
+	$(PYTEST) ai/tests/ $(COV) --cov-append --cov-report=term-missing --cov-report=xml:coverage.xml --cov-fail-under=52
 
 # ── Lint / type-check ──────────────────────────────────────────────────────────
 

--- a/docs/risk_analysis.md
+++ b/docs/risk_analysis.md
@@ -273,7 +273,7 @@ Verified present, not merely intended:
 | 5 | Formal risk register with likelihood and severity scoring | all | Yes |
 | 6 | Human-factors review of how the ranked list is read | all | Yes |
 | 7 | Analyse LLM summary failure modes | H5 | Yes |
-| 8 | Reconcile the Alembic/model drift so `alembic check` can gate rather than warn | — | No |
+| 8 | Restore the 19 indexes `a8bf7eb4833c` dropped, and bound the 11 unbounded VARCHAR columns | — | No |
 
 ---
 
@@ -304,12 +304,30 @@ specifically, dependency failure is **not** primarily an availability risk, it
 is the wrong-answer risk described in F4.
 
 Mitigations in place: structured PHI access logging middleware; Keycloak JWT
-auth and role extraction; Redis-backed rate limiter infrastructure; dependency,
-SAST, DAST and image scanning in CI.
+auth and role extraction; Redis-backed rate limiter infrastructure; migration
+drift gating in CI (`alembic check`, plus a revision-graph gate in
+`scripts/check_migration_chain.py`).
+
+Scanning deserves a more exact statement than "in CI", because the earlier
+wording claimed more than ran. Dependency, SAST, DAST and image scanning all
+exist in `.github/workflows/security.yml`, but until now that workflow had no
+`pull_request` trigger, so none of it ran before a merge: findings surfaced after
+the change was already on `main`, or up to a week later on the weekly cron. The
+fast jobs now run on pull requests. What each one can actually do:
+
+| Scan | Runs on PR | Can fail the build |
+|---|---|---|
+| pip-audit (Python deps) | yes | yes |
+| npm audit (frontend deps) | yes | only at `critical`; 6 HIGH advisories in a transitive `postcss` are unfixable without a breaking Next.js major |
+| Bandit (Python SAST) | yes | no, reports to the Security tab |
+| Semgrep (SAST) | yes | no, reports to the Security tab |
+| CodeQL (SAST) | yes | yes |
+| ZAP (DAST) | no, push/cron only | no, report only |
+| Trivy (image) | no, push/cron only | yes, on `main` |
 
 Open: formal risk register with per-control scoring; audit log retention and
-immutability verification in the deployment environment; migration drift checks
-in CI.
+immutability verification in the deployment environment; promoting Bandit and
+Semgrep from reporting to blocking once their current findings are triaged.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,21 @@ addopts = "--import-mode=importlib"
 # accidentally pull both `ai` packages into one process. Run the ai suite
 # explicitly: `pytest ai/tests/` (see the Makefile and CONTRIBUTING.md).
 testpaths = ["api/tests"]
+
+[tool.coverage.run]
+# Without this, `--cov=api --cov=ai` measures api/tests/ and ai/tests/ as well as
+# the code under test. A test file is ~100% covered by the act of running it, so
+# the 34 test modules were reporting near-100% and pulling the headline number up
+# with them:
+#
+#     api/tests/test_oncokb_evidence.py    376 stmts    0 miss    100%
+#     api/tests/test_sample_qc.py           75 stmts    0 miss    100%
+#
+# The gap is not small. On the same coverage data, 13,118 statements including
+# tests reads 70%, while the 8,327 statements of production code read 52%. A
+# threshold set against the first number cannot detect a regression in the second,
+# which is the only one that means anything.
+omit = [
+    "*/tests/*",
+    "*/conftest.py",
+]

--- a/scripts/check_migration_chain.py
+++ b/scripts/check_migration_chain.py
@@ -3,16 +3,20 @@
 Purpose:
 - Enforce the migration-chain properties that CAN be checked today, blocking.
 
-`alembic check` (model-vs-migration drift) is a different, stronger check, and
-it currently reports substantial pre-existing drift that needs a dedicated
-reconciliation migration rather than a rushed autogenerate. It therefore runs
-non-blocking in CI and is tracked as open action 8 in docs/risk_analysis.md.
+`alembic check` covers a different question, model-vs-migration drift, and now
+gates in CI on its own. It needs a live database, so it cannot run here.
 
-That left nothing at all gating migrations. This is the part that can gate now:
-a divergent chain, a duplicate revision id, or a dangling down_revision breaks
-`alembic upgrade head` for every deployment, and none of those need a database
-or a resolved drift to detect. Two developers adding a migration on parallel
-branches is the common way it happens, and the merge that causes it looks clean.
+This script covers what `alembic check` does not look at: the shape of the
+revision graph itself. A divergent chain, a duplicate revision id, or a dangling
+down_revision breaks `alembic upgrade head` for every deployment, and none of it
+needs a database to detect. Two branches each adding a migration is the ordinary
+way a fork appears, and the merge that creates it looks clean in review.
+
+Also outside both checks, and tracked as open action 8 in docs/risk_analysis.md:
+11 columns where 0001 used a bare `sa.String` against a model that specifies a
+length (alembic treats a reflected type that is less specific than the metadata
+type as a match, so it reports nothing), and 19 indexes that a8bf7eb4833c dropped
+because no model declares `index=True`.
 
 Usage:
     .venv\\Scripts\\python.exe scripts\\check_migration_chain.py


### PR DESCRIPTION
Follow-up to #101, which made these gates able to fail. This fixes what they were failing *against*, including two claims #101 itself got wrong.

## Coverage was measuring the tests

`pyproject.toml` had no `[tool.coverage.run]`, so `--cov=api` swept in `api/tests` and `ai/tests`. A test module is ~100% covered by the act of running it, and 34 of them were being averaged into the headline:

```
api/tests/test_oncokb_evidence.py    376 stmts   0 miss   100%
api/tests/test_sample_qc.py           75 stmts   0 miss   100%
```

| | Statements | Coverage |
|---|---|---|
| As CI reported it | 13,118 | 70.34% |
| Production code only | 8,353 | **53.93%** |

The gate moves 69 to 52. Coverage did not fall 17 points today; the earlier numbers were partly reporting on the tests. This also corrects #101, which raised the gate to 69 on the reasoning that a floor four points under the real number was decorative. The reasoning was right, the number it was applied to was wrong.

## alembic check was told its answer did not count

The step ran with `continue-on-error` and a comment describing substantial drift in `repurposing_candidates`, `campaigns` and `submissions`. Every table it named was reconciled by `a8bf7eb4833c` in July. The comment predates that migration and was never re-read against it, and #101 copied it forward into two more files.

From #101's own CI run (31708281608):

```
Detect uncommitted model changes: No new upgrade operations detected.
```

It has been green the whole time. It now gates.

Two real gaps survive that `alembic check` structurally cannot see, so open action 8 is rewritten to describe them instead:
- 11 columns where `0001` used a bare `sa.String` against a model specifying a length. `DefaultImpl._column_args_match` does not flag a reflected type for being *less specific* than the metadata type, so a `String(128)` field backed by an unbounded VARCHAR reads as a match.
- 19 indexes dropped by `a8bf7eb4833c` because no model declares `index=True`. Chain and models agree, so the check stays silent, but the database lost every FK join-column index.

## Security scanning never ran before a merge

`security.yml` triggered on schedule, push to main and `workflow_dispatch`, with no `pull_request` trigger. A dependency CVE or a new SAST finding surfaced only after it had landed, or up to a week later on the cron. The fast jobs now run on PRs; ZAP and Trivy stay on push and cron because each builds an image and ZAP additionally boots Postgres, Redis and the API.

`risk_analysis.md` §7 claimed "dependency, SAST, DAST and image scanning in CI" as a mitigation in place. True of the repository, not of the review path. Replaced with a table of what runs where and what can actually fail a build.

`npm audit` stays at `--audit-level=critical`. Six HIGH advisories in a transitive `postcss` have no fix short of a breaking Next.js major, so tightening it would have meant a permanently red gate rather than a real one.

## Stacked PRs got no CI at all

`ci.yml` and `codeql.yml` both filtered `pull_request` on `branches: [main]`, so a PR opened against another topic branch ran nothing: no tests, no lint, no migration gate, no CodeQL. CodeQL was the only SAST running pre-merge. #103 sat in exactly that state until it merged. The base-branch filter is removed from both.

## Verification

`alembic check` green on the CI Postgres, migration chain gate exits 0, ruff clean, all three workflows parse, 53.93% over 8,353 production statements with 844 api and 42 ai tests passing.