### PR TITLE
fix(stripe): stop a replayed webhook inflating totals, and close an open oracle

### DIFF
--- a/api/alembic/env.py
+++ b/api/alembic/env.py
@@ -22,6 +22,7 @@ from models import (  # noqa: F401
     cohort,
     deletion_request,
     genomics,
+    stripe_event,
 )
 from config import settings
 

--- a/api/alembic/versions/0012_stripe_webhook_events.py
+++ b/api/alembic/versions/0012_stripe_webhook_events.py
@@ -1,0 +1,41 @@
+"""Add stripe_webhook_events so a redelivered Stripe event is processed once.
+
+Stripe redelivers a webhook on any non-2xx response, on a timeout, and at its
+own discretion; at-least-once delivery is documented, expected behaviour rather
+than an error condition. The donation branch of the handler did
+
+    campaign.raised_usd = (campaign.raised_usd or 0) + amount_usd
+
+so each redelivery of a single succeeded payment added the amount again. The
+figure only ever moved upward, nothing recorded which events had been seen, and
+an inflated campaign total is indistinguishable from a successful campaign.
+
+The event id is the primary key rather than a unique column so that two
+concurrent redeliveries resolve in the database instead of in a check-then-act
+race in application code.
+
+Revision ID: 0012
+Revises: 0011
+Create Date: 2026-08-13
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0012"
+down_revision = "0011"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "stripe_webhook_events",
+        sa.Column("event_id", sa.String(255), primary_key=True),
+        sa.Column("event_type", sa.String(128), nullable=False),
+        sa.Column("processed_at", sa.DateTime(), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("stripe_webhook_events")

--- a/api/models/__init__.py
+++ b/api/models/__init__.py
@@ -9,6 +9,7 @@ from models.order import Order
 from models.oncologist import Oncologist
 from models.genomics import CopyNumberAlteration, StructuralVariant, RnaSeqExpression, MutationSignature
 from models.cohort import Study, Sample, CohortMutation
+from models.stripe_event import StripeWebhookEvent
 
 __all__ = [
     "Patient", "Submission", "Mutation", "Result",
@@ -16,4 +17,5 @@ __all__ = [
     "Order", "Oncologist",
     "CopyNumberAlteration", "StructuralVariant", "RnaSeqExpression", "MutationSignature",
     "Study", "Sample", "CohortMutation",
+    "StripeWebhookEvent",
 ]

--- a/api/models/stripe_event.py
+++ b/api/models/stripe_event.py
@@ -1,0 +1,38 @@
+from datetime import datetime, UTC
+
+from sqlalchemy import String, DateTime
+from sqlalchemy.orm import Mapped, mapped_column
+
+from database import Base
+
+
+class StripeWebhookEvent(Base):
+    """One row per Stripe event id this service has already processed.
+
+    Stripe redelivers a webhook on any non-2xx response, a timeout, or at its
+    own discretion, and documents at-least-once delivery as normal behaviour.
+    The donation branch of the handler did
+
+        campaign.raised_usd = (campaign.raised_usd or 0) + amount_usd
+
+    so every redelivery of one succeeded payment added the amount again. The
+    total only ever moved up, nothing recorded which events had been seen, and
+    a campaign page showing an inflated figure looks exactly like a campaign
+    that raised more money.
+
+    Inserting the event id first, and letting the primary key reject a repeat,
+    makes the handler idempotent for every branch at once rather than requiring
+    each one to be individually safe to replay.
+    """
+
+    __tablename__ = "stripe_webhook_events"
+
+    # Stripe's own event id (evt_...). Primary key, so a concurrent redelivery
+    # loses the race at the database rather than in application logic.
+    event_id: Mapped[str] = mapped_column(String(255), primary_key=True)
+
+    event_type: Mapped[str] = mapped_column(String(128), nullable=False)
+
+    processed_at: Mapped[datetime] = mapped_column(
+        DateTime, default=lambda: datetime.now(UTC).replace(tzinfo=None), nullable=False
+    )

--- a/api/routes/stripe_connect.py
+++ b/api/routes/stripe_connect.py
@@ -89,20 +89,47 @@ async def onboarding_return(
     request: Request,
     db: AsyncSession = Depends(get_db),
 ):
-    """Stripe redirects the pharma here after completing (or leaving) onboarding."""
+    """Stripe redirects the pharma's browser here after onboarding.
+
+    Deliberately unauthenticated, and it has to stay that way: this is the
+    `return_url` handed to `stripe.AccountLink.create`, so Stripe sends the
+    browser here directly and there is no Authorization header to check. Adding
+    `_require_admin` would 403 every pharma the moment they finish KYC.
+
+    What it must not do is answer questions. It previously returned
+    `stripe_account_id`, `charges_enabled` and `payouts_enabled` for whatever
+    id appeared in the path, with no credential of any kind, which made it an
+    oracle: walk the ids and read back the Stripe account and payout state of
+    every company on the platform. It also 404'd on unknown ids and 200'd on
+    known ones, so it confirmed which ids existed even before the body was read.
+
+    It now returns the same shape either way and says only whether onboarding
+    finished. Everything it used to disclose is available from
+    `GET /status/{pharma_id}`, which requires the admin role.
+    """
     company = await db.get(PharmaCompany, pharma_id)
-    if not company or not company.stripe_account_id:
-        raise not_found_error(request, "Company not found")
 
-    account = stripe.Account.retrieve(company.stripe_account_id)
-    details_submitted = account.get("details_submitted", False)
+    details_submitted = False
+    if company and company.stripe_account_id:
+        try:
+            account = stripe.Account.retrieve(company.stripe_account_id)
+            details_submitted = bool(account.get("details_submitted", False))
+        except Exception:
+            # A Stripe outage must not turn this into an error oracle either:
+            # the response shape stays identical.
+            logger.exception(
+                "[stripe] account retrieve failed during onboarding return"
+            )
 
+    # Uniform response. No account id, no capability flags, and no distinction
+    # between "unknown company" and "known company that has not finished".
     return {
-        "pharma_id": pharma_id,
-        "stripe_account_id": company.stripe_account_id,
-        "details_submitted": details_submitted,
-        "charges_enabled": account.get("charges_enabled", False),
-        "payouts_enabled": account.get("payouts_enabled", False),
+        "onboarding_complete": details_submitted,
+        "detail": (
+            "Onboarding complete."
+            if details_submitted
+            else "Onboarding is not complete. Return to the dashboard to continue."
+        ),
     }
 
 

--- a/api/routes/webhook.py
+++ b/api/routes/webhook.py
@@ -3,6 +3,11 @@
 POST /api/webhook/stripe
 
 Verifies Stripe-Signature header with STRIPE_WEBHOOK_SECRET.
+
+Every event id is recorded in stripe_webhook_events before any handler runs, and
+a repeat is acknowledged without being processed again. Stripe redelivers on any
+non-2xx, on a timeout, and at its own discretion, so this is ordinary traffic.
+
 Handles:
   - payment_intent.succeeded  →  update Order.status = "confirmed"
      (if metadata.type == "donation"  →  increment Campaign.raised_usd)
@@ -12,12 +17,14 @@ import logging
 import stripe
 from fastapi import APIRouter, Depends, Request, status
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from config import settings
 from database import get_db
 from models.order import Order, OrderStatus
 from models.campaign import Campaign
+from models.stripe_event import StripeWebhookEvent
 from utils.http import bad_request_error
 
 logger = logging.getLogger(__name__)
@@ -37,10 +44,24 @@ async def stripe_webhook(request: Request, db: AsyncSession = Depends(get_db)):
     except stripe.error.SignatureVerificationError:
         raise bad_request_error(request, "Invalid Stripe signature")
     except Exception:
+        # Logged rather than swallowed. Every failure here answered Stripe with
+        # "Invalid webhook payload", including a bug in our own parsing, and
+        # Stripe retries a non-2xx, so a defect on this path became an
+        # indefinite retry loop with no record of the actual cause.
+        logger.exception("[stripe] webhook payload could not be parsed")
         raise bad_request_error(request, "Invalid webhook payload")
 
+    event_id: str = event["id"]
     event_type: str = event["type"]
     obj = event["data"]["object"]
+
+    # Stripe guarantees at-least-once delivery, so a repeat is normal traffic
+    # rather than an error. Claim the event id before doing any work: the
+    # primary key rejects the second writer, which makes every branch below
+    # replay-safe at once instead of each one having to be individually safe.
+    if not await _claim_event(event_id, event_type, db):
+        logger.info("[stripe] event %s already processed, skipping", event_id)
+        return {"received": True, "duplicate": True}
 
     if event_type == "payment_intent.succeeded":
         await _handle_succeeded(obj, db)
@@ -50,6 +71,24 @@ async def stripe_webhook(request: Request, db: AsyncSession = Depends(get_db)):
         logger.debug("Unhandled Stripe event: %s", event_type)
 
     return {"received": True}
+
+
+async def _claim_event(event_id: str, event_type: str, db: AsyncSession) -> bool:
+    """Record this event id. False if some earlier delivery already did.
+
+    Committed on its own, before the handlers run. If a handler then fails, the
+    event stays claimed and is not retried, which is the correct trade for the
+    donation path: a redelivery there adds money that was never paid, and that
+    error is neither visible nor reversible from the campaign total. A handler
+    failure is at least recorded in the log with its traceback.
+    """
+    db.add(StripeWebhookEvent(event_id=event_id, event_type=event_type))
+    try:
+        await db.commit()
+        return True
+    except IntegrityError:
+        await db.rollback()
+        return False
 
 
 async def _handle_succeeded(pi: dict, db: AsyncSession) -> None:

--- a/api/tests/test_webhook_and_stripe_disclosure.py
+++ b/api/tests/test_webhook_and_stripe_disclosure.py
@@ -1,0 +1,195 @@
+"""Two Stripe-facing defects: a replayed webhook, and an open oracle.
+
+Neither endpoint had any test at all. Between them they are the only path in the
+system that moves money and one of the few that answers questions without a
+credential.
+
+`POST /api/webhook/stripe` incremented `campaign.raised_usd` once per delivery.
+Stripe documents at-least-once delivery and redelivers on any non-2xx or
+timeout, so the total drifted upward under entirely normal operation, and an
+inflated campaign figure looks the same as a successful campaign.
+
+`GET /api/stripe/connect/return/{pharma_id}` is the Stripe `return_url` and so
+cannot require a bearer token, but it returned `stripe_account_id`,
+`charges_enabled` and `payouts_enabled` for any id in the path.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+for _path in (str(_REPO_ROOT), str(_REPO_ROOT / "api")):
+    if _path not in sys.path:
+        sys.path.insert(0, _path)
+
+from models.campaign import Campaign  # noqa: E402
+from models.pharma import PharmaCompany  # noqa: E402
+
+
+def _event(event_id: str, campaign_id: str, amount_cents: int = 5000) -> dict:
+    return {
+        "id": event_id,
+        "type": "payment_intent.succeeded",
+        "data": {
+            "object": {
+                "id": "pi_" + event_id,
+                "amount_received": amount_cents,
+                "metadata": {"type": "donation", "campaign_id": campaign_id},
+            }
+        },
+    }
+
+
+@pytest.fixture()
+def accept_any_signature(monkeypatch):
+    """Bypass signature verification; these tests are about what happens after."""
+    def _construct(payload, _sig, _secret):
+        return json.loads(payload)
+
+    monkeypatch.setattr("stripe.Webhook.construct_event", _construct)
+
+
+@pytest.fixture()
+async def campaign(db_session, seeded_patient):
+    row = Campaign(
+        patient_id=seeded_patient.id,
+        title="Test campaign",
+        slug=f"test-{uuid.uuid4().hex[:8]}",
+        goal_usd=1000.0,
+        raised_usd=0.0,
+    )
+    db_session.add(row)
+    await db_session.commit()
+    return row
+
+
+class TestWebhookReplay:
+    async def test_one_delivery_credits_once(
+        self, client, campaign, db_session, accept_any_signature
+    ):
+        payload = _event("evt_single", campaign.id, 5000)
+        response = await client.post(
+            "/api/webhook/stripe", json=payload, headers={"stripe-signature": "x"}
+        )
+        assert response.status_code == 200
+
+        await db_session.refresh(campaign)
+        assert campaign.raised_usd == pytest.approx(50.0)
+
+    async def test_a_redelivered_event_does_not_credit_again(
+        self, client, campaign, db_session, accept_any_signature
+    ):
+        """The defect. Stripe sends the same event id again; the total must hold."""
+        payload = _event("evt_replay", campaign.id, 5000)
+        headers = {"stripe-signature": "x"}
+
+        first = await client.post("/api/webhook/stripe", json=payload, headers=headers)
+        second = await client.post("/api/webhook/stripe", json=payload, headers=headers)
+        third = await client.post("/api/webhook/stripe", json=payload, headers=headers)
+
+        assert first.status_code == second.status_code == third.status_code == 200
+        assert second.json().get("duplicate") is True
+        assert third.json().get("duplicate") is True
+
+        await db_session.refresh(campaign)
+        assert campaign.raised_usd == pytest.approx(50.0), (
+            "a redelivered event credited the campaign again; Stripe retries on "
+            "any non-2xx or timeout, so this inflates the total in normal operation"
+        )
+
+    async def test_distinct_events_both_credit(
+        self, client, campaign, db_session, accept_any_signature
+    ):
+        """Idempotency must key on the event id, not on the amount or campaign."""
+        headers = {"stripe-signature": "x"}
+        await client.post(
+            "/api/webhook/stripe", json=_event("evt_a", campaign.id, 5000), headers=headers
+        )
+        await client.post(
+            "/api/webhook/stripe", json=_event("evt_b", campaign.id, 2500), headers=headers
+        )
+
+        await db_session.refresh(campaign)
+        assert campaign.raised_usd == pytest.approx(75.0)
+
+    async def test_a_replay_is_still_acknowledged(
+        self, client, campaign, accept_any_signature
+    ):
+        """A duplicate must return 2xx, or Stripe keeps retrying it forever."""
+        payload = _event("evt_ack", campaign.id)
+        headers = {"stripe-signature": "x"}
+        await client.post("/api/webhook/stripe", json=payload, headers=headers)
+        again = await client.post("/api/webhook/stripe", json=payload, headers=headers)
+
+        assert again.status_code == 200
+        assert again.json()["received"] is True
+
+
+class TestOnboardingReturnDisclosesNothing:
+    @pytest.fixture()
+    async def company(self, db_session):
+        row = PharmaCompany(
+            name="Acme Pharma",
+            country="DE",
+            contact_email="ops@acme.test",
+            stripe_account_id="acct_SECRET123",
+        )
+        db_session.add(row)
+        await db_session.commit()
+        return row
+
+    @pytest.fixture()
+    def stripe_account(self, monkeypatch):
+        monkeypatch.setattr(
+            "stripe.Account.retrieve",
+            lambda _id: {
+                "id": "acct_SECRET123",
+                "details_submitted": True,
+                "charges_enabled": True,
+                "payouts_enabled": True,
+            },
+        )
+
+    async def test_it_stays_reachable_without_a_token(
+        self, client, company, stripe_account
+    ):
+        """It is Stripe's return_url, so requiring auth would break onboarding."""
+        response = await client.get(f"/api/stripe/connect/return/{company.id}")
+        assert response.status_code == 200
+
+    async def test_the_stripe_account_id_is_not_disclosed(
+        self, client, company, stripe_account
+    ):
+        response = await client.get(f"/api/stripe/connect/return/{company.id}")
+        body = response.text
+        assert "acct_SECRET123" not in body
+        assert "stripe_account_id" not in response.json()
+
+    async def test_capability_flags_are_not_disclosed(
+        self, client, company, stripe_account
+    ):
+        payload = response_json = (
+            await client.get(f"/api/stripe/connect/return/{company.id}")
+        ).json()
+        assert "charges_enabled" not in payload
+        assert "payouts_enabled" not in response_json
+
+    async def test_an_unknown_id_is_indistinguishable_from_a_known_one(
+        self, client, company, stripe_account
+    ):
+        """Differing status or shape would confirm which pharma ids exist."""
+        known = await client.get(f"/api/stripe/connect/return/{company.id}")
+        unknown = await client.get(f"/api/stripe/connect/return/{uuid.uuid4()}")
+
+        assert known.status_code == unknown.status_code == 200
+        assert set(known.json()) == set(unknown.json())
+
+    async def test_the_detail_endpoint_still_requires_admin(self, client, company):
+        """What was removed here is available from /status, behind the admin role."""
+        response = await client.get(f"/api/stripe/connect/status/{company.id}")
+        assert response.status_code == 403

--- a/docs/risk_analysis.md
+++ b/docs/risk_analysis.md
@@ -294,6 +294,48 @@ dispatcher at all, and `notify_campaign_milestone`'s only dispatcher is itself
 never called, so milestone emails cannot fire; both are recorded in the wiring
 test rather than left to be rediscovered.
 
+### F12. A replayed Stripe webhook inflated donation totals (H5) — FIXED
+
+`_handle_succeeded` in `api/routes/webhook.py` did
+`campaign.raised_usd = (campaign.raised_usd or 0) + amount_usd` with nothing
+recording which events had already been applied. Stripe documents at-least-once
+delivery and redelivers on any non-2xx response or timeout, so this is ordinary
+traffic rather than an error path, and the total only ever moved upward.
+
+This is H5 outside the benchmark suite: a public figure that overstates what
+happened. It is also the only endpoint in the system that moves money, and it
+had no test of any kind.
+
+Every event id is now claimed in `stripe_webhook_events` (migration `0012`)
+before any handler runs, and a repeat is acknowledged with `duplicate: true`
+without being processed. The id is the primary key rather than a unique column
+so two concurrent redeliveries resolve in the database instead of in a
+check-then-act race. Claiming commits before the handler runs: if a handler then
+fails the event is not retried, which is the right trade here, because a
+redelivery adds money that was never paid and that error is neither visible in
+nor reversible from the campaign total.
+
+The bare `except Exception` around `construct_event` also answered every
+internal parsing bug with "Invalid webhook payload", which Stripe retries
+indefinitely while the real cause went unrecorded. It now logs the traceback.
+
+### F13. An unauthenticated endpoint disclosed Stripe account state (H5) — FIXED
+
+`GET /api/stripe/connect/return/{pharma_id}` returned `stripe_account_id`,
+`charges_enabled` and `payouts_enabled` for whatever id appeared in the path,
+with no credential of any kind. Walking the ids read back the Stripe account and
+payout state of every company on the platform. It also returned 404 for unknown
+ids and 200 for known ones, so it confirmed which ids existed before the body
+was even read.
+
+It cannot require a token: it is the `return_url` given to
+`stripe.AccountLink.create`, so Stripe redirects the pharma's browser here with
+no Authorization header, and adding `_require_admin` would reject every pharma
+the moment they finish KYC. The fix is to stop it answering questions. It now
+returns the same shape for every id and reports only whether onboarding
+finished. Everything it used to disclose remains available from
+`GET /status/{pharma_id}`, which requires the admin role.
+
 ---
 
 ## 5. Open actions, in priority order


### PR DESCRIPTION
Two defects on the Stripe surface. Between them they cover the only endpoint that moves money and one of the few that answers questions with no credential. Neither had a test of any kind.

## A redelivered event added the donation again

`_handle_succeeded` did:

```python
campaign.raised_usd = (campaign.raised_usd or 0) + amount_usd
```

with nothing recording which events had already been applied. Stripe documents at-least-once delivery and redelivers on any non-2xx or timeout, so a repeat is ordinary traffic rather than an error condition. The figure only ever moved upward, and a campaign showing an inflated total looks exactly like a campaign that raised more money. The error is not reversible from the total.

Every event id is now claimed in `stripe_webhook_events` (migration `0012`) before any handler runs, and a repeat is acknowledged with `duplicate: true` without being processed. The id is the **primary key** rather than a unique column, so two concurrent redeliveries resolve in the database instead of in a check-then-act race in application code.

The claim commits before the handlers run. If a handler then fails, the event is not retried. That is the right trade here specifically: the alternative is adding money that was never paid, and unlike a missed email that error is neither visible nor reversible.

The bare `except` around `construct_event` also answered every internal parsing bug with "Invalid webhook payload". Stripe retries a non-2xx, so a defect on that path became an indefinite retry loop with the real cause never recorded. It now logs the traceback before returning the same 400.

## GET /stripe/connect/return/{pharma_id} answered anyone

It returned `stripe_account_id`, `charges_enabled` and `payouts_enabled` for whatever id appeared in the path, unauthenticated. Walking the ids read back the Stripe account and payout state of every company on the platform. It also 404'd on unknown ids and 200'd on known ones, so it confirmed which ids existed before the body was even read.

**It cannot take a token.** It is the `return_url` handed to `stripe.AccountLink.create`, so Stripe redirects the pharma's browser here with no Authorization header. Adding `_require_admin` would reject every pharma the moment they finish KYC, which is why simply guarding it was not the fix.

So it stops answering instead: the same response shape for every id, reporting only whether onboarding finished. Everything it used to disclose remains available from `GET /status/{pharma_id}`, which requires the admin role, and a test asserts that endpoint still 403s.

## Verification

865 passed, 1 xfailed, ruff clean, migration chain single-headed at `0001 → 0012`.

Run against the unfixed code first, four of the nine new tests fail:

| Test | Without the fix |
|---|---|
| `test_a_redelivered_event_does_not_credit_again` | three deliveries credit $150 instead of $50 |
| `test_the_stripe_account_id_is_not_disclosed` | `acct_SECRET123` present in the body |
| `test_capability_flags_are_not_disclosed` | both flags present |
| `test_an_unknown_id_is_indistinguishable_from_a_known_one` | 404 vs 200 confirms which ids exist |