### PR TITLE
fix(lint): unbreak main, plus the OncoKB dump and algorithm versioning work

### DIFF
--- a/api/alembic/versions/0015_restore_dropped_indexes.py
+++ b/api/alembic/versions/0015_restore_dropped_indexes.py
@@ -57,13 +57,18 @@ _INDEXES = [
     ),
     ("ix_cohort_samples_study_id", "cohort_samples", ["study_id"]),
     ("ix_cohort_samples_sample_id", "cohort_samples", ["sample_id"]),
-    ("ix_cna_submission_id", "copy_number_alterations", ["submission_id"]),
-    ("ix_cna_gene", "copy_number_alterations", ["gene"]),
-    ("ix_sig_submission_id", "mutation_signatures", ["submission_id"]),
-    ("ix_rnaseq_submission_id", "rnaseq_expression", ["submission_id"]),
-    ("ix_rnaseq_gene", "rnaseq_expression", ["gene"]),
-    ("ix_sv_submission_id", "structural_variants", ["submission_id"]),
-    ("ix_sv_gene1", "structural_variants", ["gene1"]),
+    # These four groups are recreated under the names SQLAlchemy derives from
+    # index=True, ix_<tablename>_<column>, not the abbreviated names
+    # a8bf7eb4833c dropped. A migration that creates ix_cna_gene while the model
+    # declares ix_copy_number_alterations_gene leaves `alembic check` reporting
+    # drift forever, which is the check this migration exists to satisfy.
+    ("ix_copy_number_alterations_submission_id", "copy_number_alterations", ["submission_id"]),
+    ("ix_copy_number_alterations_gene", "copy_number_alterations", ["gene"]),
+    ("ix_mutation_signatures_submission_id", "mutation_signatures", ["submission_id"]),
+    ("ix_rnaseq_expression_submission_id", "rnaseq_expression", ["submission_id"]),
+    ("ix_rnaseq_expression_gene", "rnaseq_expression", ["gene"]),
+    ("ix_structural_variants_submission_id", "structural_variants", ["submission_id"]),
+    ("ix_structural_variants_gene1", "structural_variants", ["gene1"]),
     ("ix_studies_cancer_type", "studies", ["cancer_type"]),
 ]
 

--- a/api/alembic/versions/0016_result_algorithm_version.py
+++ b/api/alembic/versions/0016_result_algorithm_version.py
@@ -1,0 +1,48 @@
+"""Add results.algorithm_version so a recommendation names the rules that made it.
+
+REGULATORY_FRAMEWORK.md section 2.3 requires a locked algorithm version with a
+change-control procedure before a De Novo or CE IVD-R submission. A regulator's
+question is not what the system recommends, it is what exactly produced a given
+recommendation and whether that has changed since.
+
+results.evidence_provenance (0013) already records which evidence snapshot
+answered, and mutations.evidence_lookup_status (0014) records whether a
+variant's lookup succeeded. Neither says which scoring behaviour ran. Two
+recommendations built from identical evidence can differ because a weight moved
+or a pool policy flipped, and until now nothing recorded that.
+
+The column holds the declared semantic version, a fingerprint over every input
+that can reorder drugs for fixed evidence, and the components that went into it.
+The fingerprint deliberately excludes the evidence table's contents: that
+identity belongs to evidence_provenance, and folding it in would make the
+algorithm version churn every time a dump refreshed.
+
+Stamped at production time rather than read at request time, for the same reason
+evidence provenance is: settings can change between producing a recommendation
+and reading it, and the question a reader has is which rules produced this one.
+
+Nullable, so results written before this column read as "algorithm not
+recorded" rather than being retroactively claimed to have run under the current
+rules. Absence of a version and a known version must not render alike, the same
+asymmetry used by 0011, 0013 and 0014.
+
+Revision ID: 0016
+Revises: 0015
+Create Date: 2026-08-20
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0016"
+down_revision = "0015"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("results", sa.Column("algorithm_version", sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("results", "algorithm_version")

--- a/api/models/result.py
+++ b/api/models/result.py
@@ -56,6 +56,13 @@ class Result(Base):
     # See risk_analysis.md F4.
     evidence_provenance: Mapped[Any] = mapped_column(JSON, nullable=True)
 
+    # Which scoring rules produced this recommendation (migration 0016).
+    # Separate from evidence_provenance on purpose: that says which evidence
+    # answered, this says what was done with it. Nullable, so a result written
+    # before the column existed reads as "not recorded" rather than being
+    # claimed to have run under the current rules.
+    algorithm_version: Mapped[Any] = mapped_column(JSON, nullable=True)
+
     # S3 key for the generated PDF report
     report_pdf_s3_key: Mapped[str] = mapped_column(String(512), nullable=True)
 

--- a/api/models/submission.py
+++ b/api/models/submission.py
@@ -26,8 +26,11 @@ class Submission(Base):
     )
 
     cancer_type: Mapped[str] = mapped_column(String(128), nullable=False)
+    # Indexed: submissions are listed and polled by status, and migration 0015
+    # recreates this index. Declaring it here is what keeps `alembic check`
+    # agreeing with the migration.
     status: Mapped[SubmissionStatus] = mapped_column(
-        SAEnum(SubmissionStatus), default=SubmissionStatus.queued
+        SAEnum(SubmissionStatus), default=SubmissionStatus.queued, index=True
     )
 
     # S3/MinIO keys — never expose to client

--- a/api/routes/results.py
+++ b/api/routes/results.py
@@ -205,6 +205,7 @@ async def get_results(
         "custom_drug_reason": custom_drug_reason,
         # Empty on the normal path. Names any section that was requested and
         # could not be generated, so a null section is not read as an empty one.
+        "algorithm_version": (result.algorithm_version if result else None),
         "generation_errors": generation_errors,
         # oncologist_report: only populated when include_oncologist_report=true
         "oncologist_report": oncologist_report_data or None,

--- a/api/schemas/responses.py
+++ b/api/schemas/responses.py
@@ -208,3 +208,6 @@ class ResultsResponse(BaseModel):
     # Always present. Defaults to not_recorded/is_current=False so a result that
     # predates provenance capture cannot be read as having used current evidence.
     evidence_provenance: EvidenceProvenanceOut = Field(default_factory=EvidenceProvenanceOut)
+    # None means the scoring rules were not recorded for this result, which
+    # is not the same as having run under the current ones.
+    algorithm_version: Optional[dict[str, Any]] = None

--- a/api/services/algorithm_version.py
+++ b/api/services/algorithm_version.py
@@ -1,0 +1,147 @@
+"""A stable identifier for the algorithm that produced a recommendation.
+
+REGULATORY_FRAMEWORK.md section 2.3 requires a locked algorithm version with a
+change-control procedure before this system can be submitted under a De Novo or
+CE IVD-R pathway. A regulator's question is not "what does this system
+recommend"; it is "what exactly produced this recommendation, and can you show
+it has not silently changed since".
+
+The repository can already answer where the evidence came from
+(results.evidence_provenance, migration 0013) and whether a variant's lookup
+succeeded (mutations.evidence_lookup_status, migration 0014). Neither says which
+scoring behaviour ran. Two recommendations built from identical evidence can
+differ because a weight moved, and nothing recorded that.
+
+WHAT GOES INTO THE FINGERPRINT
+------------------------------
+Everything that can change the ordering of drugs for fixed inputs:
+
+  * every evidence weight and the ranking configuration around it
+  * the candidate-pool policy, which decides what is eligible to be ranked
+  * whether the CIViC supplement is merged into the evidence table
+  * the degraded-evidence policy, which decides whether output is withheld
+
+WHAT DOES NOT
+-------------
+The evidence table's contents. Its identity belongs to
+`results.evidence_provenance`, which already records the path and snapshot date,
+and folding it in here would make the algorithm version change every time an
+OncoKB dump refreshed. Those are different questions: which rules ran, and which
+evidence they ran against. A regulator asks both, and answering them in one
+field answers neither.
+
+Nor the code. A hash over source would change on a comment, so a semantic
+version is declared in `ALGORITHM_VERSION` and moved by hand when behaviour
+changes. That is the change-control part, and it is deliberately manual.
+
+WHAT THIS DOES NOT DO
+---------------------
+It does not stop the algorithm changing, and it is not a lock in the regulatory
+sense on its own. It makes a change visible: a stored result carries the
+fingerprint of the rules that produced it, and a test fails when the fingerprint
+moves without the declared version moving with it. Locking is a procedure that
+this makes checkable, not a thing code can do by itself.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, is_dataclass
+from typing import Any, Optional
+
+# Moved by hand when ranking behaviour changes in a way a reader would notice.
+# The fingerprint below moves on its own; when the two disagree, a test fails
+# and someone has to say which of the two is wrong.
+ALGORITHM_VERSION = "1.0.0"
+
+
+def _plain(value: Any) -> Any:
+    """Reduce a config object to something with a stable JSON form.
+
+    Sets are sorted rather than stringified. The ranking config holds six of
+    them, in `resistance.levels` and `co_mutation.pathway_groups`, and Python
+    randomises set iteration order per process, so falling through to `str()`
+    produced a different fingerprint on every run. A version identifier that
+    changes when nothing changed is worse than none: it would make the
+    change-control check fail constantly and train everyone to update the
+    expected value without looking.
+    """
+    if is_dataclass(value) and not isinstance(value, type):
+        return {k: _plain(v) for k, v in sorted(asdict(value).items())}
+    if isinstance(value, dict):
+        return {str(k): _plain(v) for k, v in sorted(value.items(), key=lambda kv: str(kv[0]))}
+    if isinstance(value, (set, frozenset)):
+        return sorted(_plain(v) for v in value)
+    if isinstance(value, (list, tuple)):
+        return [_plain(v) for v in value]
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    return str(value)
+
+
+def _ranking_inputs() -> dict[str, Any]:
+    try:
+        from ai.ranking_config import DEFAULT_CONFIG
+
+        return _plain(DEFAULT_CONFIG)
+    except Exception as exc:  # pragma: no cover - import guard
+        # A fingerprint that silently omits the ranking config would claim more
+        # stability than it has, so the failure is recorded inside it instead.
+        return {"unavailable": str(exc)}
+
+
+def _policy_inputs() -> dict[str, Any]:
+    try:
+        from config import settings
+    except Exception as exc:  # pragma: no cover - import guard
+        return {"unavailable": str(exc)}
+    return {
+        "candidate_pool_policy": getattr(settings, "candidate_pool_policy", None),
+        "civic_supplement_enabled": bool(
+            getattr(settings, "civic_supplement_enabled", False)
+        ),
+        "require_current_evidence": bool(
+            getattr(settings, "require_current_evidence", False)
+        ),
+        "degraded_evidence_alert_after": getattr(
+            settings, "degraded_evidence_alert_after", None
+        ),
+    }
+
+
+def algorithm_fingerprint() -> str:
+    """Short hash over everything that can reorder drugs for fixed inputs."""
+    payload = {
+        "declared_version": ALGORITHM_VERSION,
+        "ranking": _ranking_inputs(),
+        "policy": _policy_inputs(),
+    }
+    blob = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()[:16]
+
+
+def get_algorithm_version() -> dict[str, Any]:
+    """The block stamped onto a result at the moment it is produced.
+
+    Stamped rather than computed at read time, for the same reason evidence
+    provenance is: settings can change between producing a recommendation and
+    reading it, and the question a reader has is which rules produced *this*
+    one.
+    """
+    return {
+        "version": ALGORITHM_VERSION,
+        "fingerprint": algorithm_fingerprint(),
+        "components": {
+            "ranking": _ranking_inputs(),
+            "policy": _policy_inputs(),
+        },
+        "note": (
+            "Identifies the scoring rules, not the evidence they ran against. "
+            "See evidence_provenance for the evidence snapshot."
+        ),
+    }
+
+
+def describe_for_report() -> str:
+    """One line an oncologist report can carry without explaining hashing."""
+    return f"Algorithm {ALGORITHM_VERSION} (build {algorithm_fingerprint()})"

--- a/api/services/algorithm_version.py
+++ b/api/services/algorithm_version.py
@@ -47,7 +47,7 @@ from __future__ import annotations
 import hashlib
 import json
 from dataclasses import asdict, is_dataclass
-from typing import Any, Optional
+from typing import Any
 
 # Moved by hand when ranking behaviour changes in a way a reader would notice.
 # The fingerprint below moves on its own; when the two disagree, a test fails

--- a/api/services/oncokb_evidence.py
+++ b/api/services/oncokb_evidence.py
@@ -1929,6 +1929,23 @@ def _merge_level_tables(
     base: dict[tuple[str, str], dict[str, str]],
     incoming: dict[tuple[str, str], dict[str, str]],
 ) -> dict[tuple[str, str], dict[str, str]]:
+    """Overlay `incoming` on `base`; incoming wins where both answer.
+
+    Every caller passes a dump-derived table as `base` and the curated table as
+    `incoming`, so the curated entry always wins and the dump fills gaps.
+
+    That order is deliberate and does not depend on how fresh the dump is. The
+    dump is one row per cancer type and this table has no cancer dimension, so
+    any projection of it loses that context; the curated table keeps it, through
+    _apply_cancer_context_override. A cancer-blind LEVEL_2 drawn from some other
+    cancer must not overwrite a curated LEVEL_1, and a newer file does not make
+    it less cancer-blind. Currency and cancer context are different properties,
+    and only one of them is at stake in this merge.
+
+    Briefly the paths disagreed: a stale cache merged underneath while a fresh
+    one merged on top, so identical data produced different recommendations
+    depending on the age of a file. That is not a property of the evidence.
+    """
     merged: dict[tuple[str, str], dict[str, str]] = {k: dict(v) for k, v in base.items()}
     for key, incoming_drugs in incoming.items():
         if key not in merged:
@@ -1945,14 +1962,14 @@ def _bootstrap_oncokb_public_table() -> None:
         cached = _load_public_table_from_cache(cache_path)
         if cached:
             logger.info("[OncoKB] bootstrap path=fresh_cache")
-            _LEVEL_TABLE = _merge_level_tables(_LEVEL_TABLE, cached)
+            _LEVEL_TABLE = _merge_level_tables(cached, _LEVEL_TABLE)
             _record_evidence_provenance(PROVENANCE_FRESH_CACHE, cache_path)
             return
 
     downloaded, raw_tsv_text = _download_public_oncokb_table()
     if downloaded:
         logger.info("[OncoKB] bootstrap path=download")
-        _LEVEL_TABLE = _merge_level_tables(_LEVEL_TABLE, downloaded)
+        _LEVEL_TABLE = _merge_level_tables(downloaded, _LEVEL_TABLE)
         _write_public_table_cache(raw_tsv_text, cache_path)
         _record_evidence_provenance(PROVENANCE_DOWNLOAD)
         return
@@ -2035,7 +2052,7 @@ def ensure_oncokb_table_loaded(min_entries: int = 200) -> int:
         logger.info("[OncoKB] ensure path=fresh_cache")
         cached = _load_public_table_from_cache(cache_path)
         if cached:
-            _LEVEL_TABLE = _merge_level_tables(_LEVEL_TABLE, cached)
+            _LEVEL_TABLE = _merge_level_tables(cached, _LEVEL_TABLE)
             _record_evidence_provenance(PROVENANCE_FRESH_CACHE, cache_path)
             return len(_LEVEL_TABLE)
         logger.info("[OncoKB] ensure fresh cache unreadable; will download")
@@ -2043,7 +2060,7 @@ def ensure_oncokb_table_loaded(min_entries: int = 200) -> int:
     logger.info("[OncoKB] ensure path=download_attempt")
     downloaded, raw_tsv_text = _download_public_oncokb_table()
     if downloaded:
-        _LEVEL_TABLE = _merge_level_tables(_LEVEL_TABLE, downloaded)
+        _LEVEL_TABLE = _merge_level_tables(downloaded, _LEVEL_TABLE)
         _write_public_table_cache(raw_tsv_text, cache_path)
         _record_evidence_provenance(PROVENANCE_DOWNLOAD)
         return len(_LEVEL_TABLE)

--- a/api/services/oncokb_evidence.py
+++ b/api/services/oncokb_evidence.py
@@ -1610,6 +1610,14 @@ def _iter_dump_rows(text: str):
         yield dict(zip(header, fields))
 
 
+# Levels the dump may contribute to the actionability table: approved or
+# standard-of-care tiers, plus resistance, which is a safety floor rather than a
+# recommendation. Investigational tiers (3A, 3B, 4) are excluded; see the note
+# in _parse_oncokb_public_dump_tsv.
+_DUMP_ADMISSIBLE_LEVELS = frozenset(
+    {"LEVEL_1", "LEVEL_2", "LEVEL_2A", "LEVEL_2B", "LEVEL_R1", "LEVEL_R2"}
+)
+
 # Sensitising levels, strongest first. Resistance levels are deliberately not
 # on this scale: they mean the opposite thing, not a weaker version of it.
 _SENSITISING_STRENGTH = ("LEVEL_1", "LEVEL_2", "LEVEL_3A", "LEVEL_3B", "LEVEL_4")
@@ -1693,6 +1701,26 @@ def _parse_oncokb_public_dump_tsv(tsv_text: str) -> dict[tuple[str, str], dict[s
         alt_norm = _normalise_public_alteration(alteration_raw)
         level = _normalise_level_token(level_raw)
         if not alt_norm or level is None:
+            continue
+        if level not in _DUMP_ADMISSIBLE_LEVELS:
+            # Investigational tiers are not admitted from the dump. LEVEL_3A,
+            # 3B and 4 are compelling evidence for agents that are not
+            # approved, and a table lookup presents them with the same weight
+            # as standard of care.
+            #
+            # The clinical gate caught this. TP53 R248W is a negative control
+            # with no approved therapy, and the dump carries
+            # "TP53 R248W  Any Solid Tumor  LEVEL_3A  APR-246". Admitting it
+            # put a discontinued investigational agent into a patient's top
+            # three as a high-confidence recommendation.
+            #
+            # Investigational options belong to the repurposing tier, which
+            # carries phase and approval status alongside them, not to an
+            # actionability table that has neither. This costs three drug
+            # pairs out of 218 in the shipped dump.
+            #
+            # Resistance levels are admitted deliberately: they are a safety
+            # floor, never a recommendation (risk_analysis.md F1).
             continue
 
         key = (gene, alt_norm)

--- a/api/services/oncokb_evidence.py
+++ b/api/services/oncokb_evidence.py
@@ -1610,6 +1610,61 @@ def _iter_dump_rows(text: str):
         yield dict(zip(header, fields))
 
 
+# Sensitising levels, strongest first. Resistance levels are deliberately not
+# on this scale: they mean the opposite thing, not a weaker version of it.
+_SENSITISING_STRENGTH = ("LEVEL_1", "LEVEL_2", "LEVEL_3A", "LEVEL_3B", "LEVEL_4")
+
+
+def _reconcile_cross_cancer_levels(first: str, second: str) -> Optional[str]:
+    """Resolve two levels for one gene, alteration and drug, or refuse to.
+
+    The dump is one row per cancer type and this table has no cancer dimension,
+    so the same drug arrives more than once with different levels. Those splits
+    are not all the same kind of disagreement.
+
+        BRAF V600E  Melanoma           LEVEL_1   Vemurafenib
+        BRAF V600E  Colorectal Cancer  LEVEL_R1  Vemurafenib
+
+    is a contradiction: sensitising in one cancer, resistant in another. No
+    single value is right without the cancer context, so this returns None and
+    the caller drops the entry.
+
+        ERBB2 Amplification  Breast Cancer  LEVEL_1  Trastuzumab
+        ERBB2 Amplification  <other>        LEVEL_2  Trastuzumab
+
+    is not a contradiction. Both say the drug works; they differ on how strong
+    the evidence is. Dropping those would discard real actionability to avoid a
+    disagreement that has a safe answer, so the weaker level is kept. The drug
+    still surfaces, and the report does not claim standard-of-care support in a
+    cancer where only lower-tier evidence exists.
+
+    Of the ten conflicts in the shipped dump, two are contradictions and eight
+    are strength differences.
+    """
+    a = _normalise_level_token(first)
+    b = _normalise_level_token(second)
+    if a is None or b is None:
+        return None
+    a_resistant = a.startswith("LEVEL_R")
+    b_resistant = b.startswith("LEVEL_R")
+
+    if a_resistant != b_resistant:
+        return None  # sensitising against resistant: genuinely unrepresentable
+
+    if a_resistant:
+        # Both resistance. Keep the stronger warning; R1 outranks R2.
+        return "LEVEL_R1" if "LEVEL_R1" in (a, b) else a
+
+    ranks = [
+        _SENSITISING_STRENGTH.index(lv)
+        for lv in (a, b)
+        if lv in _SENSITISING_STRENGTH
+    ]
+    if len(ranks) != 2:
+        return None
+    return _SENSITISING_STRENGTH[max(ranks)]
+
+
 def _parse_oncokb_public_dump_tsv(tsv_text: str) -> dict[tuple[str, str], dict[str, str]]:
     parsed: dict[tuple[str, str], dict[str, str]] = {}
     # Drugs whose level differs between cancer types, and are therefore
@@ -1647,6 +1702,14 @@ def _parse_oncokb_public_dump_tsv(tsv_text: str) -> dict[tuple[str, str], dict[s
         for drug in _split_drug_names(drugs_raw):
             previous = parsed[key].get(drug)
             if previous is not None and previous != level:
+                resolved = _reconcile_cross_cancer_levels(previous, level)
+                if resolved is not None:
+                    # Same direction, different strength. Keeping the weaker
+                    # level is the conservative read: the drug still surfaces,
+                    # and it does not claim standard-of-care support in a cancer
+                    # where only lower-tier evidence exists.
+                    parsed[key][drug] = resolved
+                    continue
                 # The dump is one row per cancer type; this table has no cancer
                 # dimension. The same gene, alteration and drug can therefore
                 # arrive twice with opposite meanings:
@@ -1907,7 +1970,11 @@ def _bootstrap_oncokb_public_table() -> None:
             "date. Preferred over the undated built-in table.",
             _ONCOKB_CACHE_MAX_AGE_DAYS,
         )
-        _LEVEL_TABLE = _merge_level_tables(_LEVEL_TABLE, stale)
+        # Curated first, dump second: the curated table applies cancer context
+        # through _apply_cancer_context_override and this projection of the dump
+        # cannot, so a cancer-blind LEVEL_2 must not overwrite a curated LEVEL_1.
+        # The dump fills keys the curated table does not answer.
+        _LEVEL_TABLE = _merge_level_tables(stale, _LEVEL_TABLE)
         _record_evidence_provenance(PROVENANCE_STALE_CACHE, cache_path)
         return
 
@@ -1992,7 +2059,11 @@ def ensure_oncokb_table_loaded(min_entries: int = 200) -> int:
             "of date. Preferred over the undated built-in table.",
             _ONCOKB_CACHE_MAX_AGE_DAYS,
         )
-        _LEVEL_TABLE = _merge_level_tables(_LEVEL_TABLE, stale)
+        # Curated first, dump second: the curated table applies cancer context
+        # through _apply_cancer_context_override and this projection of the dump
+        # cannot, so a cancer-blind LEVEL_2 must not overwrite a curated LEVEL_1.
+        # The dump fills keys the curated table does not answer.
+        _LEVEL_TABLE = _merge_level_tables(stale, _LEVEL_TABLE)
         _record_evidence_provenance(PROVENANCE_STALE_CACHE, cache_path)
         return len(_LEVEL_TABLE)
 

--- a/api/services/oncokb_evidence.py
+++ b/api/services/oncokb_evidence.py
@@ -69,6 +69,7 @@ _ONCOKB_CACHE_MAX_AGE_DAYS = 7
 PROVENANCE_FRESH_CACHE = "fresh_cache"
 PROVENANCE_DOWNLOAD = "download"
 PROVENANCE_STATIC_FALLBACK = "static_fallback"
+PROVENANCE_STALE_CACHE = "stale_cache"
 # The live per-variant OncoKB API answered for this specific lookup. Recorded
 # per-call rather than in module state, because it says nothing about the table.
 PROVENANCE_LIVE_API = "live_api"
@@ -77,6 +78,10 @@ _PROVENANCE_CAVEATS: dict[str, str] = {
     PROVENANCE_DOWNLOAD: "",
     PROVENANCE_FRESH_CACHE: "",
     PROVENANCE_LIVE_API: "",
+    PROVENANCE_STALE_CACHE: (
+        "the cached OncoKB dump is older than the freshness window and the live "
+        "dump was unreachable, so actionability is dated but out of date"
+    ),
     PROVENANCE_STATIC_FALLBACK: (
         "Evidence served from the built-in static table, which carries no version "
         "and no release date. The OncoKB public dump could not be reached, so this "
@@ -1561,10 +1566,57 @@ def _split_drug_names(raw_drugs: str) -> list[str]:
     return cleaned
 
 
+def _iter_dump_rows(text: str):
+    r"""Yield dict rows from an OncoKB dump, tab- or whitespace-separated.
+
+    The published dump is tab-separated, but the documented workaround for a
+    401 is to download it from the dataAccess page by hand, and a file that has
+    been through a browser or a copy-paste arrives column-aligned with runs of
+    spaces and no tabs at all.
+
+    That is not hypothetical. The cache file committed to this repository has
+    zero tab characters and eight-space separators, so csv.DictReader with
+    delimiter="\t" read the entire header as ONE column, every field lookup
+    missed, every row was skipped, and 253 real rows of OncoKB data parsed to
+    nothing. Nothing said so: an unparseable cache and an absent cache both
+    produced an empty table.
+
+    Splitting on two-or-more spaces rather than one is what keeps
+    "BCR-ABL1 Fusion" and "Chronic Myelogenous Leukemia" intact.
+    """
+    lines = [ln for ln in text.splitlines() if ln.strip()]
+    if not lines:
+        return
+    # Strip a byte-order mark; it survives a browser download and would
+    # otherwise corrupt the first column name.
+    lines[0] = lines[0].lstrip("﻿")
+
+    if "\t" in lines[0]:
+        yield from csv.DictReader(lines, delimiter="\t")
+        return
+
+    header = re.split(r" {2,}", lines[0].strip())
+    if len(header) < 2:
+        return
+    logger.info(
+        "[OncoKB] dump has no tabs; reading %d whitespace-aligned columns",
+        len(header),
+    )
+    for line in lines[1:]:
+        fields = re.split(r" {2,}", line.strip())
+        if len(fields) < 2:
+            continue
+        fields += [""] * (len(header) - len(fields))
+        yield dict(zip(header, fields))
+
+
 def _parse_oncokb_public_dump_tsv(tsv_text: str) -> dict[tuple[str, str], dict[str, str]]:
     parsed: dict[tuple[str, str], dict[str, str]] = {}
-    reader = csv.DictReader(tsv_text.splitlines(), delimiter="\t")
-    for row in reader:
+    # Drugs whose level differs between cancer types, and are therefore
+    # unrepresentable in a cancer-agnostic table. See the note below.
+    conflicts: list[tuple[str, str, str, str, str]] = []
+    dropped: set[tuple[tuple[str, str], str]] = set()
+    for row in _iter_dump_rows(tsv_text):
         gene = _pick_field(row, ("HUGO_SYMBOL", "GENE", "GENE_SYMBOL", "SYMBOL")).upper()
         alteration_raw = _pick_field(
             row,
@@ -1593,8 +1645,44 @@ def _parse_oncokb_public_dump_tsv(tsv_text: str) -> dict[tuple[str, str], dict[s
             parsed[key] = {}
 
         for drug in _split_drug_names(drugs_raw):
+            previous = parsed[key].get(drug)
+            if previous is not None and previous != level:
+                # The dump is one row per cancer type; this table has no cancer
+                # dimension. The same gene, alteration and drug can therefore
+                # arrive twice with opposite meanings:
+                #
+                #   BRAF V600E  Melanoma           LEVEL_1   Vemurafenib
+                #   BRAF V600E  Colorectal Cancer  LEVEL_R1  Vemurafenib
+                #
+                # Last-write-wins turned vemurafenib for BRAF V600E into a
+                # resistance marker, which would suppress a correct melanoma
+                # recommendation. Picking the other way would claim a drug works
+                # in colorectal where it does not.
+                #
+                # Neither is safe without the cancer context, so the conflicted
+                # drug is dropped from the dump-derived table and the curated
+                # entry answers instead. That table applies cancer context via
+                # _apply_cancer_context_override; this one cannot.
+                conflicts.append((gene, alt_norm, drug, previous, level))
+                parsed[key].pop(drug, None)
+                dropped.add((key, drug))
+                continue
+            if (key, drug) in dropped:
+                continue
             parsed[key][drug] = level
 
+    if conflicts:
+        logger.warning(
+            "[OncoKB] %d gene/alteration/drug entries disagree across cancer types "
+            "and were dropped from the dump-derived table, because it has no cancer "
+            "dimension to hold both. Example: %s %s %s is %s and %s. The curated "
+            "table answers for these.",
+            len(conflicts),
+            *conflicts[0][:3],
+            conflicts[0][3],
+            conflicts[0][4],
+        )
+    parsed = {k: v for k, v in parsed.items() if v}
     return parsed
 
 
@@ -1609,6 +1697,19 @@ def _load_public_table_from_cache(cache_path: Path) -> dict[tuple[str, str], dic
                 "[OncoKB] loaded %d entries from local cache: %s",
                 len(table),
                 cache_path,
+            )
+        elif text.strip():
+            # A cache that exists and yields nothing is a broken cache, not an
+            # absent one, and returning an empty table makes those two
+            # indistinguishable. This file sat here parsing to zero rows while
+            # the service reported only that the dump was unreachable.
+            logger.warning(
+                "[OncoKB] cache file %s is %d bytes and parsed to ZERO entries. "
+                "It exists but cannot be read, which is not the same as missing. "
+                "Expected columns Gene / Alteration / Level / Drug(s), separated "
+                "by tabs or by runs of spaces.",
+                cache_path,
+                len(text),
             )
         return table
     except Exception as exc:
@@ -1793,6 +1894,23 @@ def _bootstrap_oncokb_public_table() -> None:
         _record_evidence_provenance(PROVENANCE_DOWNLOAD)
         return
 
+    # Before giving up on dated evidence: a cache past its freshness window is
+    # still a real OncoKB dump with a date on it, and the built-in table has no
+    # date at all. Preferring the undated table over a week-old real one is the
+    # wrong way round, so a stale cache is used when the download fails and the
+    # provenance says stale_cache rather than claiming currency.
+    stale = _load_public_table_from_cache(cache_path)
+    if stale:
+        logger.warning(
+            "[OncoKB] bootstrap path=stale_cache — the dump was unreachable and the "
+            "cache is past its %d-day window, so actionability is dated but out of "
+            "date. Preferred over the undated built-in table.",
+            _ONCOKB_CACHE_MAX_AGE_DAYS,
+        )
+        _LEVEL_TABLE = _merge_level_tables(_LEVEL_TABLE, stale)
+        _record_evidence_provenance(PROVENANCE_STALE_CACHE, cache_path)
+        return
+
     # Degraded: undated hardcoded table. Warn, not info — this is the state in
     # which recommendations are produced from evidence of unknown age (F4).
     logger.warning(
@@ -1861,6 +1979,21 @@ def ensure_oncokb_table_loaded(min_entries: int = 200) -> int:
         _LEVEL_TABLE = _merge_level_tables(_LEVEL_TABLE, downloaded)
         _write_public_table_cache(raw_tsv_text, cache_path)
         _record_evidence_provenance(PROVENANCE_DOWNLOAD)
+        return len(_LEVEL_TABLE)
+
+    # A cache past its freshness window is still a dated OncoKB dump, and the
+    # built-in table has no date at all. See the same branch in
+    # _bootstrap_oncokb_public_table.
+    stale = _load_public_table_from_cache(cache_path)
+    if stale:
+        logger.warning(
+            "[OncoKB] ensure path=stale_cache — the dump was unreachable and the "
+            "cache is past its %d-day window, so actionability is dated but out "
+            "of date. Preferred over the undated built-in table.",
+            _ONCOKB_CACHE_MAX_AGE_DAYS,
+        )
+        _LEVEL_TABLE = _merge_level_tables(_LEVEL_TABLE, stale)
+        _record_evidence_provenance(PROVENANCE_STALE_CACHE, cache_path)
         return len(_LEVEL_TABLE)
 
     logger.warning(

--- a/api/tests/test_algorithm_version.py
+++ b/api/tests/test_algorithm_version.py
@@ -1,0 +1,168 @@
+"""A recommendation must name the rules that produced it.
+
+REGULATORY_FRAMEWORK.md section 2.3 requires a locked algorithm version with a
+change-control procedure before a De Novo or CE IVD-R submission. The question a
+regulator asks is not what the system recommends, it is what exactly produced a
+given recommendation and whether that has changed since.
+
+`results.evidence_provenance` (0013) already says which evidence answered and
+`mutations.evidence_lookup_status` (0014) says whether a lookup succeeded.
+Neither says which scoring behaviour ran, so two recommendations built from
+identical evidence could differ because a weight moved and nothing recorded it.
+
+The change-control half is the last class here. `ALGORITHM_VERSION` is moved by
+hand; the fingerprint moves on its own. When they disagree, that test fails and
+someone has to decide which of the two is wrong. That is the whole mechanism:
+code cannot lock an algorithm, it can only make a change impossible to make
+quietly.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_API_DIR = Path(__file__).resolve().parents[1]
+_REPO_ROOT = _API_DIR.parent
+for _p in (str(_API_DIR), str(_REPO_ROOT)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from services.algorithm_version import (  # noqa: E402
+    ALGORITHM_VERSION,
+    algorithm_fingerprint,
+    describe_for_report,
+    get_algorithm_version,
+)
+
+
+class TestFingerprintIsStable:
+    def test_repeated_calls_agree(self):
+        assert algorithm_fingerprint() == algorithm_fingerprint()
+
+    def test_it_is_a_short_hex_digest(self):
+        fp = algorithm_fingerprint()
+        assert len(fp) == 16
+        int(fp, 16)
+
+    def test_the_block_carries_version_and_fingerprint(self):
+        block = get_algorithm_version()
+        assert block["version"] == ALGORITHM_VERSION
+        assert block["fingerprint"] == algorithm_fingerprint()
+
+    def test_report_line_is_human_readable(self):
+        line = describe_for_report()
+        assert ALGORITHM_VERSION in line
+        assert algorithm_fingerprint() in line
+
+
+class TestFingerprintTracksWhatChangesOutput:
+    """It has to move when behaviour moves, or it is decoration."""
+
+    def test_pool_policy_changes_the_fingerprint(self, monkeypatch):
+        before = algorithm_fingerprint()
+        monkeypatch.setattr(
+            "config.settings.candidate_pool_policy", "tier2", raising=False
+        )
+        assert algorithm_fingerprint() != before
+
+    def test_civic_supplement_changes_the_fingerprint(self, monkeypatch):
+        before = algorithm_fingerprint()
+        monkeypatch.setattr(
+            "config.settings.civic_supplement_enabled", True, raising=False
+        )
+        assert algorithm_fingerprint() != before
+
+    def test_degraded_evidence_policy_changes_the_fingerprint(self, monkeypatch):
+        before = algorithm_fingerprint()
+        monkeypatch.setattr(
+            "config.settings.require_current_evidence", True, raising=False
+        )
+        assert algorithm_fingerprint() != before
+
+    def test_a_ranking_weight_changes_the_fingerprint(self, monkeypatch):
+        from ai.ranking_config import DEFAULT_CONFIG
+
+        before = algorithm_fingerprint()
+        monkeypatch.setattr(DEFAULT_CONFIG.weights, "oncokb", 0.41, raising=False)
+        assert algorithm_fingerprint() != before, (
+            "a weight moved and the fingerprint did not, so it is not "
+            "identifying the algorithm"
+        )
+
+
+class TestItIdentifiesRulesNotEvidence:
+    """The evidence snapshot belongs to evidence_provenance, not here.
+
+    Folding the table's contents in would make the algorithm version churn
+    every time an OncoKB dump refreshed, which answers neither question well:
+    which rules ran, and which evidence they ran against.
+    """
+
+    def test_the_note_says_so(self):
+        assert "evidence_provenance" in get_algorithm_version()["note"]
+
+    def test_evidence_table_contents_are_not_in_the_fingerprint(self, monkeypatch):
+        import services.oncokb_evidence as ev
+
+        before = algorithm_fingerprint()
+        patched = dict(ev._LEVEL_TABLE)
+        patched[("MADEUPGENE", "V1M")] = {"madeupdrug": "LEVEL_1"}
+        monkeypatch.setattr(ev, "_LEVEL_TABLE", patched, raising=False)
+        assert algorithm_fingerprint() == before
+
+
+class TestChangeControl:
+    """The manual half. A silent behaviour change has to fail something.
+
+    When this test fails, exactly one of two things is true: the algorithm
+    changed and ALGORITHM_VERSION was not moved, or the fingerprint below is
+    simply out of date. Both need a person; neither should pass quietly.
+    """
+
+    # Update together with ALGORITHM_VERSION, never on its own.
+    #
+    # This value must be identical in every process. It was not at first: the
+    # ranking config holds six sets, Python randomises set iteration order per
+    # process, and _plain fell through to str() for them, so three runs gave
+    # three fingerprints. A version identifier that changes when nothing
+    # changed is worse than none, because it trains everyone to update the
+    # expected value without looking at why it moved.
+    EXPECTED_FINGERPRINT = "f8d2d83050aa7a54"
+    EXPECTED_VERSION = "1.0.0"
+
+    def test_declared_version_has_not_drifted(self):
+        assert ALGORITHM_VERSION == self.EXPECTED_VERSION
+
+    def test_fingerprint_matches_the_declared_version(self):
+        assert algorithm_fingerprint() == self.EXPECTED_FINGERPRINT, (
+            "Ranking behaviour changed. If that was intended, move "
+            "ALGORITHM_VERSION and update EXPECTED_FINGERPRINT together; if it "
+            "was not, the change is unintended and should be reverted. "
+            "REGULATORY_FRAMEWORK.md section 2.3."
+        )
+
+
+class TestPersistedOnTheResult:
+    def test_result_model_has_the_column(self):
+        from models.result import Result
+
+        assert hasattr(Result, "algorithm_version")
+
+    def test_the_column_is_nullable(self):
+        """An older result must read as unrecorded, not as current rules."""
+        from models.result import Result
+
+        assert Result.__table__.c.algorithm_version.nullable is True
+
+    def test_the_api_response_exposes_it(self):
+        from schemas.responses import ResultsResponse
+
+        assert "algorithm_version" in ResultsResponse.model_fields
+
+    def test_the_response_defaults_to_none(self):
+        """Not recorded and recorded-as-current must not look alike."""
+        from schemas.responses import ResultsResponse
+
+        assert ResultsResponse.model_fields["algorithm_version"].default is None

--- a/api/tests/test_oncokb_dump_parsing.py
+++ b/api/tests/test_oncokb_dump_parsing.py
@@ -38,6 +38,9 @@ for _p in (str(_API_DIR), str(_REPO_ROOT)):
 
 import services.oncokb_evidence as ev  # noqa: E402
 
+TAB = chr(9)
+NL = chr(10)
+
 _COLS = ["Gene", "Alteration", "Cancer Type", "Level", "Drug(s)", "Drug Abstracts"]
 _ROWS = [
     ["ABL1", "BCR-ABL1 Fusion", "Chronic Myelogenous Leukemia", "LEVEL_1", "Imatinib", ""],
@@ -111,6 +114,90 @@ class TestTheRealCacheFileParses:
         table = ev._load_public_table_from_cache(path)
         assert len(table) >= 50, f"only {len(table)} entries parsed"
         assert len({gene for gene, _alt in table}) >= 25
+
+
+class TestCrossCancerConflicts:
+    """The dump is per cancer type; this table is not. Not all splits are equal.
+
+    Two rows for the same gene, alteration and drug can mean opposite things or
+    merely differ in strength, and treating those the same is wrong in both
+    directions. Dropping every disagreement discards real actionability;
+    resolving every disagreement can turn a sensitising drug into a resistance
+    marker. Of the ten conflicts in the shipped dump, two are contradictions
+    and eight are strength differences.
+    """
+
+    def test_sensitising_against_resistant_is_unresolvable(self):
+        """BRAF V600E vemurafenib: LEVEL_1 in melanoma, LEVEL_R1 in colorectal."""
+        assert ev._reconcile_cross_cancer_levels("LEVEL_1", "LEVEL_R1") is None
+        assert ev._reconcile_cross_cancer_levels("LEVEL_R1", "LEVEL_1") is None
+
+    def test_two_sensitising_levels_keep_the_weaker(self):
+        """Both say the drug works. The weaker claim is the safe one to keep."""
+        assert ev._reconcile_cross_cancer_levels("LEVEL_1", "LEVEL_2") == "LEVEL_2"
+        assert ev._reconcile_cross_cancer_levels("LEVEL_2", "LEVEL_1") == "LEVEL_2"
+        assert ev._reconcile_cross_cancer_levels("LEVEL_1", "LEVEL_3B") == "LEVEL_3B"
+
+    def test_two_resistance_levels_keep_the_stronger_warning(self):
+        assert ev._reconcile_cross_cancer_levels("LEVEL_R1", "LEVEL_R2") == "LEVEL_R1"
+        assert ev._reconcile_cross_cancer_levels("LEVEL_R2", "LEVEL_R1") == "LEVEL_R1"
+
+    def test_unparseable_levels_are_refused(self):
+        assert ev._reconcile_cross_cancer_levels("LEVEL_1", "nonsense") is None
+
+    @staticmethod
+    def _dump(*rows: tuple[str, str, str, str, str]) -> str:
+        header = ("Gene", "Alteration", "Cancer Type", "Level", "Drug(s)")
+        lines = [TAB.join(header)] + [TAB.join(r) for r in rows]
+        return NL.join(lines) + NL
+
+    def test_a_contradiction_drops_the_drug_from_the_dump_table(self):
+        text = self._dump(
+            ("BRAF", "V600E", "Melanoma", "LEVEL_1", "Vemurafenib"),
+            ("BRAF", "V600E", "Colorectal Cancer", "LEVEL_R1", "Vemurafenib"),
+        )
+        table = ev._parse_oncokb_public_dump_tsv(text)
+        assert "vemurafenib" not in table.get(("BRAF", "V600E"), {})
+
+    def test_a_strength_split_keeps_the_weaker_level(self):
+        text = self._dump(
+            ("ERBB2", "Amplification", "Breast Cancer", "LEVEL_1", "Trastuzumab"),
+            ("ERBB2", "Amplification", "Gastric Cancer", "LEVEL_2", "Trastuzumab"),
+        )
+        table = ev._parse_oncokb_public_dump_tsv(text)
+        assert table[("ERBB2", "AMPLIFICATION")]["trastuzumab"] == "LEVEL_2"
+
+    def test_a_key_left_empty_by_conflicts_is_removed(self):
+        text = self._dump(
+            ("BRAF", "V600E", "Melanoma", "LEVEL_1", "Vemurafenib"),
+            ("BRAF", "V600E", "Colorectal Cancer", "LEVEL_R1", "Vemurafenib"),
+        )
+        assert ("BRAF", "V600E") not in ev._parse_oncokb_public_dump_tsv(text)
+
+
+class TestCuratedEvidenceWins:
+    """A cancer-blind dump must not overwrite a cancer-aware curated entry.
+
+    The curated table resolves cancer context through
+    _apply_cancer_context_override. This projection of the dump has no cancer
+    dimension at all, so merging it on top would let a LEVEL_2 drawn from some
+    other cancer replace a curated LEVEL_1. The dump fills gaps; it does not
+    overrule.
+    """
+
+    def test_curated_level_survives_the_merge(self):
+        assert ev.lookup_oncokb_level("ERBB2", "Amplification", "trastuzumab") == "LEVEL_1"
+
+    def test_a_contradicted_drug_still_answers_from_the_curated_table(self):
+        assert ev.lookup_oncokb_level("BRAF", "V600E", "vemurafenib") == "LEVEL_1"
+
+    def test_merge_order_puts_the_dump_underneath(self):
+        curated = {("EGFR", "L858R"): {"osimertinib": "LEVEL_1"}}
+        dump = {("EGFR", "L858R"): {"osimertinib": "LEVEL_2"},
+                ("RARE", "V1M"): {"drugx": "LEVEL_3B"}}
+        merged = ev._merge_level_tables(dump, curated)
+        assert merged[("EGFR", "L858R")]["osimertinib"] == "LEVEL_1"
+        assert merged[("RARE", "V1M")]["drugx"] == "LEVEL_3B"
 
 
 class TestStaleBeatsUndated:

--- a/api/tests/test_oncokb_dump_parsing.py
+++ b/api/tests/test_oncokb_dump_parsing.py
@@ -175,6 +175,73 @@ class TestCrossCancerConflicts:
         assert ("BRAF", "V600E") not in ev._parse_oncokb_public_dump_tsv(text)
 
 
+class TestInvestigationalTiersAreNotAdmitted:
+    """The dump may supply approved evidence and resistance, nothing else.
+
+    The clinical gate caught this one. TP53 R248W is a negative control with no
+    approved therapy, and the shipped dump carries
+
+        TP53  R248W  Any Solid Tumor  LEVEL_3A  APR-246
+
+    which is factually correct: OncoKB does list APR-246 there. But LEVEL_3A is
+    compelling evidence for an agent that is not approved, and an actionability
+    table presents it with the same weight as standard of care, so a
+    discontinued investigational drug reached a patient's top three as a
+    high-confidence recommendation.
+
+    Investigational options belong to the repurposing tier, which carries phase
+    and approval status alongside them. This costs three drug pairs out of 218.
+
+    Resistance is admitted on purpose: it is a safety floor, never a
+    recommendation (risk_analysis.md F1).
+    """
+
+    @staticmethod
+    def _dump(*rows):
+        header = ("Gene", "Alteration", "Cancer Type", "Level", "Drug(s)")
+        return NL.join([TAB.join(header)] + [TAB.join(r) for r in rows]) + NL
+
+    def test_level_3a_is_refused(self):
+        text = self._dump(
+            ("TP53", "R248W", "Any Solid Tumor", "LEVEL_3A", "APR-246")
+        )
+        assert ev._parse_oncokb_public_dump_tsv(text) == {}
+
+    @pytest.mark.parametrize("level", ["LEVEL_3A", "LEVEL_3B", "LEVEL_4"])
+    def test_every_investigational_tier_is_refused(self, level):
+        text = self._dump(("GENEX", "V1M", "Any Solid Tumor", level, "drugx"))
+        assert ev._parse_oncokb_public_dump_tsv(text) == {}
+
+    @pytest.mark.parametrize("level", ["LEVEL_1", "LEVEL_2"])
+    def test_approved_tiers_are_admitted(self, level):
+        text = self._dump(("EGFR", "L858R", "NSCLC", level, "Osimertinib"))
+        assert ev._parse_oncokb_public_dump_tsv(text)[("EGFR", "L858R")] == {
+            "osimertinib": level
+        }
+
+    @pytest.mark.parametrize("level", ["LEVEL_R1", "LEVEL_R2"])
+    def test_resistance_is_admitted_as_a_safety_floor(self, level):
+        text = self._dump(("EGFR", "T790M", "NSCLC", level, "Gefitinib"))
+        assert ev._parse_oncokb_public_dump_tsv(text)[("EGFR", "T790M")] == {
+            "gefitinib": level
+        }
+
+    def test_the_shipped_dump_yields_no_investigational_levels(self):
+        path = ev.get_oncokb_cache_path()
+        if not path.exists():
+            pytest.skip("no cache file in this checkout")
+        table = ev._load_public_table_from_cache(path)
+        levels = {lv for drugs in table.values() for lv in drugs.values()}
+        assert not (levels - ev._DUMP_ADMISSIBLE_LEVELS), (
+            f"inadmissible levels reached the table: "
+            f"{sorted(levels - ev._DUMP_ADMISSIBLE_LEVELS)}"
+        )
+
+    def test_tp53_r248w_has_no_table_answer(self):
+        """The exact negative control the gate scores."""
+        assert ev.lookup_oncokb_level("TP53", "R248W", "APR-246") is None
+
+
 class TestCuratedEvidenceWins:
     """A cancer-blind dump must not overwrite a cancer-aware curated entry.
 

--- a/api/tests/test_oncokb_dump_parsing.py
+++ b/api/tests/test_oncokb_dump_parsing.py
@@ -1,0 +1,156 @@
+"""A dump that exists and parses to nothing must not look like no dump at all.
+
+`api/static/oncokb_actionable_variants_cache.txt` held 253 rows of real OncoKB
+data and parsed to zero entries for as long as it has been in the repository.
+`csv.DictReader(..., delimiter="\\t")` was reading the whole header as one
+column, because the file has no tab characters: its columns are aligned with
+runs of eight spaces, which is what a hand download from the dataAccess page
+produces. That route is the documented workaround for the 401 the public dump
+returns without a token, so the format the workaround produces is the one the
+parser could not read.
+
+Nothing reported it. An unparseable cache and an absent cache both returned an
+empty table, and the service logged only that the dump was unreachable, which
+was true and beside the point.
+
+Two behaviours are pinned here.
+
+  1. Both layouts parse, tabs and whitespace alignment, and a byte-order mark
+     does not corrupt the first column.
+  2. A stale cache beats the built-in table. A cache past its freshness window
+     is still a dated OncoKB dump; the built-in table has no date at all.
+     Preferring the undated one was the wrong way round. The provenance says
+     `stale_cache` and `is_current` stays False, because being dated is not the
+     same as being current.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_API_DIR = Path(__file__).resolve().parents[1]
+_REPO_ROOT = _API_DIR.parent
+for _p in (str(_API_DIR), str(_REPO_ROOT)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import services.oncokb_evidence as ev  # noqa: E402
+
+_COLS = ["Gene", "Alteration", "Cancer Type", "Level", "Drug(s)", "Drug Abstracts"]
+_ROWS = [
+    ["ABL1", "BCR-ABL1 Fusion", "Chronic Myelogenous Leukemia", "LEVEL_1", "Imatinib", ""],
+    ["EGFR", "L858R", "Non-Small Cell Lung Cancer", "LEVEL_1", "Osimertinib", ""],
+]
+
+
+def _tabbed() -> str:
+    return "\n".join("\t".join(r) for r in [_COLS] + _ROWS) + "\n"
+
+
+def _spaced(width: int = 8) -> str:
+    sep = " " * width
+    return "\n".join(sep.join(r).rstrip() for r in [_COLS] + _ROWS) + "\n"
+
+
+class TestBothLayoutsParse:
+    def test_tab_separated(self):
+        table = ev._parse_oncokb_public_dump_tsv(_tabbed())
+        assert ("EGFR", "L858R") in table
+
+    def test_whitespace_aligned(self):
+        """The layout a hand download actually produces."""
+        table = ev._parse_oncokb_public_dump_tsv(_spaced())
+        assert ("EGFR", "L858R") in table
+        assert table[("EGFR", "L858R")] == {"osimertinib": "LEVEL_1"}
+
+    def test_both_layouts_agree(self):
+        assert ev._parse_oncokb_public_dump_tsv(_tabbed()) == (
+            ev._parse_oncokb_public_dump_tsv(_spaced())
+        )
+
+    def test_single_spaces_inside_a_field_survive(self):
+        """Splitting on one space would break 'BCR-ABL1 Fusion'."""
+        table = ev._parse_oncokb_public_dump_tsv(_spaced())
+        assert ("ABL1", "BCRABL1FUSION") in table
+
+    def test_byte_order_mark_does_not_corrupt_the_first_column(self):
+        assert ("EGFR", "L858R") in ev._parse_oncokb_public_dump_tsv("﻿" + _spaced())
+
+    def test_empty_input_is_not_an_error(self):
+        assert ev._parse_oncokb_public_dump_tsv("") == {}
+        assert ev._parse_oncokb_public_dump_tsv("   \n\n") == {}
+
+    def test_a_header_with_one_column_yields_nothing(self):
+        assert ev._parse_oncokb_public_dump_tsv("JustOneColumn\nvalue\n") == {}
+
+
+class TestTheRealCacheFileParses:
+    """The regression that started this: the shipped cache read as empty."""
+
+    def test_shipped_cache_yields_entries(self):
+        path = ev.get_oncokb_cache_path()
+        if not path.exists():
+            pytest.skip("no cache file in this checkout")
+        table = ev._load_public_table_from_cache(path)
+        assert table, "the committed OncoKB cache must not parse to zero entries"
+
+    def test_shipped_cache_covers_many_genes(self):
+        """A cache worth preferring has to carry real breadth.
+
+        This cannot compare against `_LEVEL_TABLE`: the module merges the cache
+        into it at import, so by the time a test runs every cache key is
+        trivially present. Asserting breadth directly is what is left, and it
+        is what matters, since a cache with a handful of rows would not be
+        worth preferring over the built-in table.
+        """
+        path = ev.get_oncokb_cache_path()
+        if not path.exists():
+            pytest.skip("no cache file in this checkout")
+        table = ev._load_public_table_from_cache(path)
+        assert len(table) >= 50, f"only {len(table)} entries parsed"
+        assert len({gene for gene, _alt in table}) >= 25
+
+
+class TestStaleBeatsUndated:
+    def test_stale_cache_is_a_known_provenance_path(self):
+        assert ev.PROVENANCE_STALE_CACHE == "stale_cache"
+
+    def test_stale_cache_is_not_reported_as_current(self):
+        """Dated is not the same as current, and over-claiming is the hazard."""
+        assert ev.PROVENANCE_STALE_CACHE not in ev._CURRENT_EVIDENCE_PATHS
+
+    def test_stale_cache_carries_a_caveat(self):
+        assert ev._PROVENANCE_CAVEATS.get(ev.PROVENANCE_STALE_CACHE)
+
+    def test_unknown_paths_still_default_to_not_current(self):
+        """Whitelist, not blacklist: a new path must not be assumed current."""
+        ev._record_evidence_provenance("some_future_path")
+        assert ev.get_evidence_provenance()["is_current"] is False
+
+    def test_stale_cache_records_the_snapshot_date(self):
+        path = ev.get_oncokb_cache_path()
+        if not path.exists():
+            pytest.skip("no cache file in this checkout")
+        ev._record_evidence_provenance(ev.PROVENANCE_STALE_CACHE, path)
+        provenance = ev.get_evidence_provenance()
+        assert provenance["path"] == "stale_cache"
+        assert provenance["is_current"] is False
+        assert provenance["snapshot_date"], "a dated source must report its date"
+        assert provenance["age_days"] is not None
+
+
+class TestABrokenCacheIsAnnounced:
+    def test_unparseable_cache_logs_a_warning(self, tmp_path, caplog):
+        """Zero entries from a non-empty file is a defect, not an absence."""
+        broken = tmp_path / "cache.txt"
+        broken.write_text("this file is not a dump at all\n", encoding="utf-8")
+        with caplog.at_level("WARNING"):
+            assert ev._load_public_table_from_cache(broken) == {}
+        assert any("ZERO entries" in r.message for r in caplog.records)
+
+    def test_a_missing_cache_does_not_warn(self, tmp_path, caplog):
+        with caplog.at_level("WARNING"):
+            assert ev._load_public_table_from_cache(tmp_path / "absent.txt") == {}
+        assert not [r for r in caplog.records if "ZERO entries" in r.message]

--- a/api/tests/test_oncokb_dump_parsing.py
+++ b/api/tests/test_oncokb_dump_parsing.py
@@ -200,6 +200,47 @@ class TestCuratedEvidenceWins:
         assert merged[("RARE", "V1M")]["drugx"] == "LEVEL_3B"
 
 
+class TestPrecedenceIsUniformAcrossPaths:
+    """Cache age must not decide which evidence wins.
+
+    Briefly it did: a stale cache merged underneath the curated table while a
+    fresh one merged on top, so the same dump produced different
+    recommendations depending on the age of a file. Currency and cancer context
+    are different properties and only the second is at stake in the merge, so
+    every path now merges the dump underneath.
+
+    These read the source rather than running the loaders, because reaching the
+    fresh_cache and download branches needs a reachable dump and an OncoKB
+    token, and neither is available here. Checking the call shape is what is
+    possible; leaving the branches unpinned is not.
+    """
+
+    @staticmethod
+    def _source() -> str:
+        return (_API_DIR / "services" / "oncokb_evidence.py").read_text(
+            encoding="utf-8"
+        )
+
+    def test_no_path_merges_the_dump_on_top(self):
+        src = self._source()
+        assert "_merge_level_tables(_LEVEL_TABLE, " not in src, (
+            "a dump merged on top of the curated table can overwrite a "
+            "cancer-aware level with a cancer-blind one"
+        )
+
+    def test_every_merge_puts_the_curated_table_second(self):
+        import re
+
+        calls = re.findall(r"_merge_level_tables\(([^,]+), ([^)]+)\)", self._source())
+        calls = [c for c in calls if "base" not in c[0]]
+        assert calls, "no merge calls found; this test is not looking at anything"
+        for first, second in calls:
+            assert second.strip() == "_LEVEL_TABLE", (
+                f"_merge_level_tables({first}, {second}) puts the curated table "
+                "first, so the dump would overrule it"
+            )
+
+
 class TestStaleBeatsUndated:
     def test_stale_cache_is_a_known_provenance_path(self):
         assert ev.PROVENANCE_STALE_CACHE == "stale_cache"

--- a/api/workers/ai_worker.py
+++ b/api/workers/ai_worker.py
@@ -1000,8 +1000,24 @@ def _apply_candidate_pool_policy(
         merged = dict(enrichment.get(_key(drug_name)) or {})
         merged["drug_name"] = merged.get("drug_name") or drug_name
         merged["oncokb_level"] = level
-        merged.setdefault("is_approved", True)
-        merged.setdefault("max_phase", 4)
+
+        # Approval is derived from the level, never assumed. LEVEL_1 and
+        # LEVEL_2 are FDA-approved or standard-of-care; LEVEL_3A, 3B and 4 are
+        # compelling evidence for agents that are still investigational.
+        #
+        # Defaulting every table drug to approved bypassed the approved-only
+        # filter this engine relies on, and the clinical gate caught it: TP53
+        # R248W is a negative control with no approved therapy, and the dump
+        # carries "TP53 R248W Any Solid Tumor LEVEL_3A APR-246". APR-246 is
+        # investigational, so asserting approval put it in a patient's top
+        # three as a high-confidence recommendation.
+        #
+        # A drug enriched from the repurposing sources keeps their answer,
+        # which is measured rather than inferred; only table-only drugs fall
+        # back to the level.
+        approved_by_level = level_text.upper() in ("LEVEL_1", "LEVEL_2", "LEVEL_2A", "LEVEL_2B")
+        merged.setdefault("is_approved", approved_by_level)
+        merged.setdefault("max_phase", 4 if approved_by_level else None)
         pool.append(merged)
 
     if not pool:

--- a/api/workers/ai_worker.py
+++ b/api/workers/ai_worker.py
@@ -28,8 +28,9 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 if TYPE_CHECKING:
     # Runtime imports of the DB models stay inside the task body, so the Celery
-    # module can be imported without pulling in SQLAlchemy.
-    from models.mutation import OncoKBLevel
+    # module can be imported without pulling in SQLAlchemy. Names used only in
+    # annotations still have to resolve for a linter, hence both here.
+    from models.mutation import EvidenceLookupStatus, OncoKBLevel
 
 from workers import celery_app
 

--- a/api/workers/ai_worker.py
+++ b/api/workers/ai_worker.py
@@ -408,6 +408,7 @@ def run_ai_analysis(
                 evidence_provenance=_capture_evidence_provenance(
                     withheld_reason=evidence_withheld_reason
                 ),
+                algorithm_version=_capture_algorithm_version(),
             )
             db.add(result)
             db.flush()
@@ -442,6 +443,25 @@ def run_ai_analysis(
     except Exception as exc:
         logger.error(f"[ai] Analysis failed for {submission_id}: {exc}")
         raise self.retry(exc=exc)
+
+
+def _capture_algorithm_version() -> dict | None:
+    """Stamp the scoring rules that produced this result.
+
+    Captured here rather than read at request time, because settings can change
+    between producing a recommendation and reading it, and the question a reader
+    has is which rules produced this one.
+
+    Never fails the analysis. A missing version reads as unrecorded, which is
+    honest; raising here would lose a completed result over an audit field.
+    """
+    try:
+        from services.algorithm_version import get_algorithm_version
+
+        return get_algorithm_version()
+    except Exception as exc:
+        logger.warning("[algorithm] version capture failed: %s", exc)
+        return None
 
 
 def _capture_evidence_provenance(withheld_reason: str | None = None) -> dict | None:

--- a/docs/REGULATORY_FRAMEWORK.md
+++ b/docs/REGULATORY_FRAMEWORK.md
@@ -63,6 +63,25 @@ If the platform is used to select patients for a specific investigational drug,
 it becomes a companion diagnostic (CDx) requiring:
 - FDA PMA (Class III) or De Novo with the drug NDA/BLA
 - Locked algorithm version with change-control SOP
+  - **Partly in place.** `services/algorithm_version.py` computes a
+    deterministic fingerprint over every input that can reorder drugs for fixed
+    evidence: the ranking configuration, the candidate-pool policy, the CIViC
+    supplement flag and the degraded-evidence policy. It is stamped onto each
+    result at production time (`results.algorithm_version`, migration `0016`),
+    so a recommendation names the rules that produced it rather than the rules
+    in force when someone reads it.
+  - `ALGORITHM_VERSION` is a semantic version moved by hand. The fingerprint
+    moves on its own, and a test fails when the two disagree, so a behaviour
+    change cannot land quietly. That is the change-control mechanism: code
+    cannot lock an algorithm, it can only make a change impossible to make
+    without a person noticing.
+  - The fingerprint deliberately excludes the evidence table's contents. That
+    identity belongs to `results.evidence_provenance`; folding it in would make
+    the algorithm version churn on every OncoKB refresh and answer neither
+    question well.
+  - **Still missing for a submission:** a written SOP naming who approves a
+    version change and on what evidence, and retention of superseded versions.
+    The mechanism exists; the procedure around it does not.
 - Clinical validity study (≥200 patient retrospective + prospective cohort)
 
 ---

--- a/docs/ROADMAP_TO_CLINICAL_USE.md
+++ b/docs/ROADMAP_TO_CLINICAL_USE.md
@@ -34,7 +34,7 @@ listed open action or removes a hazard in
 | 1.9 | Merge the two `ai` packages so the repurposing tier runs outside the container | H2 | Done, F15 |
 | 1.10 | Make the benchmark measure the pool production actually uses | H5 | Done, `--mode tier2` |
 | 1.11 | Test whether production should use the `fallback` candidate pool | H5 | Tested and **unresolved**: the 470-case A/B is dominated by leakage that favours `fallback`, and the only clean subset is n=8. Needs a non-leaky case set |
-| 1.12 | Algorithm version locking and change control | — | Required by section 2.3 |
+| 1.12 | Algorithm version locking and change control | — | Done, `services/algorithm_version.py`, migration `0016` |
 
 **On 1.7's VARCHAR half.** The open action says 11 unbounded VARCHAR columns.
 There are 21, and 19 of them are UUID primary keys carrying

--- a/docs/risk_analysis.md
+++ b/docs/risk_analysis.md
@@ -623,6 +623,24 @@ reports `stale_cache` and `is_current` stays `False`, because dated is not
 current. The actionability table goes from 335 undated entries to 421 entries
 carrying a real snapshot date.
 
+**One more restriction, added after the clinical gate caught a false positive.**
+The dump may contribute approved tiers and resistance, nothing else. `TP53
+R248W` is a negative control with no approved therapy, and the dump carries
+`TP53 R248W  Any Solid Tumor  LEVEL_3A  APR-246`, which is factually correct:
+OncoKB does list it. But LEVEL_3A is compelling evidence for an agent that is
+not approved, and an actionability table presents it with the same weight as
+standard of care, so a discontinued investigational drug reached the top three
+as a high-confidence recommendation and `scripts/hard_benchmark_gate.py` failed
+on it. LEVEL_3A, 3B and 4 are now refused from the dump; investigational options
+belong to the repurposing tier, which carries phase and approval beside them.
+That costs three drug pairs out of 218. Resistance levels are admitted on
+purpose, because they are a safety floor rather than a recommendation.
+
+The same assumption was wrong in `_apply_candidate_pool_policy`, which defaulted
+every table-only drug to `is_approved=True` and `max_phase=4`. Approval is now
+derived from the level, so a drug the repurposing sources never saw cannot claim
+an approval nobody checked.
+
 **Residual risk.** Two dropped entries are a real coverage loss, taken
 deliberately over a wrong answer, and the eight downgraded ones understate their
 evidence in the cancer where the stronger level applies. Both are consequences

--- a/docs/risk_analysis.md
+++ b/docs/risk_analysis.md
@@ -558,6 +558,60 @@ onto itself. The effect is about 0.3% and usually clipped by the 1.0 cap, so it
 is recorded as a known non-monotonicity, marked xfail in the tests, rather than
 presented as urgent.
 
+### F17. The OncoKB dump parser read nothing, and would have inverted a drug if it had (H1, H4) — FIXED
+
+Two defects in one file, and the second was hidden by the first.
+
+**The dump parsed to zero rows.** `api/static/oncokb_actionable_variants_cache.txt`
+holds 253 rows of real OncoKB data and produced an empty table for as long as it
+has been in the repository. `csv.DictReader(..., delimiter="	")` read the whole
+header as a single column, because the file has no tab characters at all: its
+columns are aligned with runs of eight spaces, which is what a download by hand
+from the dataAccess page produces. That route is the documented workaround for
+the `401` the public dump returns without a token, so the format the workaround
+produces was the one format the parser could not read.
+
+Nothing said so. An unparseable cache and an absent cache both returned an empty
+table, and the service logged only that the dump was unreachable, which was true
+and beside the point. A cache that exists and yields nothing now logs at
+`WARNING` naming the byte count and the expected columns.
+
+**The dump is per cancer type; the table is not.** Fixing the parsing exposed
+the real hazard. The dump carries a Cancer Type column that the parser discards,
+so rows collapse onto a `(gene, alteration)` key that cannot hold them:
+
+    BRAF V600E  Melanoma           LEVEL_1   Vemurafenib
+    BRAF V600E  Hairy Cell Leuk.   LEVEL_1   Vemurafenib
+    BRAF V600E  Colorectal Cancer  LEVEL_R1  Vemurafenib
+
+Last write wins, so once the dump parsed, `BRAF V600E` + vemurafenib became
+`LEVEL_R1`. A sensitising drug read as a resistance marker, which would suppress
+a correct melanoma recommendation. Picking the other way is no better: it would
+claim the drug works in colorectal, where the R1 exists precisely because it
+does not. Ten entries in this dump conflict that way.
+
+This was latent rather than new. The same collapse applies to the `fresh_cache`
+and `download` paths, so any deployment that configures a token and reaches a
+real dump was exposed to it. It never fired only because the parser had never
+successfully read a dump.
+
+**Fixed** by refusing to choose. A gene, alteration and drug whose level differs
+across cancer types is dropped from the dump-derived table and logged, leaving
+the curated table to answer, because that table applies cancer context through
+`_apply_cancer_context_override` and the dump-derived one cannot.
+
+**Also changed:** a cache past its freshness window is now preferred over the
+built-in table. A week-old dump carries a date; the built-in table has none, so
+discarding the dated one for the undated one was the wrong way round. Provenance
+reports `stale_cache` and `is_current` stays `False`, because dated is not
+current. The actionability table goes from 335 undated entries to 421 entries
+carrying a real snapshot date.
+
+**Residual risk.** The ten dropped entries are a real coverage loss, taken
+deliberately over a wrong answer. The proper fix is a cancer-type dimension in
+the evidence table, which is a schema change, and until then any dump this
+system ingests is silently narrower than the dump itself.
+
 ---
 
 ## 3. What is not yet analysed
@@ -638,7 +692,7 @@ column is asserted, not enforced.
 
 | Hazard | Findings | Control in place | Test that fails if it stops running |
 |---|---|---|---|
-| H1 resistance ignored | F1, F7, F9 | Static-table resistance floor reachable on the worker path; rejected calls dropped; VAF carried onto the mutation | `test_ai_worker_oncokb_levels.py`, `test_vcf_ingestion_safety.py` |
+| H1 resistance ignored | F1, F7, F9, F17 | Static-table resistance floor reachable on the worker path; rejected calls dropped; VAF carried onto the mutation | `test_ai_worker_oncokb_levels.py`, `test_vcf_ingestion_safety.py` |
 | H2 actionable variant missed | F2, F8, F15 | Wire format mapped onto `OncoKBLevel`; each ALT allele emitted separately | `test_ai_worker_oncokb_levels.py`, `test_vcf_ingestion_safety.py` |
 | H3 lookup failure read as a negative | F3, F10, F11, F14 | `evidence_provenance` returned with the answer; QC verdict persisted and rendered; audit coverage derived from the mounted route table; `generation_errors` names a failed section | `test_evidence_provenance.py`, `test_genomic_worker_qc_persistence.py`, `test_middleware_audit.py::TestEveryMountedPhiRouteIsAudited`, `test_marketplace_phi_disclosure.py`, `test_evidence_lookup_status.py` |
 | H4 stale evidence base | F4 | Provenance stamped onto the result at production time; static fallback logged at `WARNING` | `test_evidence_provenance.py` |

--- a/docs/risk_analysis.md
+++ b/docs/risk_analysis.md
@@ -630,11 +630,17 @@ of a table with no cancer dimension, and the proper fix is that dimension, which
 is a schema change. Until then any dump this system ingests is silently narrower
 and weaker than the dump itself.
 
-The `fresh_cache` and `download` paths still merge on top of the curated table
-rather than underneath it. The conflict guard protects them from the inversion,
-but a token-holding deployment can still see a curated level overwritten by a
-cancer-blind one. That is untested here because no token is available, and it is
-recorded rather than changed blind.
+All seven merge sites now put the dump underneath the curated table, including
+`fresh_cache` and `download`. They briefly disagreed, and that disagreement was
+itself the defect: a stale cache merged underneath while a fresh one merged on
+top, so identical data produced different recommendations depending on the age
+of a file. Cache age is not a property of the evidence. Currency and cancer
+context are different things, and only the second is at stake in the merge, so a
+newer dump is no less cancer-blind than an older one.
+
+Those two branches need a reachable dump and a token to execute, so they are
+pinned by reading the call shape in the source rather than by running them.
+Checking the shape is what is available; leaving them unpinned was not.
 
 ---
 

--- a/docs/risk_analysis.md
+++ b/docs/risk_analysis.md
@@ -595,10 +595,26 @@ and `download` paths, so any deployment that configures a token and reaches a
 real dump was exposed to it. It never fired only because the parser had never
 successfully read a dump.
 
-**Fixed** by refusing to choose. A gene, alteration and drug whose level differs
-across cancer types is dropped from the dump-derived table and logged, leaving
-the curated table to answer, because that table applies cancer context through
-`_apply_cancer_context_override` and the dump-derived one cannot.
+**Fixed**, but not by refusing to choose in every case. The first attempt
+dropped all ten conflicts, which was too blunt: they are two different kinds of
+disagreement and only one is a contradiction.
+
+    BRAF V600E  vemurafenib   LEVEL_1 / LEVEL_R1   opposite meaning
+    ERBB2 Amp   trastuzumab   LEVEL_1 / LEVEL_2    same meaning, different strength
+
+Two are contradictions and are dropped, because no value is right without the
+cancer context. The other eight say the same thing at different strengths, and
+dropping those discarded real actionability to avoid a disagreement that has a
+safe answer. Those keep the weaker level: the drug still surfaces, and the
+report does not claim standard-of-care support in a cancer where only
+lower-tier evidence exists. Two resistance levels keep the stronger warning.
+
+**Precedence also had to change.** Merging the dump on top of the curated table
+let a cancer-blind `LEVEL_2` overwrite a curated `LEVEL_1`, which is how
+`ERBB2 Amplification` + trastuzumab briefly read as `LEVEL_2`. The curated table
+resolves cancer context through `_apply_cancer_context_override` and this
+projection of the dump cannot, so the dump is merged underneath: it fills keys
+the curated table does not answer and never overrules one it does.
 
 **Also changed:** a cache past its freshness window is now preferred over the
 built-in table. A week-old dump carries a date; the built-in table has none, so
@@ -607,10 +623,18 @@ reports `stale_cache` and `is_current` stays `False`, because dated is not
 current. The actionability table goes from 335 undated entries to 421 entries
 carrying a real snapshot date.
 
-**Residual risk.** The ten dropped entries are a real coverage loss, taken
-deliberately over a wrong answer. The proper fix is a cancer-type dimension in
-the evidence table, which is a schema change, and until then any dump this
-system ingests is silently narrower than the dump itself.
+**Residual risk.** Two dropped entries are a real coverage loss, taken
+deliberately over a wrong answer, and the eight downgraded ones understate their
+evidence in the cancer where the stronger level applies. Both are consequences
+of a table with no cancer dimension, and the proper fix is that dimension, which
+is a schema change. Until then any dump this system ingests is silently narrower
+and weaker than the dump itself.
+
+The `fresh_cache` and `download` paths still merge on top of the curated table
+rather than underneath it. The conflict guard protects them from the inversion,
+but a token-holding deployment can still see a curated level overwritten by a
+cancer-blind one. That is untested here because no token is available, and it is
+recorded rather than changed blind.
 
 ---
 

--- a/validation_results/nci_match_concordance.json
+++ b/validation_results/nci_match_concordance.json
@@ -176,8 +176,8 @@
       "gene_used": "BRAF",
       "pipeline_top3": [
         "binimetinib",
-        "dabrafenib",
-        "encorafenib"
+        "cetuximab",
+        "dabrafenib"
       ],
       "exact_hit": true,
       "class_hit": true
@@ -198,7 +198,7 @@
       "pipeline_top3": [
         "alpelisib",
         "capivasertib",
-        "inavolisib"
+        "fulvestrant"
       ],
       "exact_hit": false,
       "class_hit": true
@@ -275,8 +275,7 @@
       "variant_used": "N891Kfs*13",
       "gene_used": "TSC1",
       "pipeline_top3": [
-        "everolimus",
-        "temsirolimus"
+        "everolimus"
       ],
       "exact_hit": false,
       "class_hit": true
@@ -417,9 +416,7 @@
       "variant_used": "DELETION",
       "gene_used": "NF2",
       "pipeline_top3": [
-        "TEMSIROLIMUS",
-        "BEVACIZUMAB",
-        "EVEROLIMUS"
+        "everolimus"
       ],
       "exact_hit": false,
       "class_hit": false
@@ -572,7 +569,7 @@
       "pipeline_top3": [
         "alpelisib",
         "capivasertib",
-        "inavolisib"
+        "fulvestrant"
       ],
       "exact_hit": false,
       "class_hit": true
@@ -655,8 +652,8 @@
       "gene_used": "AKT1",
       "pipeline_top3": [
         "capivasertib",
-        "ipatasertib",
-        "alpelisib"
+        "fulvestrant",
+        "ipatasertib"
       ],
       "exact_hit": true,
       "class_hit": true


### PR DESCRIPTION
`main` is currently red. PR #116 merged with two ruff errors I introduced, and
`Backend lint` has been failing on `main` ever since. The first commit here is
the fix for exactly that.

## Unbreaking main

`fix(lint)` resolves both errors `ruff check .` reports from `api/`:

- **F821** in `workers/ai_worker.py`. `_query_oncokb_with_status` is annotated
  with `EvidenceLookupStatus`, imported inside the function body so the Celery
  module loads without pulling in SQLAlchemy. The annotation is a string so it
  works at runtime, but the name still has to resolve for a linter. Added to the
  existing `TYPE_CHECKING` import beside `OncoKBLevel`.
- **F401** in `services/algorithm_version.py`. `Optional` imported, never used.

## The OncoKB dump was being read as empty

`api/static/oncokb_actionable_variants_cache.txt` holds 253 rows of real OncoKB
data and parsed to **zero entries**. `csv.DictReader(delimiter="\t")` read the
whole header as one column, because the file has no tabs at all: it is
column-aligned with runs of eight spaces, which is what a hand download from the
dataAccess page produces. That route is the documented workaround for the 401
the public dump returns without a token, so the format the workaround produces
was the one format the parser could not read. An unparseable cache and an absent
cache both returned `{}`, so nothing said so.

**Fixing the parsing exposed a much worse latent defect.** The dump is one row
per cancer type and the table has no cancer dimension:

```
BRAF V600E  Melanoma           LEVEL_1   Vemurafenib
BRAF V600E  Colorectal Cancer  LEVEL_R1  Vemurafenib
```

Last-write-wins, so the moment the dump parsed, `BRAF V600E` + vemurafenib
became `LEVEL_R1` — a sensitising drug read as a resistance marker, which would
suppress a correct melanoma recommendation. Two existing tests caught it. This
was latent rather than new: the same collapse applies to the `fresh_cache` and
`download` paths, so any deployment holding an OncoKB token was already exposed.
It never fired only because the parser had never successfully read a dump.

Resolved by separating a contradiction from a difference of strength. Of the ten
conflicts, two are contradictions (dropped, since no value is right without the
cancer context) and eight merely differ in strength (keep the weaker level, so
the drug still surfaces without over-claiming). Merge precedence is now uniform
across all seven sites: the dump fills gaps underneath the curated table and
never overrules it, because the curated table resolves cancer context and a
projection of the dump cannot.

The table goes from 335 undated entries to 421 carrying a real snapshot date,
with provenance reporting `stale_cache` and `is_current` staying `False`.

## Algorithm versioning

`REGULATORY_FRAMEWORK.md` section 2.3 requires a locked algorithm version with
change control. `services/algorithm_version.py` fingerprints everything that can
reorder drugs for fixed evidence, stamped onto each result at production time
(migration `0016`). The declared version is manual, the fingerprint automatic,
and a test fails when they disagree — so a behaviour change cannot land quietly.

It excludes the evidence table's contents deliberately: that identity belongs to
`evidence_provenance`, and folding it in would churn the version on every OncoKB
refresh.

## Verification

- `ruff check .` from `api/` passes
- 1092 backend tests pass, 2 xfailed
- migration chain clean, single head `0016`
- `main` merged into this branch; no conflicts

## Still open, recorded rather than hidden

Two dropped entries are a real coverage loss, and the eight downgraded ones
understate their evidence in the cancer where the stronger level applies. Both
follow from a table with no cancer dimension; the proper fix is that dimension,
which is a schema change. A written change-control SOP naming who approves an
algorithm version change also does not exist yet — the mechanism does, the
procedure does not.