### PR TITLE
docs(coverage): point the badge and contributor docs at the 52% gate

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -239,7 +239,7 @@ PYTHONPATH=. pytest ai/tests/                     # top-level ai/ package tests
 
 # with coverage across both (mirrors CI):
 PYTHONPATH=. pytest api/tests/ --cov=ai --cov=api --cov-report= --cov-fail-under=0
-PYTHONPATH=. pytest ai/tests/  --cov=ai --cov=api --cov-append --cov-report=term-missing --cov-fail-under=62
+PYTHONPATH=. pytest ai/tests/  --cov=ai --cov=api --cov-append --cov-report=term-missing --cov-fail-under=52
 ```
 
 Tests must be **hermetic** — no live network. Service tests that hit external
@@ -292,7 +292,7 @@ print(report.summary())
 
 CI already runs the backend and frontend suites on every push/PR — see
 [.github/workflows/ci.yml](.github/workflows/ci.yml). It enforces a backend
-coverage gate (`--cov-fail-under=62`), the hard clinical benchmark gate, ESLint
+coverage gate (`--cov-fail-under=52`), the hard clinical benchmark gate, ESLint
 (`--max-warnings 0`), `tsc --noEmit`, Vitest, and Playwright. A separate
 [.github/workflows/security.yml](.github/workflows/security.yml) runs pip-audit
 (blocking), Trivy (blocking on fixable HIGH/CRITICAL), plus report-only Bandit,

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p>
   <a href="https://github.com/immortal71/openoncology/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/immortal71/openoncology/ci.yml?branch=main&style=for-the-badge&logo=githubactions&logoColor=white&label=CI" alt="CI"/></a>
   <a href="https://github.com/immortal71/openoncology/actions/workflows/codeql.yml"><img src="https://img.shields.io/github/actions/workflow/status/immortal71/openoncology/codeql.yml?branch=main&style=for-the-badge&logo=github&logoColor=white&label=CodeQL" alt="CodeQL"/></a>
-  <img src="https://img.shields.io/badge/coverage-%E2%89%A562%25-22c55e?style=for-the-badge" alt="Backend coverage >= 62%"/>
+  <img src="https://img.shields.io/badge/coverage-%E2%89%A552%25-22c55e?style=for-the-badge" alt="Backend coverage >= 52%"/>
   <a href="https://github.com/immortal71/openoncology/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-22c55e?style=for-the-badge" alt="MIT License"/></a>
 </p>
 <p>


### PR DESCRIPTION
The README badge and CONTRIBUTING both advertised a 62% backend coverage gate. CI has enforced 52 since `caae08d`. Three lines, docs only.

## Why it mattered

A contributor pasting the command out of CONTRIBUTING.md got `--cov-fail-under=62` and a hard failure on a tree that CI passes. Coverage measures production code only now, since `pyproject.toml` omits `*/tests/*`, and the suite reads 53.93% under that measurement. The docs were stricter than the gate.

The number went 62, 40, 63, 69, 52 across four commits that moved CI without touching the docs.

## Acceptance criteria

- [x] `README.md:10` badge reads "coverage ≥52%" in both representations it carries: the URL-escaped `%E2%89%A5` segment and the ASCII `>=` alt text. Colour, style and position in the badge block unchanged.
- [x] `CONTRIBUTING.md:242` reads `--cov-fail-under=52`
- [x] `CONTRIBUTING.md:295` prose reads `--cov-fail-under=52`
- [x] An over-matching `rg -n '62'` sweep across README.md, CONTRIBUTING.md and docs/ leaves no coverage-gate reference at 62. The sweep returns unrelated hits by design, and each one got looked at rather than dismissed on the pattern.
- [x] Nothing outside README.md and CONTRIBUTING.md modified. Gate values in `Makefile` and `ci.yml` unchanged.

## Validation

PASS. The diff is confined to the two files and `git diff main...HEAD --summary` is empty, so no mode changes, renames or binary files. Gates still read 52 at `Makefile:35`, `Makefile:47` and `ci.yml:228`.

Both suites ran green: 877 passed and 1 xfailed for `api/tests/`, 42 passed for `ai/tests/`. Coverage came out at 54.70%, above the gate, so the badge now claims something true rather than aspirational.

The `0.625` / `62.5%` Precision@3 ceiling in `README.md:226` and several docs/ files is an unrelated number and survived intact. Occurrence counts are identical on HEAD and main. A blunt find-and-replace of `62` would most plausibly have corrupted that figure, which is why it got a direct check rather than an assumption.

## Reviewer notes, non-blocking

1. The figure drops from 62 to 52 with nothing explaining it, so a reader who remembers the old badge may take it as a lowered standard. It isn't. The denominator changed when test modules stopped being counted, and the same data reads 70% with tests included against 53.93% without. That context sits in `ci.yml` comments nobody reading the docs will open. A clause in the CONTRIBUTING "CI integration" paragraph saying the gate measures production code only would stop this being re-litigated.

2. `Makefile:30-32` still reads "Keep `--cov-fail-under` in step with `.github/workflows/ci.yml`. They disagreed (62 here, 63 there)" three lines above two `52`s. It is pre-existing and accurate as history, but it scans as a statement about current values, and a keyword grep misses it because the `62` sits on the line after the one containing `cov-fail-under`. The validator and the reviewer flagged it independently. Left alone here as out of scope; worth a follow-up.
