### PR TITLE
chore: track project state, add GDSC2 cell-line validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,6 @@ coverage.xml
 # that script; it downloads on first use unless --offline is passed.
 validation_results/cache/*.bed
 validation_results/cache/HG002_*
+
+.claude/
+loop.ps1

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,0 +1,92 @@
+# OpenOncology Backlog
+
+Git-tracked project state. Agents read this at session start and update it at
+session end, so work survives context compaction, restarts, and closed laptops.
+
+Sections are ordered by pipeline position. `/next` pulls from the top of
+`## Ready`. Nothing pulls from `## Needs human decision`.
+
+---
+
+## Ready
+
+<!-- Populate with /groom "<objective>". Entries use this shape:
+
+### OO-N: Consolidate design tokens into globals.css
+- **Why**: Tailwind autocomplete keeps reintroducing generic purple and blue, drifting from the green/cream system
+- **Files**: web/app/globals.css, web/tailwind.config.js
+- **Acceptance**:
+  - Every color in tailwind.config.js references a CSS variable, no literals
+  - #0F6E56, #FAFAF8, #16181D, #E4E2DB defined once in globals.css
+  - Grep for `purple-`, `blue-`, `cyan-` across web/ returns nothing
+  - Build passes, no visual regression on the homepage
+- **Out of scope**: component markup, marketplace modal
+- **Risk**: low
+-->
+
+### OO-2: Single-source the backend coverage threshold in pyproject.toml
+- **Why**: The number 52 is currently duplicated across `Makefile` and `ci.yml` with a comment recording that they already drifted once (62 vs 63), letting a local `make test-backend` pass what CI rejected; declaring it once removes the failure mode instead of re-synchronising after it happens.
+- **Files**: pyproject.toml, Makefile, .github/workflows/ci.yml
+- **Acceptance**:
+  - `pyproject.toml` gains a `[tool.coverage.report]` section with `fail_under = 52` and a short comment naming it the single source of truth, replacing the history comment currently parked at `ci.yml:210-225` (move that history into pyproject rather than deleting it)
+  - The second pytest invocation in both `Makefile` (`test-backend`, `coverage`) and `ci.yml` ("Run backend tests (ai suite)") no longer passes `--cov-fail-under` at all; the first invocation keeps its explicit `--cov-fail-under=0`, which still overrides the config value
+  - `rg -n 'cov-fail-under=[1-9]' -- Makefile .github/workflows/ci.yml` returns nothing, so the only `--cov-fail-under` literal left in either file is the explicit `=0` on the first pytest invocation (rg has no lookaround — do not reach for `(?!0)`, it is a parse error, not a zero-match)
+  - Temporarily editing `fail_under` to `99` makes `make coverage` fail with pytest-cov's "Coverage failure: total of ... is less than fail-under" message; restoring `52` makes it pass — verified before the change is committed
+  - The Makefile "keep --cov-fail-under in step with ci.yml" comment at `Makefile:30-32` is replaced by one pointing at `pyproject.toml`, and `CONTRIBUTING.md:240-243` still reproduces the exact commands CI runs
+- **Out of scope**: changing the threshold value itself; `[tool.coverage.run]` `omit` list; adding coverage reporting services or badge automation; `api/tests/**`.
+- **Risk**: medium
+
+### OO-3: Add a drift guard test for the coverage threshold
+- **Why**: OO-2 removes today's duplication, but nothing stops the next contributor from reintroducing a hardcoded `--cov-fail-under` or quoting a different number in the docs; a cheap test fails the PR that does it.
+- **Files**: api/tests/test_coverage_threshold_consistency.py (new)
+- **Acceptance**:
+  - The test reads `fail_under` from `pyproject.toml` via `tomllib` and asserts that the README badge line, both `CONTRIBUTING.md` mentions, and any `--cov-fail-under=<nonzero>` occurrence in `Makefile` / `.github/workflows/ci.yml` agree with it (the README check must decode the URL-escaped `%E2%89%A5` form)
+  - The test asserts that no nonzero `--cov-fail-under` literal survives in `Makefile` or `.github/workflows/ci.yml`, so the config stays the only source
+  - The test is hermetic: no network, no subprocess, paths resolved relative to the repo root rather than the CWD, and it passes under both `pytest api/tests/` and a bare `pytest` from the repo root
+  - Hand-editing the README badge to a different number makes the test fail with a message naming the offending file and the two disagreeing values
+- **Out of scope**: enforcing the number in any other repo (`docs/**` prose currently carries no threshold figure — do not add one); asserting the reported coverage percentage, only the configured gate; touching the existing test suite or conftest.
+- **Risk**: low
+
+---
+
+## In progress
+
+<!-- One entry maximum. An entry stranded here means a session died mid-work;
+     /standup will surface it. -->
+
+---
+
+## In review
+
+<!-- Entry plus PR URL. Cleared by hand when merged. -->
+
+### OO-1: Correct the stale 62% coverage figures in README and CONTRIBUTING
+- **PR**: https://github.com/immortal71/openoncology/pull/124
+- **Branch**: `docs/coverage-threshold-52`, cut from `main`, one commit `651c654`
+- **Validator**: PASS. Diff confined to the two files, gates still 52 at `Makefile:35`, `Makefile:47`, `ci.yml:228`. Suites green (877+1 xfail api, 42 ai), coverage 54.70%. The `0.625` Precision@3 ceiling confirmed unchanged.
+- **Reviewer**: Approve, no blocking findings.
+- **Why**: The README badge and CONTRIBUTING both advertise a 62% backend coverage gate that no longer exists; a contributor copying the documented pytest command gets a stricter gate than CI enforces and a local failure CI would have passed.
+- **Files**: README.md, CONTRIBUTING.md
+- **Acceptance**:
+  - `README.md:10` badge renders "coverage ≥52%" — both the shields.io path segment (`coverage-%E2%89%A552%25`) and the `alt` text are updated; badge colour, style and position in the block are unchanged
+  - `CONTRIBUTING.md:242` reads `--cov-fail-under=52`, matching the second pytest invocation in `Makefile` and `.github/workflows/ci.yml` character for character apart from the leading `PYTHONPATH=.`
+  - `CONTRIBUTING.md:295` prose reads `--cov-fail-under=52`
+  - `rg -n '62' -- README.md CONTRIBUTING.md docs/` deliberately over-matches; inspect every hit and confirm none of them refers to the backend coverage gate in any representation (`62%`, the rendered `≥62%`, the URL-escaped `%E2%89%A562`, `cov-fail-under=62`). A narrower pattern can exit clean while a stale form survives, so a few false positives to eyeball is the point, not a defect in the check.
+  - No file outside README.md and CONTRIBUTING.md is modified; no `--cov-fail-under` value in `Makefile` or `ci.yml` changes
+- **Out of scope**: the actual gate value in `Makefile` / `ci.yml` (52 stays 52); the `0.62` structural-ceiling numbers in `PROJECT_COMPLETION_STATUS.md` (unrelated benchmark metric); `CLAUDE.md:56-63`, whose "CONTRIBUTING.md still says 62 and the README badge says 62%" note goes stale with this change but is the repo owner's file to edit; frontend Vitest coverage.
+- **Risk**: low
+
+---
+
+## Needs human decision
+
+<!-- Anything an agent declined to do unattended: guard-hook blocks, validator
+     BLOCKs, mis-scoped entries, and anything the planner marked
+     Risk: scientific. This section is the safety valve. When it grows, that is
+     the system working, not failing. -->
+
+---
+
+## Done
+
+<!-- Merged entries, newest first. Trim periodically. -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,167 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+OpenOncology ranks cancer drugs against a patient's mutation profile. A VCF goes in;
+a ranked list of approved drugs, repurposing candidates, or a custom-discovery brief
+comes out. Three parts: a FastAPI backend (`api/`), a Next.js 14 frontend (`web/`),
+and a Nextflow genomics pipeline (`pipeline/`). Celery workers chain
+`genomic_worker` to `ai_worker` to `notify_worker`; Postgres, Redis, and MinIO back them.
+
+The output is clinical evidence, so the ranking path is treated as scientific code
+rather than application code. That distinction drives most of the rules below.
+
+## Commands
+
+`make help` lists the task runner. Targets are POSIX-sh friendly and this project is
+developed on Git Bash under Windows.
+
+```bash
+make test              # backend + frontend unit + E2E
+make test-backend      # both pytest suites with the coverage gate
+make test-frontend     # Vitest
+make test-e2e          # Playwright (boots the app in demo mode)
+make lint              # ruff + eslint + tsc
+```
+
+Running services locally:
+
+```bash
+cd api && uvicorn main:app --reload     # API on :8000, docs at /docs
+cd web && npm run dev                    # frontend on :3000
+docker-compose up --build                # full stack
+```
+
+### The two pytest suites are not one suite
+
+Both the top-level `ai/` package and the app's `api/ai/` package claim the import
+name `ai`. One interpreter can bind that name to exactly one of them, so the suites
+run as **separate pytest invocations** and coverage is stitched together with
+`--cov-append`:
+
+```bash
+PYTHONPATH=. pytest api/tests/    # FastAPI app + services (49 modules)
+PYTHONPATH=. pytest ai/tests/     # top-level ai/ package
+```
+
+Always run from the repo root with `PYTHONPATH=.` and an explicit path.
+`pyproject.toml` sets `testpaths = ["api/tests"]` so a bare `pytest` can never drag
+both `ai` packages into one process, and `--import-mode=importlib` sits in `addopts`
+because collecting `ai/tests/*` fails without it.
+
+Single test: `PYTHONPATH=. pytest api/tests/test_ranking.py::test_name -v`
+
+### Coverage gate
+
+**52**, enforced once at the end of the `ai/tests` run. Keep the Makefile and
+`.github/workflows/ci.yml` in step; they have drifted apart before, letting a local
+`make test-backend` pass what CI rejected. `CONTRIBUTING.md` still says 62 and the
+README badge says 62%, and both are stale. The threshold dropped from 69 to 52 when
+`*/tests/*` was omitted from coverage: a test module is ~100% covered by the act of
+running it, and 34 of them were inflating the headline. Coverage did not regress.
+
+### Import paths
+
+Backend modules import as if `api/` were the root: `from database import get_db`, not
+`from api.database import ...`. That is how it runs in production (`api/` on
+sys.path), and `api/tests/conftest.py` reproduces it with a `sys.path.insert`. Scripts
+under `scripts/` put both the repo root and `api/` on the path, so they use
+`from api.services.benchmark import ...` instead.
+
+## Protected paths, read before editing
+
+A `PreToolUse` hook (`.claude/hooks/guard_protected.py`, patterns in
+`.claude/protected-paths.json`) hard-blocks writes to the ranking and validation
+pipeline: `api/ai/**`, `api/services/benchmark.py`, `scripts/**`, `data/**`,
+`validation_results/**`, `test-fixtures/**`, `artifacts/**`, the benchmark JSON files,
+the ranking test modules, and `PAPER.md`.
+
+The hook is code, not advice. It exists because this repo's four real defects, a
+deduplication bug in the holdout sampler, leakage between tuning and evaluation sets,
+a live CIViC call during evaluation, and set-iteration order changing output, all
+passed the test suite. An agent optimizing for green tests reproduces that class of
+bug, and the reported Hit@3 and MRR move without anyone noticing.
+
+If the hook fires: record the proposed change in `BACKLOG.md` under
+`## Needs human decision` and move on to other work. Do not route around it with Bash,
+sed, a script, or a copy. Routing around it is worse than not making the change.
+Humans edit these files in an interactive session with `OO_GUARD_OFF=1`.
+
+## Quality gates that block CI
+
+- **Hard clinical benchmark** (`scripts/hard_benchmark_gate.py`). Locked primary
+  metric is standard P@3 at 0.65 or better, with Hit@3 at 0.90 or better and zero
+  false positives. Never lower a threshold to make it pass.
+- **Migration chain** (`scripts/check_migration_chain.py`). One head, one root, no
+  duplicate revision ids, no dangling `down_revision`. A fork breaks
+  `alembic upgrade head` for every deployment and looks clean in review.
+- **`alembic check`**, no uncommitted model changes.
+- ESLint at `--max-warnings 0` and `tsc --noEmit`.
+
+Tests must be hermetic. Service tests mock the HTTP layer; OncoKB, OpenTargets,
+ChEMBL, and cBioPortal are never called from the default CI path. The slower
+live-API benchmark suite is deliberately off the PR path.
+
+## Ranking architecture
+
+`api/ai/ranking.py` holds the logic and `api/ai/ranking_config.py` holds every tunable
+number: weights, thresholds, boosts. No magic numbers in the logic file. This split is
+what makes ablation studies possible (`scripts/run_ablation.py` swaps in a config with
+one source zeroed) and it should be preserved. `EvidenceWeights` must sum to 1.0; call
+`RankingConfig.validate()` on any custom instance. When a source is missing its weight
+is redistributed proportionally, so a nominal weight is an intent, not a guarantee.
+
+`rank_candidates()` computes a weighted composite, then applies post-hoc rules in
+order: resistance gate (EGFR T790M blocks erlotinib, which never ranks positively),
+source-diversity penalty, co-mutation penalties, clinical priority boost, tie
+annotation. Read `docs/METHODS.md` before touching any of it.
+
+Evidence lookup is `_LEVEL_TABLE` in `api/services/oncokb_evidence.py`, a dict keyed
+by `(gene_upper, normalised_alteration)` mapping to `{drug: oncokb_level}`.
+`_normalise_alteration()` strips `p.`, converts 3-letter amino acid codes to 1-letter,
+strips separators, and consults `_ALTERATION_ALIASES`. `_CANCER_CONTEXT_OVERRIDES`
+handles the same mutation having different approved drugs by tumour type (BRAF V600E
+in melanoma vs CRC vs NSCLC). Unmatched variants fall through direct lookup, then
+fuzzy substring, then gene-level, then `{}`, and an empty result escalates to
+Tier 2/3.
+
+Adding an evidence entry means updating `_LEVEL_TABLE`, adding the benchmark case, and
+confirming the gate still passes; the full recipe is in `CONTRIBUTING.md`. OncoKB
+LEVEL_1/2 map to tier `fda_approved`, LEVEL_3A/3B/4 to `repurposed`, R1/R2 block the
+drug. Withdrawn drugs (mobocertinib) must not be added.
+
+Without `ONCOKB_API_TOKEN` the system uses the curated static table rather than the
+live API, which is a supported mode, not a degraded one.
+
+## Frontend
+
+Next.js 14 App Router. `web/lib/api.ts` is the typed client; `web/lib/demo-data.ts`
+carries the KRAS G12C demo case.
+
+Demo mode (`NEXT_PUBLIC_ENABLE_DEMO_AUTH=1`) bypasses Keycloak and serves that demo
+case from local data, so Playwright E2E needs no backend, database, or auth server.
+The Playwright config builds and serves a production bundle on :3100 because
+`next dev` boots less deterministically in CI.
+
+## Autonomous work
+
+`BACKLOG.md` is git-tracked project state. Read it at session start and update it at
+session end, so work survives compaction and restarts. `/groom "<objective>"` fills
+it, `/next` takes the top `## Ready` entry through implementer, validator, reviewer,
+and PR, and `/standup` reports status. `loop.ps1` runs `/next` headlessly until the
+backlog drains. Subagent definitions live in `.claude/agents/`.
+
+Suitable for unattended work: frontend, docs, CI, type coverage, error handling, dead
+code, dependency hygiene. Not suitable: anything reachable from the ranking path,
+holdout composition, metric reporting, or the claims in the preprint. Those are
+`Risk: scientific` and stay in `## Needs human decision`.
+
+**Merging is never automated.** Never open stacked PRs here; twice a child PR merged
+into an orphaned branch and the work vanished. Branch from `main`.
+
+## Style
+
+Code without comments unless the surrounding file comments. Complete blocks, not
+fragments. Match the style already in the file.

--- a/scripts/validate_cell_line_drug_response.py
+++ b/scripts/validate_cell_line_drug_response.py
@@ -1,0 +1,391 @@
+"""Does the pipeline's recommendation predict measured drug sensitivity?
+
+WHY THIS ONE IS DIFFERENT
+-------------------------
+Every other benchmark in this repository compares the pipeline against a
+knowledge base. NCI-MATCH arms, OncoKB levels and the gold cases in
+api/services/benchmark.py are all expert curation of the same published
+actionability literature this repo's evidence table is built from, so agreement
+partly measures whether we encoded the literature correctly. The oncologist
+concordance benchmark avoids that but scores against protocol-era chemotherapy,
+which was not biomarker-driven at all.
+
+This one uses a wet-lab measurement as the answer key.
+
+  input   <- real mutation profiles of cancer cell lines, cBioPortal CCLE
+             (Broad, 2019)
+  output  <- what this pipeline recommends for those mutations
+  truth   <- measured dose-response for those exact cell lines, GDSC2
+             (Genomics of Drug Sensitivity in Cancer, Sanger)
+
+Nothing links the three except the cell line's own mutations. GDSC IC50 values
+were measured in a laboratory years before this repository existed and are not
+derived from OncoKB, CIViC, or any actionability database.
+
+THE METRIC
+----------
+GDSC publishes Z_SCORE: the cell line's sensitivity to a drug, standardised
+across all cell lines tested with that same drug. So it already controls for
+the fact that some drugs are potent everywhere.
+
+  Z_SCORE < 0  this cell line is MORE sensitive to this drug than average
+  Z_SCORE = 0  no different from the average cell line
+  Z_SCORE > 0  less sensitive than average
+
+The question is therefore sharp and has a real null hypothesis: when the
+pipeline recommends drug D for cell line C because of C's mutations, is C
+measurably more sensitive to D than other cell lines are?
+
+  H0: recommended pairs have the same Z_SCORE distribution as unrecommended
+      pairs in the same cell lines. The pipeline carries no information about
+      real drug response.
+  H1: recommended pairs are shifted negative.
+
+Tested by permutation, so no distributional assumption is made. The control
+group is drugs tested on the SAME cell lines but not recommended for them,
+which holds cell line identity fixed.
+
+WHAT IT STILL CANNOT SHOW
+-------------------------
+Cell lines are not patients. Sensitivity in culture is a poor predictor of
+clinical response for many drug classes, immunotherapy above all, since there
+is no immune system in a dish. A positive result here means the biomarker to
+drug links being asserted have measurable biological reality, not that a
+patient would benefit. That is a genuinely different claim and this script does
+not make it.
+
+Usage:
+    python scripts/validate_cell_line_drug_response.py
+    python scripts/validate_cell_line_drug_response.py --offline
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import json
+import os
+import random
+import re
+import statistics
+import sys
+import urllib.request
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, _REPO_ROOT)
+sys.path.insert(0, os.path.join(_REPO_ROOT, "api"))
+
+os.environ.setdefault("ENVIRONMENT", "development")
+os.environ.setdefault("SECRET_KEY", "cell-line-validation-local-only")
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+
+_CACHE_DIR = os.path.join(_REPO_ROOT, "validation_results", "cache")
+_GDSC_EXTRACT = os.path.join(_CACHE_DIR, "gdsc2_response.tsv")
+_CCLE_EXTRACT = os.path.join(_CACHE_DIR, "ccle_mutations.tsv")
+_RESULTS_OUT = os.path.join(_REPO_ROOT, "validation_results", "cell_line_drug_response.json")
+
+GDSC_URL = (
+    "https://ftp.sanger.ac.uk/pub/project/cancerrxgene/releases/current_release/"
+    "GDSC2_fitted_dose_response_24Jul22.csv"
+)
+CBIO = "https://www.cbioportal.org/api"
+CCLE_STUDY = "ccle_broad_2019"
+GENE_PANEL_ID = "IMPACT468"
+
+# A cell line needs enough drugs tested on it for a within-line control to mean
+# anything.
+_MIN_DRUGS_PER_LINE = 20
+_PERMUTATIONS = 20000
+_SEED = 20260813
+
+
+def _norm_drug(name: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "", (name or "").lower())
+
+
+def _norm_cell_line(name: str) -> str:
+    """CCLE writes A549_LUNG, GDSC writes A-549. Both reduce to A549."""
+    base = (name or "").upper()
+    # CCLE appends the tissue after the first underscore.
+    base = base.split("_")[0]
+    return re.sub(r"[^A-Z0-9]+", "", base)
+
+
+def _get(url: str, timeout: int = 120):
+    req = urllib.request.Request(url, headers={"User-Agent": "openoncology-research", "Accept": "application/json"})
+    with urllib.request.urlopen(req, timeout=timeout) as response:
+        return json.load(response)
+
+
+def _post(url: str, body: dict, timeout: int = 300):
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(body).encode(),
+        headers={
+            "User-Agent": "openoncology-research",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(url=req, timeout=timeout) as response:
+        return json.load(response)
+
+
+def fetch_ccle_mutations() -> None:
+    panel = _get(f"{CBIO}/gene-panels/{GENE_PANEL_ID}")
+    entrez = sorted({g["entrezGeneId"] for g in panel["genes"]})
+    print(f"  panel {GENE_PANEL_ID}: {len(entrez)} genes")
+
+    records = _post(
+        f"{CBIO}/molecular-profiles/{CCLE_STUDY}_mutations/mutations/fetch?projection=DETAILED",
+        {"sampleListId": f"{CCLE_STUDY}_all", "entrezGeneIds": entrez},
+    )
+    print(f"  {len(records)} panel mutations across CCLE")
+
+    os.makedirs(_CACHE_DIR, exist_ok=True)
+    with open(_CCLE_EXTRACT, "w", encoding="utf-8", newline="") as handle:
+        writer = csv.writer(handle, delimiter="\t", lineterminator="\n")
+        writer.writerow(["cell_line", "gene", "protein_change", "mutation_type"])
+        for record in records:
+            protein_change = (record.get("proteinChange") or "").strip()
+            gene = (record.get("gene") or {}).get("hugoGeneSymbol")
+            sample = record.get("sampleId") or ""
+            if not protein_change or not gene or not sample:
+                continue
+            writer.writerow([sample, gene, protein_change, record.get("mutationType") or ""])
+
+
+def fetch_gdsc() -> None:
+    print(f"  downloading {GDSC_URL.rsplit('/', 1)[-1]} (~40 MB)")
+    req = urllib.request.Request(GDSC_URL, headers={"User-Agent": "openoncology-research"})
+    with urllib.request.urlopen(req, timeout=900) as response:
+        raw = response.read()
+    rows = list(csv.DictReader(io.StringIO(raw.decode("utf-8", "replace"))))
+    print(f"  {len(rows)} dose-response curves")
+
+    os.makedirs(_CACHE_DIR, exist_ok=True)
+    with open(_GDSC_EXTRACT, "w", encoding="utf-8", newline="") as handle:
+        writer = csv.writer(handle, delimiter="\t", lineterminator="\n")
+        writer.writerow(["cell_line", "drug", "ln_ic50", "auc", "z_score"])
+        for row in rows:
+            try:
+                writer.writerow([
+                    row["CELL_LINE_NAME"], row["DRUG_NAME"],
+                    row["LN_IC50"], row["AUC"], row["Z_SCORE"],
+                ])
+            except KeyError:
+                continue
+
+
+def _load(path: str) -> list[dict[str, str]]:
+    with open(path, encoding="utf-8", newline="") as handle:
+        return list(csv.DictReader(handle, delimiter="\t"))
+
+
+def recommend(gene: str, variant: str) -> list[str]:
+    """Top-3 from the production Tier 1 path, same as the other benchmarks."""
+    from ai.ranking import rank_candidates
+    from services.oncokb_evidence import get_all_drugs_for_variant
+
+    evidence = get_all_drugs_for_variant(gene, variant, alphamissense_score=1.0) or {}
+    candidates = []
+    for drug_name, level in evidence.items():
+        level_text = str(level)
+        if "R" in level_text:  # resistance markers are not recommendations
+            continue
+        candidates.append({
+            "drug_name": drug_name,
+            "oncokb_level": level,
+            "is_approved": True,
+            "max_phase": 4,
+            "opentargets_score": 0.8 if "LEVEL_1" in level_text else (
+                0.6 if "LEVEL_2" in level_text else 0.4),
+        })
+    if not candidates:
+        return []
+    return [c["drug_name"] for c in rank_candidates(candidates)[:3]]
+
+
+def _permutation_p(recommended: list[float], control: list[float], rng: random.Random) -> float:
+    """One-sided: are recommended pairs shifted more sensitive than control?"""
+    observed = statistics.mean(recommended) - statistics.mean(control)
+    pooled = recommended + control
+    n = len(recommended)
+    hits = 0
+    for _ in range(_PERMUTATIONS):
+        rng.shuffle(pooled)
+        diff = statistics.mean(pooled[:n]) - statistics.mean(pooled[n:])
+        if diff <= observed:
+            hits += 1
+    return (hits + 1) / (_PERMUTATIONS + 1)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--offline", action="store_true", help="reuse cached extracts")
+    args = parser.parse_args()
+
+    if not args.offline or not os.path.exists(_CCLE_EXTRACT):
+        print("Fetching CCLE mutations...")
+        fetch_ccle_mutations()
+    if not args.offline or not os.path.exists(_GDSC_EXTRACT):
+        print("Fetching GDSC2 dose response...")
+        fetch_gdsc()
+
+    # cell line -> [(gene, variant)]
+    mutations: dict[str, list[tuple[str, str]]] = {}
+    for row in _load(_CCLE_EXTRACT):
+        key = _norm_cell_line(row["cell_line"])
+        if key:
+            mutations.setdefault(key, []).append((row["gene"], row["protein_change"]))
+
+    # cell line -> {drug -> z_score}
+    response: dict[str, dict[str, float]] = {}
+    for row in _load(_GDSC_EXTRACT):
+        key = _norm_cell_line(row["cell_line"])
+        try:
+            z = float(row["z_score"])
+        except (TypeError, ValueError):
+            continue
+        if key:
+            response.setdefault(key, {})[_norm_drug(row["drug"])] = z
+
+    shared = sorted(set(mutations) & set(response))
+    scored_lines = [c for c in shared if len(response[c]) >= _MIN_DRUGS_PER_LINE]
+
+    rec_z: list[float] = []
+    ctl_z: list[float] = []
+    per_line: list[dict] = []
+    cache: dict[tuple[str, str], list[str]] = {}
+
+    for line in scored_lines:
+        recommended: set[str] = set()
+        for gene, variant in mutations[line]:
+            key = (gene, variant)
+            if key not in cache:
+                cache[key] = recommend(gene, variant)
+            recommended.update(_norm_drug(d) for d in cache[key])
+
+        tested = response[line]
+        hits = sorted(recommended & set(tested))
+        if not hits:
+            continue
+
+        line_rec = [tested[d] for d in hits]
+        line_ctl = [z for d, z in tested.items() if d not in recommended]
+        if not line_ctl:
+            continue
+
+        rec_z.extend(line_rec)
+        ctl_z.extend(line_ctl)
+        per_line.append({
+            "cell_line": line,
+            "n_mutations": len(mutations[line]),
+            "n_drugs_tested": len(tested),
+            "recommended_and_tested": hits,
+            "mean_z_recommended": round(statistics.mean(line_rec), 4),
+            "mean_z_control": round(statistics.mean(line_ctl), 4),
+        })
+
+    print()
+    print("=" * 78)
+    print("CELL LINE DRUG RESPONSE  (pipeline recommendation vs measured GDSC2 IC50)")
+    print("=" * 78)
+    print(f"  CCLE cell lines with panel mutations   : {len(mutations)}")
+    print(f"  GDSC2 cell lines with response data    : {len(response)}")
+    print(f"  present in both                        : {len(shared)}")
+    print(f"  with >= {_MIN_DRUGS_PER_LINE} drugs tested                : {len(scored_lines)}")
+    print(f"  SCORED (pipeline named a tested drug)  : {len(per_line)}")
+    print()
+
+    if not rec_z or not ctl_z:
+        print("  No scorable pairs. Nothing can be concluded.")
+        return 1
+
+    mean_rec = statistics.mean(rec_z)
+    mean_ctl = statistics.mean(ctl_z)
+    pooled_sd = statistics.pstdev(rec_z + ctl_z) or 1.0
+    effect = (mean_rec - mean_ctl) / pooled_sd
+    rng = random.Random(_SEED)
+    p_value = _permutation_p(list(rec_z), list(ctl_z), rng)
+
+    print(f"  recommended drug/cell-line pairs       : {len(rec_z)}")
+    print(f"  control pairs (same lines, not rec'd)  : {len(ctl_z)}")
+    print()
+    print(f"  mean Z_SCORE, recommended              : {mean_rec:+.4f}")
+    print(f"  mean Z_SCORE, control                  : {mean_ctl:+.4f}")
+    print(f"  difference                             : {mean_rec - mean_ctl:+.4f}")
+    print(f"  effect size (Cohen's d)                : {effect:+.3f}")
+    print(f"  permutation p (one-sided, {_PERMUTATIONS} shuffles) : {p_value:.5f}")
+    print()
+    print("  Negative Z_SCORE means the cell line is MORE sensitive to the drug")
+    print("  than the average cell line tested with it.")
+    print()
+
+    significant = p_value < 0.05 and mean_rec < mean_ctl
+    print("=" * 78)
+    if significant:
+        print("  RESULT: recommended drugs are measurably more effective on the")
+        print("          cell lines they were recommended for.")
+    else:
+        print("  RESULT: no detectable shift. On this evidence the recommendation")
+        print("          carries no information about measured drug response.")
+    print()
+    print("  Cell lines are not patients. Sensitivity in culture predicts clinical")
+    print("  response poorly for many drug classes, immunotherapy most of all,")
+    print("  since there is no immune system in a dish. This speaks to whether the")
+    print("  biomarker-to-drug links have measurable biological reality, not to")
+    print("  whether a patient would benefit.")
+    print("=" * 78)
+
+    payload = {
+        "benchmark": "cell_line_drug_response",
+        "question": (
+            "When the pipeline recommends drug D for cell line C on the basis of C's "
+            "mutations, is C measurably more sensitive to D than other cell lines are?"
+        ),
+        "sources": {
+            "mutations": f"cBioPortal {CCLE_STUDY} (Cancer Cell Line Encyclopedia, Broad 2019)",
+            "truth": "GDSC2 fitted dose response, Genomics of Drug Sensitivity in Cancer (Sanger)",
+            "independence": (
+                "GDSC IC50 values are laboratory measurements and are not derived from "
+                "OncoKB, CIViC or any actionability database."
+            ),
+        },
+        "metric": "GDSC Z_SCORE, sensitivity standardised across cell lines per drug; negative is more sensitive",
+        "denominator": {
+            "ccle_lines_with_mutations": len(mutations),
+            "gdsc_lines_with_response": len(response),
+            "in_both": len(shared),
+            "with_enough_drugs_tested": len(scored_lines),
+            "scored": len(per_line),
+        },
+        "result": {
+            "n_recommended_pairs": len(rec_z),
+            "n_control_pairs": len(ctl_z),
+            "mean_z_recommended": round(mean_rec, 4),
+            "mean_z_control": round(mean_ctl, 4),
+            "difference": round(mean_rec - mean_ctl, 4),
+            "cohens_d": round(effect, 4),
+            "permutation_p_one_sided": round(p_value, 5),
+            "significant": bool(significant),
+        },
+        "limitation": (
+            "Cell lines are not patients. In-culture sensitivity predicts clinical response "
+            "poorly for many drug classes, immunotherapy especially. A positive result means "
+            "the asserted biomarker-to-drug links have measurable biological reality, not that "
+            "a patient would benefit."
+        ),
+        "per_cell_line": per_line,
+    }
+    os.makedirs(os.path.dirname(_RESULTS_OUT), exist_ok=True)
+    with open(_RESULTS_OUT, "w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2)
+    print(f"Wrote {os.path.relpath(_RESULTS_OUT, _REPO_ROOT)}")
+
+    return 0 if significant else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Two changes. They are unrelated and would normally be separate PRs; kept together deliberately.

## `303d956` — track BACKLOG.md and CLAUDE.md

`BACKLOG.md` holds the project state the `/next` pipeline reads and writes, but it was gitignored. Every backlog commit that pipeline makes was therefore a silent no-op: an interrupted run lost its place, and a fresh clone saw no state at all. Tracking it is what makes the file do the job it was written for.

`CLAUDE.md` documents the things that take several files to reconstruct. The two pytest suites that cannot share an interpreter, because the top-level `ai/` package and `api/ai/` both claim the import name `ai`. The protected-path guard and why it exists. The split between `ranking.py` and `ranking_config.py`. The demo-mode E2E setup that needs no backend.

`.claude/` and `loop.ps1` stay ignored as local tooling. The `CLAUDE-append.md` ignore entry goes with the file, whose contents are now in `CLAUDE.md`.

## `77b0f34` — GDSC2 cell-line drug response validation

Every other benchmark in the repo compares the pipeline against a knowledge base curated from the same actionability literature the evidence table is built from, so agreement partly measures whether that literature was encoded correctly. The oncologist concordance benchmark avoids that but scores against protocol-era chemotherapy, which was not biomarker-driven.

This one uses a wet-lab measurement as the answer key. Mutation profiles come from CCLE via cBioPortal, sensitivity from GDSC2. Nothing links them except the cell line's own mutations, and the IC50s were measured years before this repository existed.

The null is that recommended cell-line/drug pairs carry the same `Z_SCORE` distribution as unrecommended pairs in the same cell lines, which holds cell line identity fixed. Tested by permutation over 20000 shuffles under a fixed seed (`_SEED = 20260813`), so reruns reproduce.

The script is explicit about what it cannot show. Cell lines are not patients, and sensitivity in culture predicts clinical response poorly for many drug classes, immunotherapy most of all. A positive result means the biomarker-to-drug links have measurable biological reality, not that a patient would benefit.

## Notes for review

The script writes `validation_results/cell_line_drug_response.json` and caches extracts under `validation_results/cache/`. Neither path is currently ignored beyond `*.bed` and `HG002_*`, so a first run leaves untracked files. Whether those results should be tracked is a separate decision, handled outside this PR.

`--offline` reuses cached extracts so the network fetch is not repeated.
