### PR TITLE
OO-3: guard the coverage threshold against drift, and reconcile the backlog

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -24,29 +24,6 @@ Sections are ordered by pipeline position. `/next` pulls from the top of
 - **Risk**: low
 -->
 
-### OO-2: Single-source the backend coverage threshold in pyproject.toml
-- **Why**: The number 52 is currently duplicated across `Makefile` and `ci.yml` with a comment recording that they already drifted once (62 vs 63), letting a local `make test-backend` pass what CI rejected; declaring it once removes the failure mode instead of re-synchronising after it happens.
-- **Files**: pyproject.toml, Makefile, .github/workflows/ci.yml
-- **Acceptance**:
-  - `pyproject.toml` gains a `[tool.coverage.report]` section with `fail_under = 52` and a short comment naming it the single source of truth, replacing the history comment currently parked at `ci.yml:210-225` (move that history into pyproject rather than deleting it)
-  - The second pytest invocation in both `Makefile` (`test-backend`, `coverage`) and `ci.yml` ("Run backend tests (ai suite)") no longer passes `--cov-fail-under` at all; the first invocation keeps its explicit `--cov-fail-under=0`, which still overrides the config value
-  - `rg -n 'cov-fail-under=[1-9]' -- Makefile .github/workflows/ci.yml` returns nothing, so the only `--cov-fail-under` literal left in either file is the explicit `=0` on the first pytest invocation (rg has no lookaround — do not reach for `(?!0)`, it is a parse error, not a zero-match)
-  - Temporarily editing `fail_under` to `99` makes `make coverage` fail with pytest-cov's "Coverage failure: total of ... is less than fail-under" message; restoring `52` makes it pass — verified before the change is committed
-  - The Makefile "keep --cov-fail-under in step with ci.yml" comment at `Makefile:30-32` is replaced by one pointing at `pyproject.toml`, and `CONTRIBUTING.md:240-243` still reproduces the exact commands CI runs
-- **Out of scope**: changing the threshold value itself; `[tool.coverage.run]` `omit` list; adding coverage reporting services or badge automation; `api/tests/**`.
-- **Risk**: medium
-
-### OO-3: Add a drift guard test for the coverage threshold
-- **Why**: OO-2 removes today's duplication, but nothing stops the next contributor from reintroducing a hardcoded `--cov-fail-under` or quoting a different number in the docs; a cheap test fails the PR that does it.
-- **Files**: api/tests/test_coverage_threshold_consistency.py (new)
-- **Acceptance**:
-  - The test reads `fail_under` from `pyproject.toml` via `tomllib` and asserts that the README badge line, both `CONTRIBUTING.md` mentions, and any `--cov-fail-under=<nonzero>` occurrence in `Makefile` / `.github/workflows/ci.yml` agree with it (the README check must decode the URL-escaped `%E2%89%A5` form)
-  - The test asserts that no nonzero `--cov-fail-under` literal survives in `Makefile` or `.github/workflows/ci.yml`, so the config stays the only source
-  - The test is hermetic: no network, no subprocess, paths resolved relative to the repo root rather than the CWD, and it passes under both `pytest api/tests/` and a bare `pytest` from the repo root
-  - Hand-editing the README badge to a different number makes the test fail with a message naming the offending file and the two disagreeing values
-- **Out of scope**: enforcing the number in any other repo (`docs/**` prose currently carries no threshold figure — do not add one); asserting the reported coverage percentage, only the configured gate; touching the existing test suite or conftest.
-- **Risk**: low
-
 ---
 
 ## In progress
@@ -60,22 +37,6 @@ Sections are ordered by pipeline position. `/next` pulls from the top of
 
 <!-- Entry plus PR URL. Cleared by hand when merged. -->
 
-### OO-1: Correct the stale 62% coverage figures in README and CONTRIBUTING
-- **PR**: https://github.com/immortal71/openoncology/pull/124
-- **Branch**: `docs/coverage-threshold-52`, cut from `main`, one commit `651c654`
-- **Validator**: PASS. Diff confined to the two files, gates still 52 at `Makefile:35`, `Makefile:47`, `ci.yml:228`. Suites green (877+1 xfail api, 42 ai), coverage 54.70%. The `0.625` Precision@3 ceiling confirmed unchanged.
-- **Reviewer**: Approve, no blocking findings.
-- **Why**: The README badge and CONTRIBUTING both advertise a 62% backend coverage gate that no longer exists; a contributor copying the documented pytest command gets a stricter gate than CI enforces and a local failure CI would have passed.
-- **Files**: README.md, CONTRIBUTING.md
-- **Acceptance**:
-  - `README.md:10` badge renders "coverage ≥52%" — both the shields.io path segment (`coverage-%E2%89%A552%25`) and the `alt` text are updated; badge colour, style and position in the block are unchanged
-  - `CONTRIBUTING.md:242` reads `--cov-fail-under=52`, matching the second pytest invocation in `Makefile` and `.github/workflows/ci.yml` character for character apart from the leading `PYTHONPATH=.`
-  - `CONTRIBUTING.md:295` prose reads `--cov-fail-under=52`
-  - `rg -n '62' -- README.md CONTRIBUTING.md docs/` deliberately over-matches; inspect every hit and confirm none of them refers to the backend coverage gate in any representation (`62%`, the rendered `≥62%`, the URL-escaped `%E2%89%A562`, `cov-fail-under=62`). A narrower pattern can exit clean while a stale form survives, so a few false positives to eyeball is the point, not a defect in the check.
-  - No file outside README.md and CONTRIBUTING.md is modified; no `--cov-fail-under` value in `Makefile` or `ci.yml` changes
-- **Out of scope**: the actual gate value in `Makefile` / `ci.yml` (52 stays 52); the `0.62` structural-ceiling numbers in `PROJECT_COMPLETION_STATUS.md` (unrelated benchmark metric); `CLAUDE.md:56-63`, whose "CONTRIBUTING.md still says 62 and the README badge says 62%" note goes stale with this change but is the repo owner's file to edit; frontend Vitest coverage.
-- **Risk**: low
-
 ---
 
 ## Needs human decision
@@ -85,27 +46,45 @@ Sections are ordered by pipeline position. `/next` pulls from the top of
      Risk: scientific. This section is the safety valve. When it grows, that is
      the system working, not failing. -->
 
-### OO-2 follow-up: CONTRIBUTING.md:242 falls out of step with CI
-- **Why**: OO-2's last acceptance bullet asks that `CONTRIBUTING.md:240-243` still
-  reproduce the exact commands CI runs, but `CONTRIBUTING.md` is not in the entry's
-  **Files** list. Now that `ci.yml` no longer passes `--cov-fail-under` on the ai
-  suite, the documented command no longer matches it character for character. The
-  documented form is stricter-looking but harmless (52 is what the config says
-  anyway); it is a doc drift, not a broken gate.
-- **Proposed change** — `CONTRIBUTING.md:242`, one line:
-
-      PYTHONPATH=. pytest ai/tests/  --cov=ai --cov=api --cov-append --cov-report=term-missing
-
-  and, if wanted, `CONTRIBUTING.md:295` ("coverage gate (`--cov-fail-under=52`)")
-  reworded to name `pyproject.toml` `[tool.coverage.report] fail_under` as the
-  source of the number.
-- **Why not done**: outside OO-2's declared file list; expanding scope silently is
-  the failure mode the file list exists to prevent. Needs either an amended OO-2 or
-  its own entry.
-- **Risk**: low
-
 ---
 
 ## Done
 
 <!-- Merged entries, newest first. Trim periodically. -->
+
+### OO-3: Add a drift guard test for the coverage threshold
+Merged in [#128](https://github.com/immortal71/openoncology/pull/128).
+`api/tests/test_coverage_threshold_consistency.py` reads `fail_under` from
+`pyproject.toml` and fails the build if the README badge, the `CONTRIBUTING.md`
+prose, or a `--cov-fail-under` literal in `Makefile` or `ci.yml` disagrees with it.
+
+The badge is checked in both representations it carries on one line, URL-escaped
+and ASCII. Verified by breaking only the URL form and leaving the alt text correct:
+a check written against a single representation passes that edit with the badge
+visibly wrong, which is the shape the original 62 drift took.
+
+### OO-2 follow-up: CONTRIBUTING.md falls out of step with CI
+Merged in [#127](https://github.com/immortal71/openoncology/pull/127) alongside OO-2
+itself, plus `CONTRIBUTING.md:306` in the reconcile that followed. The entry was
+raised because `CONTRIBUTING.md` sat outside OO-2's declared **Files** list, and
+widening scope silently is what that list exists to prevent. Both mentions now point
+at `pyproject.toml` as the source of the number instead of quoting a flag CI no longer
+passes.
+
+### OO-2: Single-source the backend coverage threshold in pyproject.toml
+Merged in [#127](https://github.com/immortal71/openoncology/pull/127) as `ba6c04a`.
+`[tool.coverage.report] fail_under = 52` now declares the gate once; `Makefile` and
+`ci.yml` inherit it, and the api-suite invocation keeps its explicit
+`--cov-fail-under=0` because coverage is only complete after the second run appends.
+Verified locally at 1102 + 42 tests passing, 61% total against the 52 gate.
+
+One consequence to remember: any `pytest --cov=...` run now inherits the gate unless
+it opts out, so a single suite on its own reports around 14% and exits non-zero with
+every test passing. `CONTRIBUTING.md` documents this.
+
+### OO-1: Correct the stale 62% coverage figures in README and CONTRIBUTING
+Merged in [#124](https://github.com/immortal71/openoncology/pull/124) as `fd2bf89`.
+The README badge and both `CONTRIBUTING.md` mentions moved from 62 to 52, in every
+representation the badge carries (the URL-escaped `%E2%89%A5` segment and the ASCII
+`>=` alt text). The `0.625` Precision@3 ceiling elsewhere in the docs is an unrelated
+number and was confirmed untouched.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -303,7 +303,8 @@ print(report.summary())
 
 CI already runs the backend and frontend suites on every push/PR — see
 [.github/workflows/ci.yml](.github/workflows/ci.yml). It enforces a backend
-coverage gate (`--cov-fail-under=52`), the hard clinical benchmark gate, ESLint
+coverage gate (`fail_under` in `pyproject.toml`, currently 52), the hard clinical
+benchmark gate, ESLint
 (`--max-warnings 0`), `tsc --noEmit`, Vitest, and Playwright. A separate
 [.github/workflows/security.yml](.github/workflows/security.yml) runs pip-audit
 (blocking), Trivy (blocking on fixable HIGH/CRITICAL), plus report-only Bandit,

--- a/api/tests/test_coverage_threshold_consistency.py
+++ b/api/tests/test_coverage_threshold_consistency.py
@@ -1,0 +1,156 @@
+"""The backend coverage gate is declared once. These tests fail if it stops being.
+
+`pyproject.toml` `[tool.coverage.report] fail_under` is the only place the number
+lives. `Makefile` and `.github/workflows/ci.yml` inherit it by omitting
+`--cov-fail-under` on the invocation that enforces it, and README and CONTRIBUTING
+quote it as prose.
+
+Prose has no compiler, which is the whole problem. Before the number was
+consolidated it had drifted twice: 62 in `Makefile` against 63 in `ci.yml`, so a
+local `make test-backend` passed what CI rejected; and later the README badge and
+CONTRIBUTING sat at 62 for four commits while the enforced gate moved 62, 40, 63,
+69, 52 underneath them. Nothing failed, because nothing was checking.
+
+These tests are the check. They are deliberately literal about representation: the
+README badge carries the number twice on one line, once URL-escaped inside the
+shields.io path and once as ASCII in the `alt` text, and an earlier sweep that
+matched only one of those forms would have reported clean with the other stale.
+
+Hermetic by construction: file reads only, no network, no subprocess, and every
+path resolved from `__file__` rather than the working directory, so the suite
+behaves the same under `pytest api/tests/` and a bare `pytest` from the repo root.
+"""
+
+import re
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Files that quote the gate. Anything added here is covered by the sweep below.
+MAKEFILE = "Makefile"
+CI_WORKFLOW = ".github/workflows/ci.yml"
+README = "README.md"
+CONTRIBUTING = "CONTRIBUTING.md"
+
+# `--cov-fail-under=0` is not a second source of truth. It is an explicit opt-out on
+# the api-suite invocation, which runs before the ai suite has appended its coverage
+# and would otherwise fail on a partial total. Only nonzero literals are drift.
+COV_FAIL_UNDER = re.compile(r"--cov-fail-under=(\d+)")
+
+# The badge encodes U+2265 (>=) as %E2%89%A5 and the trailing percent as %25.
+BADGE_URL_FORM = re.compile(r"coverage-%E2%89%A5(\d+)%25")
+BADGE_ALT_FORM = re.compile(r"Backend coverage >= (\d+)%")
+
+# CONTRIBUTING names pyproject as the source and quotes the current value beside it.
+CONTRIBUTING_PROSE = re.compile(
+    r"`fail_under` in `pyproject\.toml`, currently (\d+)"
+)
+
+
+def _read(relative_path: str) -> str:
+    return (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def configured_threshold() -> int:
+    """The single source of truth, read the way coverage itself reads it."""
+    with open(REPO_ROOT / "pyproject.toml", "rb") as handle:
+        config = tomllib.load(handle)
+    return config["tool"]["coverage"]["report"]["fail_under"]
+
+
+def test_pyproject_declares_the_threshold():
+    """Removing the declaration must fail loudly, not silently drop the gate."""
+    with open(REPO_ROOT / "pyproject.toml", "rb") as handle:
+        config = tomllib.load(handle)
+
+    report = config.get("tool", {}).get("coverage", {}).get("report", {})
+    assert "fail_under" in report, (
+        "pyproject.toml has no [tool.coverage.report] fail_under. That section is "
+        "the only place the backend coverage gate is declared; without it, neither "
+        "make test-backend nor CI enforces any threshold at all."
+    )
+    assert isinstance(report["fail_under"], int), (
+        f"pyproject.toml fail_under is {report['fail_under']!r}, expected an int"
+    )
+
+
+def test_readme_badge_matches_configured_threshold():
+    """Both representations on the badge line, not just whichever one a grep found."""
+    expected = configured_threshold()
+    readme = _read(README)
+
+    url_match = BADGE_URL_FORM.search(readme)
+    assert url_match is not None, (
+        f"{README}: no coverage badge matching {BADGE_URL_FORM.pattern}. If the badge "
+        "was reworded, update this test rather than deleting it, or the number goes "
+        "back to being unchecked."
+    )
+    assert int(url_match.group(1)) == expected, (
+        f"{README}: coverage badge URL says {url_match.group(1)}, but "
+        f"pyproject.toml [tool.coverage.report] fail_under is {expected}. "
+        "The badge advertises a gate the project does not enforce."
+    )
+
+    alt_match = BADGE_ALT_FORM.search(readme)
+    assert alt_match is not None, (
+        f"{README}: coverage badge has no alt text matching "
+        f"{BADGE_ALT_FORM.pattern}. Screen readers would get no number at all."
+    )
+    assert int(alt_match.group(1)) == expected, (
+        f"{README}: coverage badge alt text says {alt_match.group(1)}, but "
+        f"pyproject.toml fail_under is {expected}. The rendered badge and its alt "
+        "text disagree, which a check on either one alone would miss."
+    )
+
+
+def test_contributing_matches_configured_threshold():
+    expected = configured_threshold()
+    contributing = _read(CONTRIBUTING)
+
+    prose_match = CONTRIBUTING_PROSE.search(contributing)
+    assert prose_match is not None, (
+        f"{CONTRIBUTING}: no passage matching {CONTRIBUTING_PROSE.pattern}. That "
+        "sentence is what tells a contributor where the number comes from; if it "
+        "was reworded, update this pattern so the value stays checked."
+    )
+    assert int(prose_match.group(1)) == expected, (
+        f"{CONTRIBUTING}: prose says the gate is {prose_match.group(1)}, but "
+        f"pyproject.toml fail_under is {expected}. A contributor reading the docs "
+        "would expect a different threshold than CI applies."
+    )
+
+
+def test_no_nonzero_cov_fail_under_survives_in_makefile_or_ci():
+    """The flag must not reappear. A literal there is a second source of truth."""
+    expected = configured_threshold()
+
+    for relative_path in (MAKEFILE, CI_WORKFLOW):
+        for match in COV_FAIL_UNDER.finditer(_read(relative_path)):
+            value = int(match.group(1))
+            if value == 0:
+                continue
+            raise AssertionError(
+                f"{relative_path}: found --cov-fail-under={value}. The threshold is "
+                f"declared once in pyproject.toml (currently {expected}) and inherited "
+                "here. Passing it on the command line reintroduces the duplication "
+                "that let Makefile and ci.yml drift apart (62 against 63), so a local "
+                "make test-backend passed what CI rejected. Drop the flag; only the "
+                "explicit =0 opt-out on the api-suite invocation belongs."
+            )
+
+
+def test_any_documented_threshold_flag_agrees_with_config():
+    """Docs may show the flag. If they do, the value has to be right."""
+    expected = configured_threshold()
+
+    for relative_path in (README, CONTRIBUTING):
+        for match in COV_FAIL_UNDER.finditer(_read(relative_path)):
+            value = int(match.group(1))
+            if value == 0:
+                continue
+            assert value == expected, (
+                f"{relative_path}: documents --cov-fail-under={value}, but "
+                f"pyproject.toml fail_under is {expected}. Anyone pasting that "
+                "command runs a different gate than CI does."
+            )


### PR DESCRIPTION
Backlog entry OO-3, plus the backlog reconcile that was overdue after #124 and #127, plus the one line of #127's follow-up that was still outstanding.

## The guard test

`api/tests/test_coverage_threshold_consistency.py`, five tests, no network and no subprocess. It reads `fail_under` from `pyproject.toml` the way coverage itself reads it, then checks every other place the number appears against it.

OO-2 declared the gate once. Nothing stopped it being duplicated again, and the history says it would be. The value drifted to 62 in `Makefile` against 63 in `ci.yml`, so a local `make test-backend` passed what CI rejected. Later the README badge sat at 62 through four commits that moved the enforced gate underneath it. Neither failure broke a build, because nothing compared the two.

What it checks:

- `pyproject.toml` still declares `[tool.coverage.report] fail_under`, so deleting the gate fails loudly instead of silently disabling it
- README badge, in **both** representations it carries on one line: `%E2%89%A5` inside the shields.io path, and ASCII `>=` in the `alt` text
- `CONTRIBUTING.md` prose naming the source and value
- No nonzero `--cov-fail-under` literal survives in `Makefile` or `ci.yml`
- Any `--cov-fail-under` shown in README or CONTRIBUTING matches the config

`--cov-fail-under=0` is allowed and skipped. It is the opt-out on the api-suite invocation, which runs before the ai suite has appended its coverage and would otherwise fail on a partial total. Every nonzero literal is a second source of truth and fails.

## Acceptance criteria

- [x] Reads `fail_under` via `tomllib`; checks README badge, CONTRIBUTING, `Makefile`, `ci.yml`
- [x] README check decodes the URL-escaped `%E2%89%A5` form
- [x] Asserts no nonzero `--cov-fail-under` survives in `Makefile` or `ci.yml`
- [x] Hermetic: file reads only, paths resolved from `__file__` rather than the CWD
- [x] Passes under `pytest api/tests/` and under a bare `pytest` from the repo root
- [x] Editing the badge produces a message naming the file and both disagreeing values

## Verification of the failure path

I broke the badge deliberately to confirm the test fails when it should, and that the message says something useful:

```
AssertionError: README.md: coverage badge URL says 99, but pyproject.toml
[tool.coverage.report] fail_under is 52. The badge advertises a gate the
project does not enforce.
1 failed, 4 passed
```

Worth noting which case that is. I changed only the URL-escaped form and left the `alt` text reading 52. A check written against a single representation would have passed that edit with the badge visibly wrong. That is the shape the original 62 drift took.

README was restored and `git diff --stat README.md` is empty.

## The remaining follow-up line

`CONTRIBUTING.md:306` still described the gate as a `--cov-fail-under` flag CI passes. It has not passed one since OO-2. That line now names `pyproject.toml` as the source. The follow-up entry raised during OO-2 is closed by this.

## Backlog reconcile

`BACKLOG.md` had drifted from reality while the pipeline crashed and restarted. OO-1 was still under `In review` pointing at a PR merged hours earlier, OO-2 was still under `Ready` after merging, and the follow-up sat under `Needs human decision` after being resolved. All four entries move to `Done` with their merge commits.

`Ready` is empty after this.
