### PR TITLE
Fix the deployment path: unconsumed gdpr queue, missing beat, readiness probe, and JWKS auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,22 @@ ENVIRONMENT=development
 # Keycloak
 KEYCLOAK_ADMIN_PASSWORD=change_me_keycloak_admin
 
+# Expected `aud` claim on incoming tokens. Leave empty for a local realm; the
+# API refuses to boot with ENVIRONMENT=production while it is empty, because
+# without it a token issued to any other client in the realm authenticates
+# against every protected route.
+#
+# Keycloak does not put the client id in `aud` by default — it goes in `azp` and
+# `aud` is "account". Setting this means adding an audience mapper to the
+# client and using the value that mapper emits.
+KEYCLOAK_AUDIENCE=
+
+# Expected `iss` claim. Empty derives it from KEYCLOAK_URL and the realm. Set it
+# where the address the API dials differs from the hostname Keycloak signs with,
+# which is the usual case in a cluster: the API reaches the internal Service
+# while tokens carry the public ingress hostname.
+KEYCLOAK_ISSUER=
+
 # Grafana
 GRAFANA_PASSWORD=change_me_grafana
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,19 +266,54 @@ jobs:
           tar xf kubeconform.tar.gz kubeconform
           sudo mv kubeconform /usr/local/bin/
 
-      # The sub-charts are what `helm dependency build` would fetch from the
-      # Bitnami repo. They are not this repository's manifests and their schemas
-      # are not what this job is checking, so they are skipped rather than
-      # pulled on every run.
-      - name: Render and validate the chart against the Kubernetes schema
+      # Chart.yaml declares postgresql and redis and neither is vendored, so
+      # `helm template` refuses to render anything at all until they are
+      # fetched. The first version of this job piped straight into kubeconform,
+      # which meant helm's error went to stderr, stdout was empty, kubeconform
+      # reported "0 resource found parsing stdin - Valid: 0", and the pipe
+      # returned kubeconform's exit code. A job that renders nothing and passes
+      # is worse than no job, so the render below writes to a file, runs under
+      # pipefail, and has to produce resources before anything is validated.
+      - name: Fetch chart dependencies
         run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm dependency update infra/helm
+
+      - name: Render and validate the chart against the Kubernetes schema
+        shell: bash
+        run: |
+          set -euo pipefail
           helm template openoncology infra/helm \
             --values infra/helm/values.yaml \
             --values infra/helm/values.production.yaml \
             --api-versions autoscaling/v2 \
-            --namespace openoncology \
-            | kubeconform -strict -summary -ignore-missing-schemas \
-                -kubernetes-version 1.29.0
+            --namespace openoncology > rendered.yaml
+          test -s rendered.yaml
+          kubeconform -strict -summary -ignore-missing-schemas \
+            -kubernetes-version 1.29.0 rendered.yaml
+
+      # Schema validity says the YAML is well formed, not that it deploys what
+      # it is supposed to. These are the properties this chart got wrong, so
+      # they are asserted against the rendered output rather than the templates.
+      - name: Assert the rendered chart deploys what it should
+        shell: bash
+        run: |
+          set -euo pipefail
+          fail=0
+          check() {
+            if grep -q -- "$1" rendered.yaml; then
+              echo "ok: $2"
+            else
+              echo "MISSING: $2"; fail=1
+            fi
+          }
+          check 'path: /ready'         'API readiness probe checks its dependencies'
+          check 'workers.gdpr_worker'  'a worker consumes the gdpr queue'
+          check 'component: beat'      'Celery Beat is deployed'
+          check 'KEYCLOAK_AUDIENCE'    'the audience production requires is wired'
+          check 'kind: PodDisruptionBudget' 'the API has a disruption budget'
+          check 'terminationGracePeriodSeconds' 'shutdown is given a grace period'
+          exit $fail
 
       - name: Validate the standalone k8s manifests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,6 +228,66 @@ jobs:
         env:
           PYTHONPATH: ${{ github.workspace }}
 
+  # ── Deployment manifests ──────────────────────────────────────────────────
+  # Nothing in this file had ever rendered the Helm chart. The readiness probe
+  # in infra/helm/templates/api.yaml pointed at /health, which answers 200
+  # unconditionally, while infra/k8s/deployment.yaml used /ready, which
+  # round-trips Postgres and Redis. Two manifests for one service, disagreeing,
+  # on the path production deploys from — and no job that would notice.
+  #
+  # api/tests/test_deployment_manifests.py asserts the same properties by
+  # parsing, so the suite catches this offline. This job is what catches a chart
+  # that no longer renders at all, or renders into invalid Kubernetes.
+  validate-manifests:
+    name: Deployment manifests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.16.2
+
+      - name: Helm lint (base values)
+        run: helm lint infra/helm --values infra/helm/values.yaml
+
+      - name: Helm lint (production values)
+        run: |
+          helm lint infra/helm \
+            --values infra/helm/values.yaml \
+            --values infra/helm/values.production.yaml
+
+      - name: Install kubeconform
+        run: |
+          curl -sSLo kubeconform.tar.gz \
+            https://github.com/yannh/kubeconform/releases/download/v0.6.7/kubeconform-linux-amd64.tar.gz
+          tar xf kubeconform.tar.gz kubeconform
+          sudo mv kubeconform /usr/local/bin/
+
+      # The sub-charts are what `helm dependency build` would fetch from the
+      # Bitnami repo. They are not this repository's manifests and their schemas
+      # are not what this job is checking, so they are skipped rather than
+      # pulled on every run.
+      - name: Render and validate the chart against the Kubernetes schema
+        run: |
+          helm template openoncology infra/helm \
+            --values infra/helm/values.yaml \
+            --values infra/helm/values.production.yaml \
+            --api-versions autoscaling/v2 \
+            --namespace openoncology \
+            | kubeconform -strict -summary -ignore-missing-schemas \
+                -kubernetes-version 1.29.0
+
+      - name: Validate the standalone k8s manifests
+        run: |
+          kubeconform -strict -summary -ignore-missing-schemas \
+            -kubernetes-version 1.29.0 infra/k8s/
+
+      - name: Validate docker-compose
+        run: docker compose -f docker-compose.yml config --quiet
+
   # ── Docker build check ────────────────────────────────────────────────────
   docker-build:
     name: Docker build (no push)

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -24,6 +24,28 @@ Sections are ordered by pipeline position. `/next` pulls from the top of
 - **Risk**: low
 -->
 
+### OO-5: Port the NetworkPolicy set from infra/k8s into the Helm chart
+- **Why**: `infra/k8s/namespace.yaml` carries default-deny plus four allow rules; the chart carries none, and the chart is what production deploys from. Same drift class as the readiness probe and the missing beat Deployment, both fixed on `fix/deployment-and-auth-hardening`. Not fixed alongside them because it cannot be ported verbatim: `allow-workers-egress` selects on `app.kubernetes.io/part-of: openoncology-workers`, and `_helpers.tpl` never emits that label, so the rule as written selects nothing. Shipping a default-deny policy whose allow rules match no pods severs every worker from Postgres and Redis, and it renders and lints clean.
+- **Files**: infra/helm/templates/networkpolicy.yaml, infra/helm/templates/_helpers.tpl, infra/helm/values.yaml, api/tests/test_deployment_manifests.py
+- **Acceptance**:
+  - Every allow rule's selector matches labels the chart actually emits, verified against `helm template` output rather than read off the k8s copy
+  - Worker, beat, api and web pods each keep egress to Postgres, Redis and 443
+  - A test asserts every NetworkPolicy podSelector matches at least one rendered pod
+  - `helm template` output passes kubeconform in the `validate-manifests` job
+- **Out of scope**: the raw `infra/k8s` manifests, which already have this
+- **Risk**: medium — a wrong policy fails closed and silently
+
+### OO-6: Pin the pipeline's container images by digest
+- **Why**: `pipeline/modules/*.nf` pin containers by tag (`broadinstitute/gatk:4.5.0.0`, `etal/cnvkit:0.9.10`, `docker.io/szarate/manta:1.6.0`, two biocontainers). A tag is mutable. The variant-calling validation gate asks which pipeline produced a call set, and a tag cannot answer it: the same tag six months apart is a different image and possibly different calls. `nextflow.config` now declares `gatk_version` once, so the GATK pair can no longer diverge, but neither is pinned to an immutable reference.
+- **Files**: pipeline/nextflow.config, pipeline/modules/*.nf, api/tests/test_pipeline_config.py
+- **Acceptance**:
+  - Every `container` directive resolves to a `name@sha256:...` reference
+  - Digests are recorded with the date and the tag they resolved from, so a later bump is auditable
+  - A test asserts no `container` directive uses a bare tag
+  - The conda specs stay pinned to the same tool versions the digests correspond to
+- **Out of scope**: the conda-only modules, which pin exact versions already; choosing different tool versions
+- **Risk**: low
+
 ---
 
 ## In progress
@@ -57,6 +79,44 @@ Sections are ordered by pipeline position. `/next` pulls from the top of
      BLOCKs, mis-scoped entries, and anything the planner marked
      Risk: scientific. This section is the safety valve. When it grows, that is
      the system working, not failing. -->
+
+### OO-7: Decide whether `civic_supplement_enabled` should default to True
+- **Why**: Asked as "how do we raise the benchmark", and the measurements already
+  in the repository answer it in a way that rules ranking work out. In
+  `hard_benchmark_results.json`, three of five difficulty buckets sit exactly on
+  their own ceiling — MULTI_DRUG 0.9792/0.9792, LOW_PURITY 0.7778/0.7778,
+  REFRACTORY 0.5476/0.5476. A ceiling is the best any reordering of the existing
+  candidate pool could score, so for those buckets a better ranker scores
+  identically. The only headroom left is 0.033 in CONFLICTING_EVIDENCE and 0.024
+  in RARE_OR_COMPLEX, under a point of aggregate P@3.
+
+  What moves the ceiling is evidence coverage, and
+  `validation_results/civic_coverage_gain.json` has already measured the one
+  lever that exists: loading CIViC level A/B predictive evidence makes 3 of the
+  13 missed NCI-MATCH arms reachable and leaves 10 absent. The flag exists and
+  is off.
+
+  Not an agent's call. Widening the actionability table changes which drugs the
+  system can recommend, `candidate_pool_policy` is `evidence_first` so the table
+  decides the pool wherever it has an answer, and the audit's own caveat is that
+  reachable is not correct. It is also the wrong metric to optimise against
+  alone: open action 2 is still the unresolved question, and P@3 against a
+  curated key shares sources with the table being widened.
+- **Risk**: scientific
+- **Evidence to weigh**: `validation_results/civic_coverage_gain.json`,
+  `hard_benchmark_results.json` `by_difficulty` ceilings, risk_analysis.md §7 and
+  open action 2. The holdout-50 set scores standard P@3 0.5083 against the hard
+  benchmark's 0.8009; whichever way this goes, both numbers should move together
+  or the gap needs explaining.
+
+### OO-8: `require_current_evidence` must be True before any clinical deployment
+- **Why**: `api/config.py` says so in its own comment — "It MUST be True for any
+  clinical deployment" — and it defaults False, correctly, because this is
+  research-use software. Recorded here so the flip is a decision someone makes
+  rather than one someone forgets. It pairs with the new production requirement
+  for `KEYCLOAK_AUDIENCE`: both are settings whose safe research default is the
+  unsafe clinical one.
+- **Risk**: scientific / policy — this is a hazard control, not a config tidy
 
 ---
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -24,6 +24,13 @@ Sections are ordered by pipeline position. `/next` pulls from the top of
 - **Risk**: low
 -->
 
+---
+
+## In progress
+
+<!-- One entry maximum. An entry stranded here means a session died mid-work;
+     /standup will surface it. -->
+
 ### OO-4: Refresh the stale figures in the pyproject coverage comment
 - **Why**: The comment moved into `[tool.coverage.report]` by OO-2 cites 53.93% over 8,353 production statements with 844 api tests. The suite has grown since: it now measures about 61% over 8,798 statements with 1,102 api tests. Anyone reading the comment concludes the gate sits a point below the measured total, when it actually sits nine points below, so the gate catches less than the comment claims it does.
 - **Files**: pyproject.toml
@@ -35,14 +42,6 @@ Sections are ordered by pipeline position. `/next` pulls from the top of
   - `pytest api/tests/test_coverage_threshold_consistency.py` still passes
 - **Out of scope**: changing the threshold; the `omit` list; README and CONTRIBUTING, which quote the gate rather than the measurement.
 - **Risk**: low
-
----
-
-## In progress
-
-<!-- One entry maximum. An entry stranded here means a session died mid-work;
-     /standup will surface it. -->
-
 
 ---
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -24,6 +24,13 @@ Sections are ordered by pipeline position. `/next` pulls from the top of
 - **Risk**: low
 -->
 
+---
+
+## In progress
+
+<!-- One entry maximum. An entry stranded here means a session died mid-work;
+     /standup will surface it. -->
+
 ### OO-4: Refresh the stale figures in the pyproject coverage comment
 - **Why**: The comment moved into `[tool.coverage.report]` by OO-2 cites 53.93% over 8,353 production statements with 844 api tests. The suite has grown since: it now measures about 61% over 8,798 statements with 1,102 api tests. Anyone reading the comment concludes the gate sits a point below the measured total, when it actually sits nine points below, so the gate catches less than the comment claims it does.
 - **Files**: pyproject.toml
@@ -35,13 +42,6 @@ Sections are ordered by pipeline position. `/next` pulls from the top of
   - `pytest api/tests/test_coverage_threshold_consistency.py` still passes
 - **Out of scope**: changing the threshold; the `omit` list; README and CONTRIBUTING, which quote the gate rather than the measurement.
 - **Risk**: low
-
----
-
-## In progress
-
-<!-- One entry maximum. An entry stranded here means a session died mid-work;
-     /standup will surface it. -->
 
 ---
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -24,13 +24,6 @@ Sections are ordered by pipeline position. `/next` pulls from the top of
 - **Risk**: low
 -->
 
----
-
-## In progress
-
-<!-- One entry maximum. An entry stranded here means a session died mid-work;
-     /standup will surface it. -->
-
 ### OO-4: Refresh the stale figures in the pyproject coverage comment
 - **Why**: The comment moved into `[tool.coverage.report]` by OO-2 cites 53.93% over 8,353 production statements with 844 api tests. The suite has grown since: it now measures about 61% over 8,798 statements with 1,102 api tests. Anyone reading the comment concludes the gate sits a point below the measured total, when it actually sits nine points below, so the gate catches less than the comment claims it does.
 - **Files**: pyproject.toml
@@ -42,6 +35,14 @@ Sections are ordered by pipeline position. `/next` pulls from the top of
   - `pytest api/tests/test_coverage_threshold_consistency.py` still passes
 - **Out of scope**: changing the threshold; the `omit` list; README and CONTRIBUTING, which quote the gate rather than the measurement.
 - **Risk**: low
+
+---
+
+## In progress
+
+<!-- One entry maximum. An entry stranded here means a session died mid-work;
+     /standup will surface it. -->
+
 
 ---
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -24,6 +24,18 @@ Sections are ordered by pipeline position. `/next` pulls from the top of
 - **Risk**: low
 -->
 
+### OO-4: Refresh the stale figures in the pyproject coverage comment
+- **Why**: The comment moved into `[tool.coverage.report]` by OO-2 cites 53.93% over 8,353 production statements with 844 api tests. The suite has grown since: it now measures about 61% over 8,798 statements with 1,102 api tests. Anyone reading the comment concludes the gate sits a point below the measured total, when it actually sits nine points below, so the gate catches less than the comment claims it does.
+- **Files**: pyproject.toml
+- **Acceptance**:
+  - The comment cites the current measured coverage, statement count and api test count, taken from an actual local run rather than copied from this entry
+  - The narrative explaining why the number moved 63, 69, 52 is preserved, not replaced
+  - `fail_under` itself is unchanged at 52
+  - `make test-backend` still passes
+  - `pytest api/tests/test_coverage_threshold_consistency.py` still passes
+- **Out of scope**: changing the threshold; the `omit` list; README and CONTRIBUTING, which quote the gate rather than the measurement.
+- **Risk**: low
+
 ---
 
 ## In progress

--- a/api/config.py
+++ b/api/config.py
@@ -37,6 +37,31 @@ class Settings(BaseSettings):
     keycloak_client_secret: str = ""
     keycloak_admin_password: str = "admin"  # Keycloak admin-cli password
 
+    # Expected `aud` claim. Empty disables the audience check, which is what the
+    # code did unconditionally before: it passed audience="account" and then set
+    # verify_aud False, so a token minted for any other client in the realm
+    # verified against every protected route. Empty is tolerated outside
+    # production so a local realm needs no extra mapper; production requires it,
+    # enforced below.
+    #
+    # Keycloak does not put the client id in `aud` by default — it goes in
+    # `azp`, and `aud` is "account". Setting this means adding an audience
+    # mapper to the client, which is the documented way round and the only one
+    # that makes the claim mean anything.
+    keycloak_audience: str = ""
+
+    # Expected `iss` claim. Empty derives it from keycloak_url and the realm.
+    # Set it explicitly wherever the URL the API dials differs from the hostname
+    # Keycloak signs with, which is the normal case in a cluster: the API talks
+    # to the internal Service while tokens carry the public ingress hostname.
+    keycloak_issuer: str = ""
+
+    # How long a fetched JWKS is reused. A `kid` miss forces a refresh before
+    # the TTL lapses, so this bounds staleness for revoked keys rather than
+    # delaying rotation pickup.
+    keycloak_jwks_cache_seconds: int = 300
+    keycloak_jwks_timeout_seconds: float = 5.0
+
     # Stripe
     stripe_secret_key: str = ""
     stripe_webhook_secret: str = ""
@@ -142,6 +167,13 @@ class Settings(BaseSettings):
                 )
             if self.minio_secret_key == "password":
                 raise ValueError("MINIO_SECRET_KEY must be changed from the default in production")
+            if not self.keycloak_audience.strip():
+                raise ValueError(
+                    "KEYCLOAK_AUDIENCE must be set in production. Without it the `aud` "
+                    "claim is not checked, and a token issued to any other client in the "
+                    "realm authenticates against every protected route. Add an audience "
+                    "mapper to the Keycloak client and set this to the value it emits."
+                )
         if self.environment == "development" and self.sentry_dsn:
             raise ValueError(
                 "ENVIRONMENT is 'development' but SENTRY_DSN is set — this looks like a "

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -1,9 +1,33 @@
 """
-Auth route — JWT token introspection via Keycloak.
+Auth route — JWT verification against Keycloak's JWKS.
 
 Patients authenticate directly through Keycloak (OIDC).
 The API validates the Bearer token on every protected request.
+
+Verification reads the realm's JWKS rather than the legacy `public_key` field
+on the realm endpoint, and the key set is cached. Three reasons, in the order
+they bite:
+
+  * The legacy field carries one key. Keycloak rotates realm keys, and during a
+    rotation it signs with the new key while the old one is still valid. A
+    verifier that knows a single key rejects every token minted after the
+    rotation until it happens to refetch. JWKS publishes the whole set, keyed by
+    `kid`, so both are present.
+  * The fetch ran on every authenticated request. `get_current_patient` guards
+    45 route dependencies, so each protected call made a second outbound HTTP
+    round trip before it could do any work, and Keycloak being slow or down took
+    the whole API with it. The set now lives in a process-local cache with a
+    TTL, refreshed on a `kid` miss so a rotation is picked up without waiting for
+    the TTL to lapse.
+  * `audience` was passed and then disabled with `verify_aud: False`, which
+    reads like a check and is not one. Any token from any client in the realm
+    verified here. Audience is enforced whenever `KEYCLOAK_AUDIENCE` is set, and
+    `config.py` requires it to be set in production.
 """
+import asyncio
+import logging
+import time
+
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from jose import jwt, JWTError
@@ -12,20 +36,131 @@ import httpx
 from config import settings
 from middleware.rate_limit import limiter, AUTH_LIMIT
 
+logger = logging.getLogger("openoncology.auth")
+
 router = APIRouter(prefix="/api/auth", tags=["auth"])
 _bearer = HTTPBearer()
 
+# Only RS256 is accepted. Reading the algorithm out of the token's own header is
+# how alg-confusion attacks start, so the list is fixed here rather than derived
+# from the JWK.
+_ALLOWED_ALGORITHMS = ["RS256"]
 
-async def _get_keycloak_public_key() -> str:
-    """Fetch Keycloak realm's RSA public key for JWT verification."""
-    url = f"{settings.keycloak_url}/realms/{settings.keycloak_realm}"
+_jwks_cache: dict | None = None
+_jwks_fetched_at: float = 0.0
+_jwks_lock = asyncio.Lock()
+
+
+def _issuer() -> str:
+    """
+    The `iss` value tokens are expected to carry.
+
+    Configurable rather than always derived, because inside a cluster
+    `keycloak_url` is usually the internal Service address while Keycloak keeps
+    signing with its public hostname. Deriving `iss` from the internal URL
+    rejects every valid token in exactly that deployment.
+    """
+    configured = (settings.keycloak_issuer or "").strip().rstrip("/")
+    if configured:
+        return configured
+    return f"{settings.keycloak_url.rstrip('/')}/realms/{settings.keycloak_realm}"
+
+
+def _jwks_url() -> str:
+    """JWKS is fetched over the internal URL even when `iss` is the public one."""
+    base = settings.keycloak_url.rstrip("/")
+    return f"{base}/realms/{settings.keycloak_realm}/protocol/openid-connect/certs"
+
+
+def _reset_jwks_cache() -> None:
+    """Drop the cached key set. Used by tests and after a realm reconfiguration."""
+    global _jwks_cache, _jwks_fetched_at
+    _jwks_cache = None
+    _jwks_fetched_at = 0.0
+
+
+async def _fetch_jwks() -> dict:
     async with httpx.AsyncClient() as client:
-        resp = await client.get(url, timeout=5)
+        resp = await client.get(_jwks_url(), timeout=settings.keycloak_jwks_timeout_seconds)
         resp.raise_for_status()
-        data = resp.json()
-        # Keycloak returns the key as a raw base64 string
-        raw_key = data["public_key"]
-        return f"-----BEGIN PUBLIC KEY-----\n{raw_key}\n-----END PUBLIC KEY-----"
+        return resp.json()
+
+
+async def _get_jwks(force_refresh: bool = False) -> dict:
+    """
+    Return the realm's key set, from cache when it is still fresh.
+
+    A stale cache beats a failed fetch: if Keycloak is unreachable but the last
+    known key set is still in hand, tokens signed by those keys keep verifying.
+    That is the difference between the identity provider being down and the
+    entire API being down with it.
+    """
+    global _jwks_cache, _jwks_fetched_at
+
+    age = time.monotonic() - _jwks_fetched_at
+    fresh = _jwks_cache is not None and age < settings.keycloak_jwks_cache_seconds
+    if fresh and not force_refresh:
+        return _jwks_cache
+
+    async with _jwks_lock:
+        age = time.monotonic() - _jwks_fetched_at
+        fresh = _jwks_cache is not None and age < settings.keycloak_jwks_cache_seconds
+        if fresh and not force_refresh:
+            return _jwks_cache
+
+        try:
+            jwks = await _fetch_jwks()
+        except httpx.HTTPError as exc:
+            if _jwks_cache is not None:
+                logger.warning(
+                    "auth.jwks_refresh_failed_serving_stale",
+                    extra={"error": str(exc), "age_seconds": round(age, 1)},
+                )
+                return _jwks_cache
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Authentication service unavailable",
+            ) from exc
+
+        _jwks_cache = jwks
+        _jwks_fetched_at = time.monotonic()
+        return jwks
+
+
+def _select_key(jwks: dict, kid: str | None) -> dict | None:
+    keys = [
+        k for k in (jwks or {}).get("keys", [])
+        if k.get("alg", "RS256") in _ALLOWED_ALGORITHMS
+    ]
+    if not keys:
+        return None
+    if kid is None:
+        # A token with no `kid` is only unambiguous when the realm publishes one
+        # usable key. Guessing among several is how the wrong key gets trusted.
+        return keys[0] if len(keys) == 1 else None
+    for key in keys:
+        if key.get("kid") == kid:
+            return key
+    return None
+
+
+def _decode_options() -> dict:
+    return {
+        "verify_signature": True,
+        "verify_aud": bool((settings.keycloak_audience or "").strip()),
+        "verify_iss": True,
+        "verify_exp": True,
+        "verify_nbf": True,
+        "require_exp": True,
+    }
+
+
+def _unauthorized() -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Invalid or expired token",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
 
 
 async def get_current_patient(
@@ -33,7 +168,7 @@ async def get_current_patient(
 ) -> dict:
     """
     Dependency — validates the Keycloak JWT and returns the token payload.
-    Raises 401 if the token is invalid or expired.
+    Raises 401 if the token is invalid, expired, or issued for another audience.
     """
     token = credentials.credentials
     if settings.environment == "development" and token == "demo-local-token":
@@ -45,26 +180,31 @@ async def get_current_patient(
         }
 
     try:
-        public_key = await _get_keycloak_public_key()
-        payload = jwt.decode(
-            token,
-            public_key,
-            algorithms=["RS256"],
-            audience="account",
-            options={"verify_aud": False},
-        )
-        return payload
-    except httpx.HTTPError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Authentication service unavailable",
-        ) from exc
+        kid = jwt.get_unverified_header(token).get("kid")
     except JWTError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid or expired token",
-            headers={"WWW-Authenticate": "Bearer"},
-        ) from exc
+        raise _unauthorized() from exc
+
+    key = _select_key(await _get_jwks(), kid)
+    if key is None:
+        # An unknown `kid` is the normal signature of a key rotation, so refetch
+        # once before deciding the token is bad.
+        key = _select_key(await _get_jwks(force_refresh=True), kid)
+
+    if key is None:
+        logger.warning("auth.no_matching_signing_key", extra={"kid": kid})
+        raise _unauthorized()
+
+    try:
+        return jwt.decode(
+            token,
+            key,
+            algorithms=_ALLOWED_ALGORITHMS,
+            issuer=_issuer(),
+            audience=(settings.keycloak_audience or "").strip() or None,
+            options=_decode_options(),
+        )
+    except JWTError as exc:
+        raise _unauthorized() from exc
 
 
 @router.get("/me")

--- a/api/tests/test_auth_jwks.py
+++ b/api/tests/test_auth_jwks.py
@@ -1,0 +1,344 @@
+"""
+Verification tests for the Keycloak JWT path.
+
+Every one of these fails against the previous implementation, which fetched the
+realm's single legacy public key on each request and then disabled the audience
+check it appeared to perform. They are grouped by the property being asserted
+rather than by function, because the properties are what the 45 routes behind
+`get_current_patient` actually depend on.
+
+Tokens are minted here with a locally generated RSA key, so nothing reaches the
+network: the JWKS fetch is stubbed and asserted on directly.
+"""
+import time
+
+import httpx
+import pytest
+from jose import jwt
+from jose.constants import ALGORITHMS
+from jose.utils import long_to_base64
+
+from fastapi import HTTPException
+from fastapi.security import HTTPAuthorizationCredentials
+
+from routes import auth
+
+
+ISSUER = "https://id.example.org/realms/openoncology"
+AUDIENCE = "openoncology-api"
+
+# Keys are generated once per seed and reused. python-jose runs on whichever
+# backend is installed, and on the pure-Python `rsa` one a 2048-bit keygen costs
+# about three seconds, which is worth paying four times rather than twenty.
+_KEY_CACHE: dict[str, tuple[str, int, int]] = {}
+
+
+def _generate_rsa() -> tuple[str, int, int]:
+    """Return (private_pem, n, e) using whichever RSA backend is available."""
+    try:
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric import rsa as c_rsa
+
+        private = c_rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        pem = private.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        ).decode()
+        numbers = private.public_key().public_numbers()
+        return pem, numbers.n, numbers.e
+    except ImportError:
+        import rsa as pure_rsa
+
+        public, private = pure_rsa.newkeys(2048)
+        return private.save_pkcs1("PEM").decode(), public.n, public.e
+
+
+def _keypair(kid: str, seed: str | None = None):
+    """
+    Return (private_pem, jwk_dict) for an RSA key published under `kid`.
+
+    `seed` names the underlying key material, so two callers can publish
+    different keys under the same `kid` — which is what a forged token looks
+    like, and one of the cases below.
+    """
+    seed = seed or kid
+    if seed not in _KEY_CACHE:
+        _KEY_CACHE[seed] = _generate_rsa()
+    pem, n, e = _KEY_CACHE[seed]
+    jwk = {
+        "kty": "RSA",
+        "kid": kid,
+        "alg": "RS256",
+        "use": "sig",
+        "n": long_to_base64(n).decode(),
+        "e": long_to_base64(e).decode(),
+    }
+    return pem, jwk
+
+
+def _token(pem: str, kid: str, **overrides) -> str:
+    now = int(time.time())
+    claims = {
+        "sub": "patient-1",
+        "email": "patient@example.org",
+        "name": "Test Patient",
+        "iss": ISSUER,
+        "aud": AUDIENCE,
+        "iat": now,
+        "exp": now + 300,
+        "realm_access": {"roles": ["patient"]},
+    }
+    claims.update(overrides)
+    return jwt.encode(claims, pem, algorithm=ALGORITHMS.RS256, headers={"kid": kid})
+
+
+def _credentials(token: str) -> HTTPAuthorizationCredentials:
+    return HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+
+@pytest.fixture
+def realm(monkeypatch):
+    """
+    A realm with one signing key, a stubbed JWKS endpoint, and a fetch counter.
+
+    `fetches` is the thing several tests are really about: the old code made one
+    outbound request per authenticated call.
+    """
+    pem, jwk = _keypair("key-1")
+    state = {"keys": [jwk], "fetches": 0, "fail": False}
+
+    async def _fake_fetch():
+        state["fetches"] += 1
+        if state["fail"]:
+            raise httpx.ConnectError("keycloak unreachable")
+        return {"keys": list(state["keys"])}
+
+    monkeypatch.setattr(auth, "_fetch_jwks", _fake_fetch)
+    monkeypatch.setattr("config.settings.environment", "production", raising=False)
+    monkeypatch.setattr("config.settings.keycloak_issuer", ISSUER, raising=False)
+    monkeypatch.setattr("config.settings.keycloak_audience", AUDIENCE, raising=False)
+    monkeypatch.setattr("config.settings.keycloak_jwks_cache_seconds", 300, raising=False)
+    auth._reset_jwks_cache()
+    yield {"pem": pem, "jwk": jwk, "state": state}
+    auth._reset_jwks_cache()
+
+
+# ── The key set is cached ────────────────────────────────────────────────────
+
+async def test_valid_token_is_accepted(realm):
+    payload = await auth.get_current_patient(_credentials(_token(realm["pem"], "key-1")))
+    assert payload["sub"] == "patient-1"
+    assert payload["aud"] == AUDIENCE
+
+
+async def test_repeated_requests_fetch_the_key_set_once(realm):
+    for _ in range(10):
+        await auth.get_current_patient(_credentials(_token(realm["pem"], "key-1")))
+    assert realm["state"]["fetches"] == 1
+
+
+async def test_expired_cache_refetches(realm, monkeypatch):
+    await auth.get_current_patient(_credentials(_token(realm["pem"], "key-1")))
+    monkeypatch.setattr("config.settings.keycloak_jwks_cache_seconds", 0, raising=False)
+    await auth.get_current_patient(_credentials(_token(realm["pem"], "key-1")))
+    assert realm["state"]["fetches"] == 2
+
+
+async def test_stale_key_set_is_served_when_keycloak_is_down(realm, monkeypatch):
+    """
+    Keycloak being unreachable must not take the API down with it. The last known
+    key set still verifies tokens signed by those keys.
+    """
+    await auth.get_current_patient(_credentials(_token(realm["pem"], "key-1")))
+    monkeypatch.setattr("config.settings.keycloak_jwks_cache_seconds", 0, raising=False)
+    realm["state"]["fail"] = True
+
+    payload = await auth.get_current_patient(_credentials(_token(realm["pem"], "key-1")))
+    assert payload["sub"] == "patient-1"
+
+
+async def test_unreachable_keycloak_with_no_cache_is_503(realm):
+    realm["state"]["fail"] = True
+    with pytest.raises(HTTPException) as exc:
+        await auth.get_current_patient(_credentials(_token(realm["pem"], "key-1")))
+    assert exc.value.status_code == 503
+
+
+# ── Key rotation ─────────────────────────────────────────────────────────────
+
+async def test_rotated_key_is_picked_up_without_waiting_for_the_ttl(realm):
+    """
+    A realm rotation mints tokens under a `kid` the cache has never seen. One
+    forced refresh resolves it; the legacy single-key path could not.
+    """
+    await auth.get_current_patient(_credentials(_token(realm["pem"], "key-1")))
+    new_pem, new_jwk = _keypair("key-2")
+    realm["state"]["keys"] = [realm["jwk"], new_jwk]
+
+    payload = await auth.get_current_patient(_credentials(_token(new_pem, "key-2")))
+    assert payload["sub"] == "patient-1"
+    assert realm["state"]["fetches"] == 2
+
+
+async def test_unknown_kid_refreshes_only_once_before_rejecting(realm):
+    stranger_pem, _ = _keypair("attacker-key")
+    with pytest.raises(HTTPException) as exc:
+        await auth.get_current_patient(_credentials(_token(stranger_pem, "attacker-key")))
+    assert exc.value.status_code == 401
+    assert realm["state"]["fetches"] == 2
+
+
+# ── Claims that are actually verified ────────────────────────────────────────
+
+async def test_token_for_another_client_in_the_realm_is_rejected(realm):
+    """
+    The finding this file exists for. The realm signs tokens for every client it
+    hosts; only the ones minted for this API may authenticate against it.
+    """
+    token = _token(realm["pem"], "key-1", aud="some-other-client")
+    with pytest.raises(HTTPException) as exc:
+        await auth.get_current_patient(_credentials(token))
+    assert exc.value.status_code == 401
+
+
+async def test_token_from_another_issuer_is_rejected(realm):
+    token = _token(realm["pem"], "key-1", iss="https://evil.example.org/realms/openoncology")
+    with pytest.raises(HTTPException) as exc:
+        await auth.get_current_patient(_credentials(token))
+    assert exc.value.status_code == 401
+
+
+async def test_expired_token_is_rejected(realm):
+    past = int(time.time()) - 3600
+    token = _token(realm["pem"], "key-1", iat=past, exp=past + 60)
+    with pytest.raises(HTTPException) as exc:
+        await auth.get_current_patient(_credentials(token))
+    assert exc.value.status_code == 401
+
+
+async def test_token_signed_by_an_unrelated_key_is_rejected(realm):
+    """Same `kid` as the realm's key, different private key behind it."""
+    stranger_pem, _ = _keypair("key-1", seed="stranger")
+    with pytest.raises(HTTPException) as exc:
+        await auth.get_current_patient(_credentials(_token(stranger_pem, "key-1")))
+    assert exc.value.status_code == 401
+
+
+async def test_malformed_token_is_rejected(realm):
+    with pytest.raises(HTTPException) as exc:
+        await auth.get_current_patient(_credentials("not-a-jwt"))
+    assert exc.value.status_code == 401
+
+
+# ── Algorithm handling ───────────────────────────────────────────────────────
+
+async def test_symmetric_algorithm_is_not_accepted(realm):
+    """
+    Alg confusion: a token signed HS256 using the realm's public modulus as the
+    shared secret. Accepting the algorithm named in the token's own header is
+    what makes that work, so the accepted list is fixed in code.
+    """
+    now = int(time.time())
+    forged = jwt.encode(
+        {"sub": "patient-1", "iss": ISSUER, "aud": AUDIENCE, "iat": now, "exp": now + 300},
+        realm["jwk"]["n"],
+        algorithm=ALGORITHMS.HS256,
+        headers={"kid": "key-1"},
+    )
+    with pytest.raises(HTTPException) as exc:
+        await auth.get_current_patient(_credentials(forged))
+    assert exc.value.status_code == 401
+
+
+async def test_key_set_with_no_usable_key_is_rejected(realm):
+    realm["state"]["keys"] = [{"kty": "oct", "kid": "key-1", "alg": "HS256"}]
+    auth._reset_jwks_cache()
+    with pytest.raises(HTTPException) as exc:
+        await auth.get_current_patient(_credentials(_token(realm["pem"], "key-1")))
+    assert exc.value.status_code == 401
+
+
+async def test_kidless_token_is_ambiguous_when_the_realm_publishes_two_keys(realm):
+    _, second = _keypair("key-2")
+    realm["state"]["keys"] = [realm["jwk"], second]
+    auth._reset_jwks_cache()
+
+    now = int(time.time())
+    token = jwt.encode(
+        {"sub": "patient-1", "iss": ISSUER, "aud": AUDIENCE, "iat": now, "exp": now + 300},
+        realm["pem"],
+        algorithm=ALGORITHMS.RS256,
+    )
+    with pytest.raises(HTTPException) as exc:
+        await auth.get_current_patient(_credentials(token))
+    assert exc.value.status_code == 401
+
+
+# ── Issuer and audience configuration ────────────────────────────────────────
+
+async def test_issuer_defaults_to_the_realm_url_when_not_configured(monkeypatch):
+    monkeypatch.setattr("config.settings.keycloak_issuer", "", raising=False)
+    monkeypatch.setattr("config.settings.keycloak_url", "http://keycloak:8080/", raising=False)
+    monkeypatch.setattr("config.settings.keycloak_realm", "openoncology", raising=False)
+    assert auth._issuer() == "http://keycloak:8080/realms/openoncology"
+
+
+async def test_configured_issuer_overrides_the_derived_one(monkeypatch):
+    """
+    The internal/external split: the API dials the cluster Service, tokens carry
+    the public hostname. Deriving `iss` from the dial address rejects every
+    valid token in that deployment.
+    """
+    monkeypatch.setattr("config.settings.keycloak_url", "http://keycloak:8080", raising=False)
+    monkeypatch.setattr("config.settings.keycloak_issuer", ISSUER, raising=False)
+    assert auth._issuer() == ISSUER
+    assert auth._jwks_url().startswith("http://keycloak:8080/")
+
+
+async def test_audience_check_is_skipped_when_unset(realm, monkeypatch):
+    """Local realms need no audience mapper; production is required to set one."""
+    monkeypatch.setattr("config.settings.keycloak_audience", "", raising=False)
+    token = _token(realm["pem"], "key-1", aud="anything-at-all")
+    payload = await auth.get_current_patient(_credentials(token))
+    assert payload["sub"] == "patient-1"
+
+
+def test_production_settings_require_an_audience():
+    from config import Settings
+
+    with pytest.raises(ValueError, match="KEYCLOAK_AUDIENCE"):
+        Settings(
+            environment="production",
+            secret_key="x" * 64,
+            minio_secret_key="not-the-default",
+            sentry_dsn="https://example@sentry.invalid/1",
+            keycloak_audience="",
+        )
+
+
+def test_production_settings_accept_a_configured_audience():
+    from config import Settings
+
+    settings = Settings(
+        environment="production",
+        secret_key="x" * 64,
+        minio_secret_key="not-the-default",
+        sentry_dsn="https://example@sentry.invalid/1",
+        keycloak_audience=AUDIENCE,
+    )
+    assert settings.keycloak_audience == AUDIENCE
+
+
+# ── The development bypass stays shut outside development ────────────────────
+
+async def test_demo_token_is_not_honoured_in_production(realm):
+    with pytest.raises(HTTPException) as exc:
+        await auth.get_current_patient(_credentials("demo-local-token"))
+    assert exc.value.status_code == 401
+
+
+async def test_demo_token_works_in_development(realm, monkeypatch):
+    monkeypatch.setattr("config.settings.environment", "development", raising=False)
+    payload = await auth.get_current_patient(_credentials("demo-local-token"))
+    assert payload["sub"] == "demo-user"

--- a/api/tests/test_deployment_manifests.py
+++ b/api/tests/test_deployment_manifests.py
@@ -1,0 +1,280 @@
+"""
+Drift guards for the deployment manifests.
+
+Two classes of defect motivated this module, and neither was visible to any
+check that existed. Both have the shape the risk analysis keeps finding: every
+assertion in CI was a positive about something present, and these were absences.
+
+  * `task_routes` sent `workers.gdpr_worker.*` to a `gdpr` queue that no
+    deployment consumed. `DELETE /api/me` enqueued an erasure task, returned a
+    confirmation promising deletion within 30 days, and the message stayed in
+    Redis. Every producer saw success.
+  * The chart had no Celery Beat, so `gdpr-enforce-retention-daily` and
+    `sweep-stale-submissions-hourly` had never fired in Kubernetes.
+
+The third guard is a divergence rather than an absence: the readiness probe in
+the Helm chart pointed at `/health`, which answers 200 unconditionally, while
+`infra/k8s/deployment.yaml` correctly used `/ready`, which round-trips Postgres
+and Redis. Two manifests for the same service, and nothing compared them.
+
+These parse the manifests as text and data rather than rendering them. The
+`infra-manifests` job in ci.yml does the real render with helm and kubeconform;
+this module is what fails locally, offline, and in the suite everyone runs.
+"""
+import ast
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HELM = REPO_ROOT / "infra" / "helm"
+K8S = REPO_ROOT / "infra" / "k8s"
+COMPOSE = REPO_ROOT / "docker-compose.yml"
+CELERY_APP = REPO_ROOT / "api" / "workers" / "__init__.py"
+
+
+def _conf_update_kwargs() -> dict[str, ast.expr]:
+    """
+    The keyword arguments of the `celery_app.conf.update(...)` call, unevaluated.
+
+    Read from source rather than by importing the app. `test_ai_worker_helpers`
+    and `test_genomic_worker_qc_persistence` both install a MagicMock over
+    `sys.modules["workers"].celery_app` to keep task decorators inert, so in a
+    full-suite run `from workers import celery_app` hands back a mock whose
+    `conf.task_routes` is empty. Reading the declaration is also the more honest
+    thing for a drift guard to do: what ships is the source, not whatever the
+    interpreter was left holding.
+    """
+    tree = ast.parse(CELERY_APP.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if (
+            isinstance(func, ast.Attribute)
+            and func.attr == "update"
+            and isinstance(func.value, ast.Attribute)
+            and func.value.attr == "conf"
+        ):
+            return {kw.arg: kw.value for kw in node.keywords if kw.arg}
+    raise AssertionError("no celery_app.conf.update(...) call found")
+
+
+@pytest.fixture(scope="module")
+def task_routes() -> dict[str, dict]:
+    return ast.literal_eval(_conf_update_kwargs()["task_routes"])
+
+
+@pytest.fixture(scope="module")
+def scheduled_tasks() -> dict[str, str]:
+    """Beat entry name → dotted task path. `schedule` holds `crontab(...)`
+    calls, which are not literals, so only the task path is extracted."""
+    schedule = _conf_update_kwargs()["beat_schedule"]
+    entries = {}
+    for name_node, entry in zip(schedule.keys, schedule.values):
+        name = ast.literal_eval(name_node)
+        for key, value in zip(entry.keys, entry.values):
+            if ast.literal_eval(key) == "task":
+                entries[name] = ast.literal_eval(value)
+    return entries
+
+
+@pytest.fixture(scope="module")
+def routed_queues(task_routes) -> set[str]:
+    return {route["queue"] for route in task_routes.values()}
+
+
+@pytest.fixture(scope="module")
+def helm_values() -> dict:
+    return yaml.safe_load((HELM / "values.yaml").read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def compose() -> dict:
+    return yaml.safe_load(COMPOSE.read_text(encoding="utf-8"))
+
+
+def _compose_consumed_queues(compose: dict) -> set[str]:
+    queues = set()
+    for service in compose["services"].values():
+        command = service.get("command")
+        if not command:
+            continue
+        if isinstance(command, list):
+            command = " ".join(str(part) for part in command)
+        for match in re.finditer(r"-Q\s+([A-Za-z0-9_,-]+)", command):
+            queues.update(match.group(1).split(","))
+    return queues
+
+
+# ── Every routed queue has a consumer ────────────────────────────────────────
+
+def test_helm_defines_a_worker_for_every_routed_queue(routed_queues, helm_values):
+    """
+    workers.yaml renders one Deployment per key under `workers`, consuming
+    `-Q <key>`. A routed queue with no key has no consumer in the cluster.
+    """
+    declared = set(helm_values["workers"])
+    assert routed_queues <= declared, (
+        f"queues routed by task_routes with no worker in the chart: "
+        f"{sorted(routed_queues - declared)}"
+    )
+
+
+def test_compose_runs_a_worker_for_every_routed_queue(routed_queues, compose):
+    consumed = _compose_consumed_queues(compose)
+    assert routed_queues <= consumed, (
+        f"queues routed by task_routes with no worker in docker-compose: "
+        f"{sorted(routed_queues - consumed)}"
+    )
+
+
+def test_no_worker_consumes_a_queue_nothing_routes_to(routed_queues, helm_values):
+    """The other direction: a worker burning a pod on an always-empty queue."""
+    declared = set(helm_values["workers"])
+    assert declared <= routed_queues, (
+        f"workers in the chart for queues task_routes never targets: "
+        f"{sorted(declared - routed_queues)}"
+    )
+
+
+# ── Scheduled tasks can actually reach a worker ──────────────────────────────
+
+def test_scheduled_tasks_route_to_a_consumed_queue(scheduled_tasks, task_routes, helm_values):
+    declared = set(helm_values["workers"])
+    assert scheduled_tasks, "no beat entries found; this guard would pass vacuously"
+    for name, task in scheduled_tasks.items():
+        module = task.rsplit(".", 1)[0]
+        queue = task_routes.get(f"{module}.*", {}).get("queue")
+        assert queue is not None, f"beat entry {name!r} routes to no queue"
+        assert queue in declared, (
+            f"beat entry {name!r} enqueues onto {queue!r}, which no worker consumes"
+        )
+
+
+def test_helm_chart_runs_celery_beat():
+    """
+    Without this Deployment the GDPR retention sweep and the stale-submission
+    recovery sweep have no trigger at all in Kubernetes.
+    """
+    beat = HELM / "templates" / "beat.yaml"
+    assert beat.exists(), "the chart has no Celery Beat deployment"
+    text = beat.read_text(encoding="utf-8")
+    assert "beat" in text and "-A" in text
+    assert "replicas: 1" in text, "beat must be a single replica"
+    assert "type: Recreate" in text, (
+        "two beats against one schedule enqueue every periodic task twice"
+    )
+
+
+def test_compose_runs_celery_beat(compose):
+    commands = " ".join(
+        str(svc.get("command", "")) for svc in compose["services"].values()
+    )
+    assert "beat" in commands
+
+
+# ── Probes ask the question their kind is for ────────────────────────────────
+
+def _probe_paths(text: str) -> dict[str, list[str]]:
+    """
+    Map each probe kind to the paths it requests, by walking the raw manifest.
+
+    Helm templates are not valid YAML, so this reads structure from indentation
+    rather than parsing. Crude, and it only has to survive the two files here.
+    """
+    found: dict[str, list[str]] = {"livenessProbe": [], "readinessProbe": []}
+    current = None
+    for line in text.splitlines():
+        stripped = line.strip()
+        for kind in found:
+            if stripped.startswith(f"{kind}:"):
+                current = kind
+        if current and stripped.startswith("path:"):
+            found[current].append(stripped.split("path:", 1)[1].strip())
+            current = None
+    return found
+
+
+@pytest.mark.parametrize(
+    "manifest",
+    [HELM / "templates" / "api.yaml", K8S / "deployment.yaml"],
+    ids=["helm", "k8s"],
+)
+def test_api_readiness_probe_checks_dependencies(manifest):
+    """
+    /health returns 200 whenever the process is running. /ready round-trips
+    Postgres and Redis and returns 503 when either is gone. A readiness probe
+    pointed at /health sends traffic to a pod that cannot serve it.
+    """
+    probes = _probe_paths(manifest.read_text(encoding="utf-8"))
+    assert probes["readinessProbe"] == ["/ready"], (
+        f"{manifest.name} readiness probe requests {probes['readinessProbe']}, not /ready"
+    )
+    assert probes["livenessProbe"] == ["/health"], (
+        f"{manifest.name} liveness probe requests {probes['livenessProbe']}, not /health"
+    )
+
+
+# ── Settings the API refuses to boot without ─────────────────────────────────
+
+def test_chart_supplies_every_setting_production_requires(helm_values):
+    """
+    `Settings._validate_production_settings` raises rather than starting with an
+    unsafe value. That is the right behaviour and it makes the chart's env a
+    hard dependency: a setting added to that validator and not to the ConfigMap
+    turns into a CrashLoopBackOff on the next deploy, with the reason only in
+    the pod log.
+    """
+    from config import Settings
+
+    api_env = helm_values["api"]["env"]
+    assert api_env["ENVIRONMENT"] == "production", (
+        "this assertion is about the production validator; the chart no longer targets it"
+    )
+
+    configmap = (HELM / "templates" / "configmap.yaml").read_text(encoding="utf-8")
+    kwargs = {
+        "environment": "production",
+        "secret_key": "x" * 64,
+        "minio_secret_key": "not-the-default",
+        "sentry_dsn": "https://example@sentry.invalid/1",
+    }
+    for field in Settings.model_fields:
+        if not field.startswith("keycloak_"):
+            continue
+        key = field.upper()
+        if key not in api_env:
+            continue
+        kwargs[field] = api_env[key]
+        assert key in configmap, f"{key} is set in values.yaml but never reaches the ConfigMap"
+
+    Settings(**kwargs)
+
+
+def test_production_audience_is_wired_through_the_configmap(helm_values):
+    configmap = (HELM / "templates" / "configmap.yaml").read_text(encoding="utf-8")
+    assert "KEYCLOAK_AUDIENCE" in configmap
+    assert helm_values["api"]["env"]["KEYCLOAK_AUDIENCE"].strip()
+
+
+# ── Shutdown is given time to be graceful ────────────────────────────────────
+
+def test_api_termination_grace_exceeds_prestop_sleep(helm_values):
+    """SIGKILL landing mid-preStop defeats the point of having one."""
+    api = helm_values["api"]
+    assert api["terminationGracePeriodSeconds"] > api["preStopSleepSeconds"]
+
+
+def test_workers_declare_a_grace_period(routed_queues, helm_values):
+    """
+    SIGTERM is a warm shutdown for Celery only if Kubernetes waits for it. At
+    the 30-second default a long genomic task is killed on every deploy; it is
+    `acks_late` so it is redelivered, but it restarts from the beginning.
+    """
+    for queue, cfg in helm_values["workers"].items():
+        grace = cfg.get("terminationGracePeriodSeconds")
+        assert grace is not None, f"worker {queue!r} has no terminationGracePeriodSeconds"
+        assert grace > 30, f"worker {queue!r} grace period {grace}s is at or below the default"

--- a/api/tests/test_pipeline_config.py
+++ b/api/tests/test_pipeline_config.py
@@ -1,0 +1,138 @@
+"""
+Drift guards for the Nextflow pipeline configuration.
+
+The defect these exist for: five processes carried `process_high` or
+`process_medium`, and the only config in the repository defined `bigcpu` and
+`lowmem`. Neither set of names matched the other, so every labelled process ran
+on Nextflow's defaults — one CPU, two gigabytes. Somatic calling passed
+`--native-pair-hmm-threads 1` and STAR could not load a human genome index at
+all. Nothing reported this. An unmatched `withLabel` selector is not an error in
+Nextflow, and an unmatched label on a process is not one either; the two failures
+are silent from opposite directions and cancel into a pipeline that runs slowly
+and calls fewer variants.
+
+The second guard is version agreement. HaplotypeCaller was pinned to GATK
+4.5.0.0 and Mutect2 to 4.4.0.0, so one run's germline and somatic calls came
+from different releases of the same caller — the provenance question the
+variant-calling validation gate exists to answer.
+
+Text parsing rather than running Nextflow: the CI runner has no `nextflow`, and
+the properties asserted here are properties of the files.
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+PIPELINE = Path(__file__).resolve().parents[2] / "pipeline"
+MODULES = sorted((PIPELINE / "modules").glob("*.nf"))
+CONFIGS = [PIPELINE / "nextflow.config"] + sorted((PIPELINE / "conf").glob("*.config"))
+
+
+def _labels_used() -> dict[str, list[str]]:
+    """Label name → the module files that carry it."""
+    used: dict[str, list[str]] = {}
+    for module in MODULES:
+        for match in re.finditer(
+            r"""^\s*label\s+["']([^"']+)["']""", module.read_text(encoding="utf-8"), re.M
+        ):
+            used.setdefault(match.group(1), []).append(module.name)
+    return used
+
+
+def _labels_defined() -> set[str]:
+    defined = set()
+    for config in CONFIGS:
+        text = config.read_text(encoding="utf-8")
+        defined.update(re.findall(r"withLabel:\s*['\"]?([A-Za-z0-9_]+)", text))
+    return defined
+
+
+def test_pipeline_has_a_base_config():
+    """
+    Without nextflow.config a plain `nextflow run main.nf` gets no resource
+    labels, no container engine and no tool versions.
+    """
+    assert (PIPELINE / "nextflow.config").exists()
+
+
+def test_every_label_a_process_uses_is_defined():
+    used = _labels_used()
+    defined = _labels_defined()
+    missing = {label: files for label, files in used.items() if label not in defined}
+    assert not missing, (
+        "processes carry labels no config selects on, so they run at Nextflow's "
+        f"one-CPU default: {missing}"
+    )
+
+
+def test_no_config_selects_on_a_label_no_process_uses():
+    """
+    The other half of the same drift. `bigcpu` and `lowmem` were tuned, reviewed
+    and inert.
+    """
+    orphans = _labels_defined() - set(_labels_used())
+    assert not orphans, f"withLabel selectors matching no process: {sorted(orphans)}"
+
+
+def test_labelled_processes_still_exist():
+    """A guard over an empty set proves nothing."""
+    assert len(_labels_used()) >= 2
+    assert sum(len(v) for v in _labels_used().values()) >= 5
+
+
+# ── Tool versions agree across modules ───────────────────────────────────────
+
+def _gatk_versions() -> dict[str, set[str]]:
+    versions: dict[str, set[str]] = {}
+    for module in MODULES:
+        text = module.read_text(encoding="utf-8")
+        found = set(re.findall(r"gatk4?[:=]([0-9]+(?:\.[0-9]+)+)", text))
+        found |= set(re.findall(r"broadinstitute/gatk:([0-9]+(?:\.[0-9]+)+)", text))
+        if found:
+            versions[module.name] = found
+    return versions
+
+
+def test_gatk_version_is_not_hardcoded_per_module():
+    """
+    Both GATK modules must take the version from `params.gatk_version`. A
+    literal in either one is how 4.4.0.0 and 4.5.0.0 came to coexist.
+    """
+    literals = _gatk_versions()
+    assert not literals, (
+        f"GATK versions hardcoded instead of read from params.gatk_version: {literals}"
+    )
+
+
+def test_gatk_version_is_declared_once():
+    text = (PIPELINE / "nextflow.config").read_text(encoding="utf-8")
+    declared = re.findall(r"gatk_version\s*=\s*['\"]([^'\"]+)['\"]", text)
+    assert len(declared) == 1, f"expected one gatk_version declaration, found {declared}"
+
+
+@pytest.mark.parametrize("module", ["gatk.nf", "mutect2.nf"], ids=["haplotypecaller", "mutect2"])
+def test_gatk_modules_read_the_shared_version(module):
+    text = (PIPELINE / "modules" / module).read_text(encoding="utf-8")
+    assert "params.gatk_version" in text
+
+
+# ── A container engine is actually selectable ────────────────────────────────
+
+def test_config_offers_a_profile_for_every_dependency_style():
+    """
+    Modules mix `conda` and `container` directives. conf/local.config enabled
+    conda alone, so the container-based processes — the entire somatic and
+    multi-omic path — resolved against whatever was on the host PATH, with no
+    record of the version that produced the calls.
+    """
+    text = (PIPELINE / "nextflow.config").read_text(encoding="utf-8")
+    for profile in ("conda", "docker", "singularity"):
+        assert re.search(rf"^\s*{profile}\s*\{{", text, re.M), f"no {profile} profile"
+
+
+def test_container_processes_are_reachable_by_a_container_profile():
+    using_containers = [m.name for m in MODULES if re.search(r"^\s*container\s", m.read_text(encoding="utf-8"), re.M)]
+    assert using_containers, "expected at least one containerised process"
+    text = (PIPELINE / "nextflow.config").read_text(encoding="utf-8")
+    assert "docker.enabled" in text and "singularity.enabled" in text

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -162,6 +162,46 @@ services:
     command: celery -A workers.notify_worker worker --loglevel=info -Q notify
 
   # ─────────────────────────────────────────────
+  # Celery GDPR Worker  →  background
+  # ─────────────────────────────────────────────
+  # Consumes the `gdpr` queue: erasure requests from DELETE /api/me, and the
+  # daily retention sweep celery-beat schedules. task_routes has sent work here
+  # since the queue was added and nothing consumed it, so both accumulated in
+  # Redis unexecuted while every producer saw a successful enqueue.
+  worker-gdpr:
+    build:
+      context: .
+      dockerfile: api/Dockerfile
+    environment:
+      - DATABASE_URL=postgresql+asyncpg://openoncology:${DB_PASSWORD}@db:5432/openoncology
+      - REDIS_URL=redis://redis:6379/0
+      - RESEND_API_KEY=${RESEND_API_KEY}
+      - MINIO_ENDPOINT=storage:9000
+      - MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY}
+      - MINIO_SECRET_KEY=${MINIO_SECRET_KEY}
+      - KEYCLOAK_URL=http://keycloak:8080
+      - KEYCLOAK_ADMIN_PASSWORD=${KEYCLOAK_ADMIN_PASSWORD}
+    volumes:
+      - ./api:/app
+      - ./ai/alphamissense:/app/ai/alphamissense
+      - ./ai/diffdock:/app/ai/diffdock
+      - ./ai/repurposing:/app/ai/repurposing
+      - ./ai/services:/app/ai/services
+    depends_on:
+      - db
+      - redis
+      - storage
+    healthcheck:
+      test: ["CMD", "celery", "-A", "workers.gdpr_worker", "inspect", "ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    networks:
+      - openoncology
+    command: celery -A workers.gdpr_worker worker --loglevel=info -Q gdpr
+
+  # ─────────────────────────────────────────────
   # PostgreSQL Database  →  localhost:5432
   # ─────────────────────────────────────────────
   db:

--- a/infra/helm/templates/api.yaml
+++ b/infra/helm/templates/api.yaml
@@ -21,12 +21,22 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
       serviceAccountName: {{ include "openoncology.serviceAccountName" . }}
+      # Endpoint removal and SIGTERM race each other: both start when the pod is
+      # deleted, and a proxy that has not yet seen the removal keeps sending
+      # requests to a server that has already stopped listening. The preStop
+      # sleep holds the container open across that window, so the rollout stays
+      # as invisible to callers as `maxUnavailable: 0` promises.
+      terminationGracePeriodSeconds: {{ .Values.api.terminationGracePeriodSeconds }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
         fsGroup: 1000
       containers:
         - name: api
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sleep", "{{ .Values.api.preStopSleepSeconds }}"]
           image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}"
           imagePullPolicy: {{ .Values.api.image.pullPolicy }}
           ports:
@@ -46,6 +56,16 @@ spec:
                   key: password
           resources:
             {{- toYaml .Values.api.resources | nindent 12 }}
+          # /health answers 200 unconditionally — it reports that the process is
+          # up, which is what liveness asks. Readiness must ask a different
+          # question, and /ready is the endpoint that answers it: it round-trips
+          # Postgres and Redis and returns 503 when either is unreachable.
+          #
+          # This probe pointed at /health, so a pod whose database was gone
+          # passed readiness and was sent traffic, on the deployment path
+          # production actually uses. infra/k8s/deployment.yaml had it right the
+          # whole time; the two manifests simply drifted, and nothing rendered
+          # or compared them. The infra-manifests job in ci.yml now does.
           livenessProbe:
             httpGet:
               path: /health
@@ -55,10 +75,11 @@ spec:
             failureThreshold: 3
           readinessProbe:
             httpGet:
-              path: /health
+              path: /ready
               port: http
             initialDelaySeconds: 5
             periodSeconds: 10
+            failureThreshold: 3
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/infra/helm/templates/beat.yaml
+++ b/infra/helm/templates/beat.yaml
@@ -1,0 +1,88 @@
+{{/*
+Celery Beat — the scheduler behind `beat_schedule` in api/workers/__init__.py.
+
+Two tasks depend on it: `gdpr-enforce-retention-daily`, which deletes patient
+data past its retention window, and `sweep-stale-submissions-hourly`, which
+recovers submissions left in `processing` by a crashed pipeline. Neither has a
+non-scheduled trigger, so without this Deployment neither has ever run in the
+cluster.
+
+Single replica, Recreate strategy. Beat holds no lock; a second instance
+enqueues the same schedule again, and two retention passes would run concurrent
+deletions over the same rows.
+*/}}
+{{- if .Values.beat.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "openoncology.fullname" . }}-beat
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "openoncology.labels" . | nindent 4 }}
+    app.kubernetes.io/component: beat
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "openoncology.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: beat
+  template:
+    metadata:
+      labels:
+        {{- include "openoncology.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: beat
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+    spec:
+      serviceAccountName: {{ include "openoncology.serviceAccountName" . }}
+      terminationGracePeriodSeconds: {{ .Values.beat.terminationGracePeriodSeconds }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+      containers:
+        - name: beat
+          image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}"
+          imagePullPolicy: {{ .Values.api.image.pullPolicy }}
+          # The schedule file is state beat writes on every tick. The root
+          # filesystem is read-only, so it is pointed at the tmp emptyDir; losing
+          # it on restart re-runs a missed cron entry at worst, which both tasks
+          # tolerate.
+          command:
+            - celery
+            - -A
+            - workers
+            - beat
+            - --loglevel=info
+            - --schedule=/tmp/celerybeat-schedule
+          envFrom:
+            - configMapRef:
+                name: {{ include "openoncology.fullname" . }}-config
+            - secretRef:
+                name: {{ .Values.api.secretRef }}
+          env:
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: openoncology-pg-secret
+                  key: password
+          resources:
+            {{- toYaml .Values.beat.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/infra/helm/templates/configmap.yaml
+++ b/infra/helm/templates/configmap.yaml
@@ -10,6 +10,11 @@ data:
   KEYCLOAK_URL: {{ printf "https://%s" .Values.ingress.hosts.keycloak | quote }}
   KEYCLOAK_REALM: {{ .Values.api.env.KEYCLOAK_REALM | quote }}
   KEYCLOAK_CLIENT_ID: {{ .Values.api.env.KEYCLOAK_CLIENT_ID | quote }}
+  # The API refuses to start in production without this. KEYCLOAK_URL above is
+  # already the public ingress hostname, so the derived issuer is correct here
+  # and KEYCLOAK_ISSUER is left unset; it is needed only where the API dials an
+  # internal Service address instead.
+  KEYCLOAK_AUDIENCE: {{ .Values.api.env.KEYCLOAK_AUDIENCE | quote }}
   MINIO_ENDPOINT: {{ printf "%s-minio:9000" .Release.Name | quote }}
   MINIO_SECURE: {{ .Values.api.env.MINIO_SECURE | quote }}
   MINIO_BUCKET_RAW: {{ .Values.api.env.MINIO_BUCKET_RAW | quote }}

--- a/infra/helm/templates/pdb.yaml
+++ b/infra/helm/templates/pdb.yaml
@@ -1,0 +1,27 @@
+{{/*
+PodDisruptionBudget for the API.
+
+infra/k8s/pdb.yaml has carried one since the beginning; the chart did not, and
+the chart is what production deploys from. Without it a node drain or a cluster
+upgrade can evict every API replica at once, and `maxUnavailable: 0` on the
+Deployment does not help — that governs rollouts, not voluntary disruptions.
+
+`minAvailable` is a count rather than a percentage on purpose: a percentage
+rounds up against small replica counts and can deadlock the drain outright.
+*/}}
+{{- if .Values.api.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "openoncology.fullname" . }}-api
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "openoncology.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+spec:
+  minAvailable: {{ .Values.api.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "openoncology.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: api
+{{- end }}

--- a/infra/helm/templates/workers.yaml
+++ b/infra/helm/templates/workers.yaml
@@ -23,6 +23,13 @@ spec:
         app.kubernetes.io/component: worker-{{ $name }}
     spec:
       serviceAccountName: {{ include "openoncology.serviceAccountName" $root }}
+      # SIGTERM is a warm shutdown for Celery: the worker stops taking new
+      # messages and finishes the one in hand. That only helps if Kubernetes
+      # waits for it. At the 30-second default a genomic task is SIGKILLed
+      # mid-run on every deploy, leaving the submission stuck in `processing`
+      # with nothing to retry it, so the grace period is set from how long the
+      # queue's longest task actually takes.
+      terminationGracePeriodSeconds: {{ $cfg.terminationGracePeriodSeconds }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/infra/helm/values.yaml
+++ b/infra/helm/values.yaml
@@ -19,6 +19,16 @@ api:
     pullPolicy: IfNotPresent
   replicaCount: 2
   port: 8000
+  # preStop holds the container open while endpoint removal propagates to the
+  # proxies; the grace period has to exceed it plus the longest request the API
+  # serves, or SIGKILL arrives while the sleep is still running.
+  terminationGracePeriodSeconds: 60
+  preStopSleepSeconds: 10
+  # Voluntary disruptions — node drains, cluster upgrades — are not covered by
+  # the Deployment's maxUnavailable, which only governs rollouts.
+  podDisruptionBudget:
+    enabled: true
+    minAvailable: 1
   resources:
     requests:
       cpu: "250m"
@@ -36,6 +46,11 @@ api:
     ENVIRONMENT: production
     KEYCLOAK_REALM: openoncology
     KEYCLOAK_CLIENT_ID: openoncology-api
+    # Must match what the client's audience mapper emits. Keycloak puts the
+    # client id in `azp` and "account" in `aud` unless a mapper says otherwise,
+    # so this value is a claim someone has to configure the realm to produce —
+    # it is not automatic, and the API will not boot in production without it.
+    KEYCLOAK_AUDIENCE: openoncology-api
     MINIO_SECURE: "true"
     MINIO_BUCKET_RAW: openoncology-raw
     MINIO_BUCKET_VCF: openoncology-vcf
@@ -63,9 +78,22 @@ web:
     NEXT_PUBLIC_KEYCLOAK_CLIENT_ID: openoncology-web
 
 # ── Celery Workers ────────────────────────────────────────────────────────────
+# One entry per Celery queue. The key is the queue name and the worker module
+# both — `workers.<key>_worker`, consuming `-Q <key>` — so a queue that
+# `task_routes` in api/workers/__init__.py sends work to and that has no entry
+# here has no consumer in the cluster. Messages then accumulate in Redis and are
+# never executed, which is silent: the producer's `apply_async` succeeds.
+# `api/tests/test_celery_queue_coverage.py` fails the build on that mismatch.
+#
+# terminationGracePeriodSeconds is per queue because SIGTERM is a warm shutdown
+# for Celery — stop consuming, finish the task in hand — and the wait each queue
+# needs is the length of its longest task. Tasks are `acks_late`, so one killed
+# at the deadline is redelivered rather than lost; it restarts from the
+# beginning, and any side effect it had already performed happens twice.
 workers:
   genomic:
     replicaCount: 2
+    terminationGracePeriodSeconds: 900
     resources:
       requests:
         cpu: "500m"
@@ -75,6 +103,7 @@ workers:
         memory: "4Gi"
   ai:
     replicaCount: 1
+    terminationGracePeriodSeconds: 600
     resources:
       requests:
         cpu: "1000m"
@@ -84,6 +113,7 @@ workers:
         memory: "8Gi"
   notify:
     replicaCount: 1
+    terminationGracePeriodSeconds: 120
     resources:
       requests:
         cpu: "100m"
@@ -91,6 +121,42 @@ workers:
       limits:
         cpu: "500m"
         memory: "512Mi"
+  # Erasure requests and the daily retention sweep. This queue had no consumer
+  # in either deployment path: `DELETE /api/me` enqueued `erase_patient_data`
+  # and told the patient their data would be gone within 30 days, and the task
+  # sat in Redis. Deletion is a GDPR obligation with a deadline attached, so the
+  # absence of a consumer was a compliance failure that looked like a success
+  # from every side that could observe it.
+  gdpr:
+    replicaCount: 1
+    terminationGracePeriodSeconds: 300
+    resources:
+      requests:
+        cpu: "100m"
+        memory: "256Mi"
+      limits:
+        cpu: "500m"
+        memory: "1Gi"
+
+# ── Celery Beat (periodic tasks) ──────────────────────────────────────────────
+# The scheduler for `beat_schedule`: GDPR retention enforcement daily, and the
+# hourly sweep that recovers submissions stuck in `processing` after a pipeline
+# crash. docker-compose has run it since the beginning; the chart never did, so
+# in Kubernetes neither periodic task had ever fired.
+#
+# Exactly one replica, and Recreate rather than RollingUpdate. Two beats against
+# one schedule enqueue every task twice, which for the retention sweep means
+# two concurrent deletion passes over the same rows.
+beat:
+  enabled: true
+  terminationGracePeriodSeconds: 30
+  resources:
+    requests:
+      cpu: "50m"
+      memory: "128Mi"
+    limits:
+      cpu: "200m"
+      memory: "256Mi"
 
 # ── PostgreSQL (Bitnami sub-chart) ────────────────────────────────────────────
 postgresql:
@@ -159,6 +225,25 @@ ingress:
     nginx.ingress.kubernetes.io/proxy-body-size: "100m"
     nginx.ingress.kubernetes.io/rate-limit: "100"
     nginx.ingress.kubernetes.io/rate-limit-window: "1m"
+    # The API host routes `/` as a Prefix, so every path on the pod is public,
+    # /metrics included. It carries no authentication and publishes per-handler
+    # request counts and latencies — traffic shape for a service whose traffic
+    # is patients submitting tumour genomes.
+    #
+    # Prometheus is unaffected: infra/prometheus.yml scrapes `api:8000`
+    # in-cluster and the ServiceMonitor scrapes the Service, neither through
+    # this ingress.
+    #
+    # One caveat worth knowing rather than assuming away: ingress-nginx ships
+    # `allow-snippet-annotations: false` since 1.9, and where it is false the
+    # controller ignores this annotation instead of rejecting it. That fails
+    # open. Confirm the rendered nginx.conf actually contains the location block
+    # before treating the endpoint as closed.
+    nginx.ingress.kubernetes.io/server-snippet: |
+      location /metrics {
+        deny all;
+        return 403;
+      }
   hosts:
     api: api.openoncology.org
     web: openoncology.org

--- a/pipeline/conf/local.config
+++ b/pipeline/conf/local.config
@@ -1,27 +1,26 @@
 /*
- * Local development config for Nextflow pipeline
- * Use: nextflow run main.nf -c conf/local.config
+ * Local development overrides for the Nextflow pipeline.
+ * Use: nextflow run main.nf -profile conda -c conf/local.config
+ *
+ * nextflow.config carries the resource labels, tool versions and container
+ * profiles; this file only narrows them to one workstation. It used to define
+ * `bigcpu` and `lowmem`, which no process in pipeline/modules ever carried, so
+ * the two selectors matched nothing and the labels the modules do carry —
+ * process_high and process_medium — matched nothing either. Both halves of that
+ * now live in nextflow.config under the names the modules actually use.
+ *
+ * The ceilings below are what a developer workstation can be expected to have.
+ * They are not enough for STAR against a human genome index; the RNA-seq
+ * workflow needs a real machine.
  */
-process {
-    executor       = 'local'
-    maxForks       = 4
-    errorStrategy  = 'retry'
-    maxRetries     = 2
-
-    withLabel: 'bigcpu' {
-        cpus   = 8
-        memory = '16 GB'
-    }
-
-    withLabel: 'lowmem' {
-        cpus   = 2
-        memory = '4 GB'
-    }
-}
-
-conda.enabled = true
 
 params {
-    ref_fasta = "${projectDir}/references/GRCh38.fa"
-    dbsnp     = "${projectDir}/references/dbsnp_146.hg38.vcf.gz"
+    max_cpus   = 8
+    max_memory = '16.GB'
+    max_time   = '8.h'
+}
+
+process {
+    executor = 'local'
+    maxForks = 4
 }

--- a/pipeline/modules/bwa_mem2.nf
+++ b/pipeline/modules/bwa_mem2.nf
@@ -5,6 +5,7 @@ process BWA_MEM2_ALIGN {
     tag "$reads"
     publishDir "${params.output_dir}/bam", mode: 'copy'
 
+    label "process_high"
     conda 'bioconda::bwa-mem2=2.2.1 bioconda::samtools=1.19'
 
     input:

--- a/pipeline/modules/fastqc.nf
+++ b/pipeline/modules/fastqc.nf
@@ -5,6 +5,7 @@ process FASTQC {
     tag "$reads"
     publishDir "${params.output_dir}/fastqc", mode: 'copy'
 
+    label "process_low"
     conda 'bioconda::fastqc=0.12.1'
 
     input:

--- a/pipeline/modules/gatk.nf
+++ b/pipeline/modules/gatk.nf
@@ -5,7 +5,10 @@ process GATK_HAPLOTYPE {
     tag "$bam"
     publishDir "${params.output_dir}/vcf", mode: 'copy'
 
-    conda 'bioconda::gatk4=4.5.0.0'
+    label "process_high"
+    // Version comes from params.gatk_version, shared with the Mutect2 module.
+    conda "bioconda::gatk4=${params.gatk_version} bioconda::samtools=1.19"
+    container "broadinstitute/gatk:${params.gatk_version}"
 
     input:
     path bam

--- a/pipeline/modules/mutect2.nf
+++ b/pipeline/modules/mutect2.nf
@@ -23,7 +23,12 @@
 process MUTECT2 {
     tag "${tumour_bam.simpleName}"
     label "process_high"
-    container "broadinstitute/gatk:4.4.0.0"
+    // Pinned from params.gatk_version so this cannot drift from the
+    // HaplotypeCaller module again. The two were 4.4.0.0 and 4.5.0.0, so a
+    // germline and a somatic call from one run came from different releases of
+    // the same caller.
+    container "broadinstitute/gatk:${params.gatk_version}"
+    conda "bioconda::gatk4=${params.gatk_version} bioconda::samtools=1.19"
 
     input:
     path tumour_bam

--- a/pipeline/modules/opencravat.nf
+++ b/pipeline/modules/opencravat.nf
@@ -5,6 +5,7 @@ process OPENCRAVAT {
     tag "$vcf"
     publishDir "${params.output_dir}/annotated", mode: 'copy'
 
+    label "process_medium"
     conda 'bioconda::open-cravat=2.4.2'
 
     input:

--- a/pipeline/modules/trimmomatic.nf
+++ b/pipeline/modules/trimmomatic.nf
@@ -5,6 +5,7 @@ process TRIMMOMATIC {
     tag "$reads"
     publishDir "${params.output_dir}/trimmed", mode: 'copy'
 
+    label "process_low"
     conda 'bioconda::trimmomatic=0.39'
 
     input:

--- a/pipeline/nextflow.config
+++ b/pipeline/nextflow.config
@@ -1,0 +1,149 @@
+/*
+ * OpenOncology genomic pipeline — base configuration.
+ *
+ * This file did not exist, and its absence was not visible from anything the
+ * pipeline prints. Five processes carry resource labels:
+ *
+ *   process_high    MUTECT2, MANTA, STAR_ALIGN
+ *   process_medium  CNVKIT, FEATURECOUNTS
+ *
+ * The only config in the repository, conf/local.config, defined `bigcpu` and
+ * `lowmem`, which no process uses. So every labelled process fell through to
+ * Nextflow's defaults of one CPU and two gigabytes. Somatic calling ran
+ * `--native-pair-hmm-threads 1`, and STAR, which needs upward of thirty
+ * gigabytes to hold a human genome index, could not start at all. The labels
+ * read as tuning that was in force; nothing selected on them.
+ *
+ * The second absence: modules mix `conda` and `container` directives, and
+ * conf/local.config enabled conda only. The four container-based processes —
+ * the whole somatic and multi-omic path — resolved to whatever happened to be
+ * on the host PATH. Container profiles below make that a deliberate choice.
+ *
+ * `api/tests/test_pipeline_config.py` fails if a label is used without being
+ * defined here.
+ */
+
+manifest {
+    name            = 'openoncology/pipeline'
+    description     = 'Germline, somatic and multi-omic variant calling for OpenOncology'
+    mainScript      = 'main.nf'
+    nextflowVersion = '>=23.10.0'
+    version         = '1.0.0'
+}
+
+params {
+    // Tool versions are declared once so the two GATK entry points cannot drift.
+    // They had: HaplotypeCaller pinned to conda gatk4=4.5.0.0, Mutect2 to
+    // container broadinstitute/gatk:4.4.0.0. A germline and a somatic call from
+    // the same run were made by different releases of the same caller, which is
+    // exactly the provenance question the variant-calling validation gate asks.
+    gatk_version = '4.5.0.0'
+
+    output_dir   = './results'
+    ref_fasta    = "${projectDir}/references/GRCh38.fa"
+    dbsnp        = "${projectDir}/references/dbsnp_146.hg38.vcf.gz"
+
+    // Ceilings for the resource labels below. Set these to what the executor
+    // will actually grant; requesting more than a node has makes a job pend
+    // forever rather than fail.
+    max_cpus     = 16
+    max_memory   = '128.GB'
+    max_time     = '48.h'
+}
+
+/*
+ * Clamp a requested resource to the configured ceiling. Without this a label
+ * asking for 72 GB on a 16 GB runner produces a job that is never scheduled,
+ * which looks like the pipeline hanging.
+ */
+def check_max(obj, type) {
+    if (type == 'memory') {
+        def max = params.max_memory as nextflow.util.MemoryUnit
+        return obj.compareTo(max) == 1 ? max : obj
+    }
+    if (type == 'time') {
+        def max = params.max_time as nextflow.util.Duration
+        return obj.compareTo(max) == 1 ? max : obj
+    }
+    if (type == 'cpus') {
+        return Math.min(obj as int, params.max_cpus as int)
+    }
+    return obj
+}
+
+process {
+    cpus   = { check_max(1     * task.attempt, 'cpus'  ) }
+    memory = { check_max(6.GB  * task.attempt, 'memory') }
+    time   = { check_max(4.h   * task.attempt, 'time'  ) }
+
+    // Retry only what retrying can fix. 137 and 140 are the out-of-memory and
+    // walltime kills, and the resource request above grows with task.attempt,
+    // so the retry is materially different from the attempt that failed. Every
+    // other exit status is a deterministic failure and retrying it just burns
+    // the cluster three times before reporting the same error.
+    errorStrategy = { task.exitStatus in [104, 134, 137, 139, 140, 143, 151, 255] ? 'retry' : 'finish' }
+    maxRetries    = 2
+    maxErrors     = '-1'
+
+    withLabel: process_low {
+        cpus   = { check_max(2     * task.attempt, 'cpus'  ) }
+        memory = { check_max(12.GB * task.attempt, 'memory') }
+        time   = { check_max(4.h   * task.attempt, 'time'  ) }
+    }
+    withLabel: process_medium {
+        cpus   = { check_max(6     * task.attempt, 'cpus'  ) }
+        memory = { check_max(36.GB * task.attempt, 'memory') }
+        time   = { check_max(8.h   * task.attempt, 'time'  ) }
+    }
+    withLabel: process_high {
+        cpus   = { check_max(12    * task.attempt, 'cpus'  ) }
+        memory = { check_max(72.GB * task.attempt, 'memory') }
+        time   = { check_max(16.h  * task.attempt, 'time'  ) }
+    }
+
+    // STAR holds the whole genome index in memory and does not care how many
+    // attempts it has had. Under process_high alone a first attempt at 72 GB is
+    // fine, but the floor matters on a machine where max_memory is lower: this
+    // makes the requirement explicit rather than emergent.
+    withName: STAR_ALIGN {
+        memory = { check_max(38.GB * task.attempt, 'memory') }
+    }
+}
+
+// One of these must be selected. Modules declare both `conda` and `container`
+// directives depending on the tool, and with no profile chosen Nextflow uses
+// neither and runs whatever is on PATH — silently, and with no record of what
+// version produced the calls.
+profiles {
+    conda {
+        conda.enabled          = true
+        docker.enabled         = false
+        singularity.enabled    = false
+    }
+    docker {
+        docker.enabled         = true
+        docker.runOptions      = '-u $(id -u):$(id -g)'
+        conda.enabled          = false
+        singularity.enabled    = false
+    }
+    singularity {
+        singularity.enabled    = true
+        singularity.autoMounts = true
+        conda.enabled          = false
+        docker.enabled         = false
+    }
+    test {
+        params.max_cpus        = 2
+        params.max_memory      = '6.GB'
+        params.max_time        = '1.h'
+    }
+}
+
+// Provenance for every run. The validation gate asks which pipeline produced a
+// call set; these four files are the answer, and they cost nothing to keep.
+def trace_stamp = new java.util.Date().format('yyyy-MM-dd_HH-mm-ss')
+
+report   { enabled = true; file = "${params.output_dir}/pipeline_info/report_${trace_stamp}.html"   }
+timeline { enabled = true; file = "${params.output_dir}/pipeline_info/timeline_${trace_stamp}.html" }
+trace    { enabled = true; file = "${params.output_dir}/pipeline_info/trace_${trace_stamp}.txt"     }
+dag      { enabled = true; file = "${params.output_dir}/pipeline_info/dag_${trace_stamp}.html"      }


### PR DESCRIPTION
Four defects on the deployment and auth path, none of which any check in this
repository could have caught, because every one of them is an absence and every
check asserted a positive about something present. Same shape as F11.

## The gdpr queue had no consumer

`task_routes` sends `workers.gdpr_worker.*` to a `gdpr` queue. Neither
docker-compose nor the Helm chart ran a worker for it. So `DELETE /api/me`
enqueued `erase_patient_data`, returned a confirmation promising deletion
within 30 days, and the message sat in Redis. `apply_async` succeeded, the
route returned 200, and nothing anywhere reported a problem.

The daily `gdpr-enforce-retention-daily` sweep went to the same queue, so
retention deletion never ran either.

## The chart had no Celery Beat

docker-compose has run one since the beginning. The chart never did. In
Kubernetes that means neither periodic task had ever fired: not GDPR
retention, and not `sweep-stale-submissions-hourly`, which is the only thing
that recovers a submission left in `processing` by a crashed pipeline.

One replica and `Recreate`, since two beats against one schedule enqueue every
task twice, and for the retention sweep that is two concurrent deletion passes
over the same rows.

## Readiness was probing liveness

`/health` returns 200 whenever the process is up. `/ready` round-trips Postgres
and Redis and returns 503 when either is gone. The chart's readiness probe
pointed at `/health`, so a pod with a dead database passed readiness and was
sent traffic.

`infra/k8s/deployment.yaml` had this right the whole time. The two manifests
for the same service drifted and nothing rendered or compared them, which is
also why the missing NetworkPolicy and PodDisruptionBudget went unnoticed.

## Auth refetched one key on every request

`get_current_patient` guards 45 route dependencies, and each call fetched the
realm's public key over HTTP before doing anything else. Two consequences: a
second outbound round trip on every protected request, and Keycloak being slow
or unreachable taking the API with it.

That key came from the legacy realm `public_key` field, which carries one key.
Keycloak rotates realm keys and signs with the new one while the old is still
valid, so a single-key verifier rejects everything minted after a rotation
until it happens to refetch.

And `audience` was passed as `"account"` and then switched off with
`verify_aud: False`. That reads like a check and is not one. A token issued to
any other client in the same realm verified against every protected route.

Verification now reads the JWKS keyed by `kid` from a cache with a TTL, forces
one refresh on a `kid` miss so rotations are picked up immediately, serves a
stale key set when Keycloak is unreachable rather than failing every request,
fixes RS256 in code instead of reading it from the token header, and verifies
issuer always and audience whenever `KEYCLOAK_AUDIENCE` is set.

## Deployment note

`KEYCLOAK_AUDIENCE` is now required in production and the API will refuse to
boot without it, enforced the same way `MINIO_SECRET_KEY` already is. Keycloak
does not put the client id in `aud` by default, it goes in `azp`, so this
means adding an audience mapper to the client. That is deliberate: the claim
is worth nothing until the realm is configured to emit it. The chart wires it
through the ConfigMap and a test fails if a setting the production validator
requires never reaches there.

`KEYCLOAK_ISSUER` is optional and covers the case where the address the API
dials differs from the hostname Keycloak signs with, which is the normal shape
inside a cluster.

## Pipeline

Five processes carried `process_high` or `process_medium`, and
`conf/local.config`, the only config in the repository, defined `bigcpu` and
`lowmem`, which no module used. Neither an unmatched selector nor an unmatched
label is an error in Nextflow, so both halves failed silently and every
labelled process ran on the default of one CPU and two gigabytes. Mutect2
called somatic variants with `--native-pair-hmm-threads 1`, and STAR, which
holds a human genome index in memory, could not start.

`nextflow.config` now defines the labels the modules actually use. The four
unlabelled modules were on the same default and get labels too. Modules mix
`conda` and `container` directives and only conda was ever enabled, so the
container-based processes, meaning the entire somatic and multi-omic path,
resolved against the host PATH with no record of what produced the calls;
there are conda, docker and singularity profiles now. GATK was also pinned to
4.5.0.0 in `gatk.nf` against 4.4.0.0 in `mutect2.nf`, so a germline and a
somatic call from one run came from different releases of the same caller.
Both read `params.gatk_version`.

## What guards these now

A `validate-manifests` job renders the chart and puts it through kubeconform,
which no job was doing. Three new test modules assert the same properties
offline, 44 tests in total: queue coverage in both deployment paths, beat
present and single-replica, probe paths, grace periods, production settings
reaching the ConfigMap, and every Nextflow label being defined by some config.

I checked they can fail before keeping them. Reverting the readiness probe to
`/health` and deleting the gdpr worker from `values.yaml` fails three of them;
restoring both passes all twelve. The pipeline guard caught `process_low` and
`process_single` sitting unused in my own first draft of the config, which is
how the four unlabelled modules came to be looked at.

`test_deployment_manifests.py` reads `task_routes` from source with `ast`
rather than importing the app. `test_ai_worker_helpers` and
`test_genomic_worker_qc_persistence` both install a MagicMock over
`workers.celery_app` to keep task decorators inert, so a full-suite run sees no
routes at all. Reading the declaration is the right answer for a drift guard
regardless: what ships is the source.

## Not done here

`OO-5` and `OO-6` are filed in the backlog. OO-5 is the NetworkPolicy set that
`infra/k8s` has and the chart does not. It is filed rather than done because
`allow-workers-egress` selects on `app.kubernetes.io/part-of`, a label
`_helpers.tpl` never emits, so ported verbatim it would sever every worker from
Postgres and Redis while rendering and linting clean. OO-6 is digest pinning
for the pipeline containers.

`OO-7` and `OO-8` are in `Needs human decision`. OO-7 is the benchmark ceiling
question: three of five difficulty buckets sit exactly on their own ceiling, so
reordering cannot move them, and the only lever is evidence coverage, which
`civic_coverage_gain.json` has already measured. OO-8 is that
`require_current_evidence` has to be True before any clinical deployment.

## Verification

ruff clean. 1151 api tests and 42 ai tests passing, up from 1107 and 42.
Coverage 61.11% against the 52 gate. `scripts/hard_benchmark_gate.py` PASS,
standard P@3 0.8009 unchanged, which is expected since nothing here is
reachable from the ranking path.

Neither `helm` nor `nextflow` is installed on the machine this was written on,
so the manifest and pipeline assertions here are made by parsing, and CI is
where the chart gets rendered for the first time.

That first render caught the job itself. `Chart.yaml` declares postgresql and
redis, neither is vendored and there is no `Chart.lock`, so helm refused to
render and wrote its error to stderr. stdout was empty, kubeconform read
nothing and reported `0 resource found parsing stdin - Valid: 0`, and because
a pipeline returns the last command's status the failure was discarded. The
job went green in eight seconds having validated nothing, inside a commit
whose subject was that nothing was rendering the chart. `helm lint` only warns
about missing dependencies, so it passed too.

The last commit fetches the dependencies, renders to a file under `pipefail`,
requires that file to be non-empty, and then asserts the rendered output
contains the six things this chart got wrong. The chart now renders and
validates for real: 23 seconds instead of 8, with two steps that did not run
before. I checked the assertion helper fails on a manifest missing those
strings before trusting it.

The first four commits are the OO-4 backlog chores that were sitting unpushed
on local `main`; this branch was cut on top of them and the backlog entry here
builds on that file.
