### PR TITLE
State the research-use limitation on every output path, and stop reporting unreviewed FHIR reports as final

### DIFF
--- a/api/routes/fhir.py
+++ b/api/routes/fhir.py
@@ -99,6 +99,7 @@ async def get_observation(
         select(Mutation)
         .join(Submission)
         .join(Patient)
+        .options(selectinload(Mutation.submission).selectinload(Submission.result))
         .where(
             Mutation.id == mutation_id,
             Patient.keycloak_id == keycloak_id,
@@ -108,7 +109,14 @@ async def get_observation(
     if not mutation:
         raise not_found_error(request, "Mutation not found or access denied.")
 
-    observation = build_observation(mutation)
+    # An Observation fetched on its own still has to say whether a clinician
+    # signed off the report it belongs to, so the result is loaded rather than
+    # letting the parameter fall back to its default.
+    submission = getattr(mutation, "submission", None)
+    result = getattr(submission, "result", None) if submission else None
+    reviewed = bool(getattr(result, "oncologist_reviewed", False)) if result else False
+
+    observation = build_observation(mutation, clinician_reviewed=reviewed)
 
     return JSONResponse(
         content=observation,

--- a/api/routes/results.py
+++ b/api/routes/results.py
@@ -16,6 +16,7 @@ from models.patient import Patient
 from models.result import Result
 from routes.auth import get_current_patient
 from schemas import ResultsResponse, SubmissionStatusOut
+from services.intended_use import intended_use_payload
 from utils.http import conflict_error, not_found_error
 from middleware.rate_limit import limiter, READ_LIMIT
 
@@ -178,6 +179,15 @@ async def get_results(
         "submission_id": submission_id,
         "cancer_type": submission.cancer_type,
         "status": "complete",
+        # Unconditional, and deliberately not inside patient_summary. The only
+        # disclaimer this payload used to carry was nested in that section,
+        # which is generated inside a try and becomes None when it fails. A
+        # caller reading plain_language_summary after that failure got drug
+        # names, has_targetable_mutation and per-mutation OncoKB levels with
+        # nothing in the response saying what produced them.
+        "intended_use": intended_use_payload(
+            clinician_reviewed=bool(result.oncologist_reviewed) if result else False
+        ),
         # The QC verdict stopped at the rendered report until now, so no API
         # consumer could tell a clean sample from a flagged one.
         "sample_qc": qc_payload_for_api(submission.sample_qc),

--- a/api/schemas/responses.py
+++ b/api/schemas/responses.py
@@ -5,6 +5,12 @@ from typing import Any, Optional
 
 from pydantic import BaseModel, Field
 
+from services.intended_use import (
+    NO_CLINICIAN_REVIEW_STATEMENT,
+    REFERENCE_DOCUMENT,
+    RESEARCH_USE_STATEMENT,
+)
+
 
 class SubmissionResponse(BaseModel):
     status: str
@@ -169,6 +175,29 @@ class EvidenceProvenanceOut(BaseModel):
     withheld_reason: Optional[str] = None
 
 
+class IntendedUseOut(BaseModel):
+    """What this output is, and what it is not.
+
+    Every default here is the conservative answer, so a response that forgets to
+    populate the field still states that the output is research output and that
+    nobody has reviewed it. That is the same reason ``sample_qc`` and
+    ``evidence_provenance`` carry default factories: a reader must never receive
+    silence where a limitation belongs.
+
+    Before this existed, the only disclaimer in the results payload lived inside
+    ``patient_summary``, which is generated in a try/except and becomes None on
+    failure. The response after that failure still carried drug names,
+    ``has_targetable_mutation`` and per-mutation OncoKB levels.
+    """
+    intended_use: str = "research"
+    clinical_use_approved: bool = False
+    regulator_cleared: bool = False
+    clinician_reviewed: bool = False
+    statement: str = RESEARCH_USE_STATEMENT
+    clinician_review_statement: str = NO_CLINICIAN_REVIEW_STATEMENT
+    reference: str = REFERENCE_DOCUMENT
+
+
 class ResultsResponse(BaseModel):
     submission_id: str
     cancer_type: Optional[str] = None
@@ -211,3 +240,5 @@ class ResultsResponse(BaseModel):
     # None means the scoring rules were not recorded for this result, which
     # is not the same as having run under the current ones.
     algorithm_version: Optional[dict[str, Any]] = None
+    # Always present, and not nested inside a section that is allowed to fail.
+    intended_use: IntendedUseOut = Field(default_factory=IntendedUseOut)

--- a/api/services/fhir_export.py
+++ b/api/services/fhir_export.py
@@ -22,6 +22,13 @@ from __future__ import annotations
 
 from datetime import datetime, UTC
 
+from services.intended_use import (
+    FHIR_EXTENSION_URL,
+    RESEARCH_USE_STATEMENT,
+    fhir_meta,
+    prefix_conclusion,
+)
+
 
 def build_diagnostic_report(
     submission: object,
@@ -50,7 +57,8 @@ def build_diagnostic_report(
     else:
         issued_str = str(issued)
 
-    status = _map_status(getattr(submission, "status", "unknown"))
+    clinician_reviewed = bool(getattr(result, "oncologist_reviewed", False)) if result else False
+    status = _map_status(getattr(submission, "status", "unknown"), clinician_reviewed)
 
     observation_refs = [
         {"reference": f"Observation/mutation-{m.id}"}
@@ -69,6 +77,7 @@ def build_diagnostic_report(
         "id": f"diagnostic-report-{getattr(submission, 'id', 'unknown')}",
         "meta": {
             "profile": ["http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/genomics-report"],
+            "tag": fhir_meta(clinician_reviewed),
         },
         "status": status,
         "category": [
@@ -95,7 +104,7 @@ def build_diagnostic_report(
         "subject": {"reference": patient_id_fhir},
         "issued": issued_str,
         "result": observation_refs,
-        "conclusion": interpretation_text,
+        "conclusion": prefix_conclusion(interpretation_text, clinician_reviewed),
         "conclusionCode": [
             {
                 "coding": [
@@ -116,6 +125,10 @@ def build_diagnostic_report(
                 "url": "http://openoncology.org/fhir/StructureDefinition/targetable-mutation",
                 "valueBoolean": has_targetable,
             },
+            {
+                "url": FHIR_EXTENSION_URL,
+                "valueString": RESEARCH_USE_STATEMENT,
+            },
         ],
     }
 
@@ -132,7 +145,7 @@ def build_diagnostic_report(
     return report
 
 
-def build_observation(mutation: object) -> dict:
+def build_observation(mutation: object, clinician_reviewed: bool = False) -> dict:
     """Build a FHIR R4 Observation resource for a single somatic mutation.
 
     Uses the HL7 Genomics Reporting IG (v2.0) Variant profile:
@@ -245,8 +258,13 @@ def build_observation(mutation: object) -> dict:
         "id": f"mutation-{mutation_id}",
         "meta": {
             "profile": ["http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/variant"],
+            # An Observation is individually addressable at
+            # /api/fhir/Observation/{id} and travels out of the bundle on its
+            # own, so it has to carry the marker itself rather than inherit it
+            # from the DiagnosticReport that references it.
+            "tag": fhir_meta(clinician_reviewed),
         },
-        "status": "final",
+        "status": "final" if clinician_reviewed else "preliminary",
         "category": [
             {
                 "coding": [
@@ -292,13 +310,26 @@ def build_observation(mutation: object) -> dict:
 
 # ── Helpers ────────────────────────────────────────────────────────────────────
 
-def _map_status(submission_status: str) -> str:
-    """Map OpenOncology submission status to FHIR DiagnosticReport.status."""
+def _map_status(submission_status: str, clinician_reviewed: bool = False) -> str:
+    """
+    Map an OpenOncology submission status to FHIR DiagnosticReport.status.
+
+    A completed submission mapped to `final`, which in FHIR R4 means the report
+    is complete and verified. Nothing here verifies anything: the pipeline
+    finishing is the only condition that was being reported. `preliminary` is
+    the code for results that are complete but not verified, which is what an
+    unreviewed report is, so a completed submission only reaches `final` once a
+    clinician has actually signed it off.
+
+    This is the one signal in the resource an EMR is guaranteed to act on. Tags
+    and extensions can be dropped on ingest; status cannot, because the receiving
+    system needs it to decide how to file the report.
+    """
     mapping = {
         "queued": "registered",
         "processing": "partial",
         "awaiting_ai": "partial",
-        "complete": "final",
+        "complete": "final" if clinician_reviewed else "preliminary",
         "failed": "cancelled",
     }
     return mapping.get(str(submission_status).lower(), "unknown")

--- a/api/services/intended_use.py
+++ b/api/services/intended_use.py
@@ -1,0 +1,101 @@
+"""
+The intended-use statement, declared once.
+
+Every output this system produces is research output. `docs/REGULATORY_FRAMEWORK.md`
+section 3 lists the clinical validation gates and none of them is met, so no
+result here has been shown to be fit to inform a treatment decision. That is a
+property of every response, not of one section inside some of them, and this
+module exists so it can only be written down in one place.
+
+It was not one place before. `patient_summary.DISCLAIMER` carried it for the
+patient letter, `oncologist_report.ONCOLOGIST_DISCLAIMER` for the clinician
+report, `pdf_export` had its own strings, and the results API had none of its
+own: the only disclaimer in that payload was nested inside `patient_summary`,
+which is generated inside a `try` and set to None when it fails. A caller
+reading `plain_language_summary` after that failure got drug names, an
+actionability flag and per-mutation OncoKB levels with nothing anywhere in the
+response saying what the system is.
+
+The FHIR export carried nothing at all, which is the path that matters most:
+it exists to be ingested by an EMR, where a DiagnosticReport is indistinguishable
+from one a validated laboratory produced.
+"""
+
+# Machine-readable, stable. Consumers should branch on this rather than parse
+# prose. If a clinical validation ever changes the answer, it changes here.
+INTENDED_USE = "research"
+
+RESEARCH_USE_STATEMENT = (
+    "FOR RESEARCH USE ONLY. Not for use in diagnostic or treatment procedures. "
+    "This output was produced by software that has not been cleared or approved "
+    "by the FDA or any other regulator, and has not been validated against "
+    "patient outcomes."
+)
+
+# Said separately from the sentence above because it is a different claim, and
+# the one a reader is most likely to assume the other way round.
+NO_CLINICIAN_REVIEW_STATEMENT = (
+    "No clinician has reviewed this output unless it is explicitly marked as "
+    "reviewed."
+)
+
+# Where the limits are written out in full. Kept as a bare path rather than a
+# URL because the document travels with the repository, not with a website.
+REFERENCE_DOCUMENT = "docs/REGULATORY_FRAMEWORK.md"
+
+# FHIR has no standard code for "produced by software that is not clinically
+# validated". The nearest vocabularies all mean something else: HTEST is test
+# data rather than real patient data, and the research purpose-of-use codes
+# describe why data is being accessed, not how it was produced. So the marker
+# is a tag under this project's own namespace, and the guarantee that a human
+# sees it is the conclusion text, which is the field EMRs actually render.
+FHIR_TAG_SYSTEM = "http://openoncology.org/fhir/CodeSystem/intended-use"
+FHIR_EXTENSION_URL = "http://openoncology.org/fhir/StructureDefinition/intended-use"
+
+
+def intended_use_payload(clinician_reviewed: bool = False) -> dict:
+    """The block every API response carries, whatever else it does or does not
+    manage to generate."""
+    return {
+        "intended_use": INTENDED_USE,
+        "clinical_use_approved": False,
+        "regulator_cleared": False,
+        "clinician_reviewed": bool(clinician_reviewed),
+        "statement": RESEARCH_USE_STATEMENT,
+        "clinician_review_statement": NO_CLINICIAN_REVIEW_STATEMENT,
+        "reference": REFERENCE_DOCUMENT,
+    }
+
+
+def fhir_meta(clinician_reviewed: bool = False) -> dict:
+    """`meta.tag` entries marking a FHIR resource as research output."""
+    tags = [
+        {
+            "system": FHIR_TAG_SYSTEM,
+            "code": INTENDED_USE,
+            "display": "Research use only. Not for diagnostic or treatment use.",
+        }
+    ]
+    if not clinician_reviewed:
+        tags.append(
+            {
+                "system": FHIR_TAG_SYSTEM,
+                "code": "unreviewed",
+                "display": "No clinician has reviewed this report.",
+            }
+        )
+    return tags
+
+
+def prefix_conclusion(conclusion: str, clinician_reviewed: bool = False) -> str:
+    """
+    Put the statement in front of the interpretation rather than after it.
+
+    A trailing disclaimer is the one a truncating renderer drops, and EMR
+    summary views truncate.
+    """
+    parts = [RESEARCH_USE_STATEMENT]
+    if not clinician_reviewed:
+        parts.append(NO_CLINICIAN_REVIEW_STATEMENT)
+    parts.append((conclusion or "").strip())
+    return "\n\n".join(p for p in parts if p)

--- a/api/tests/test_intended_use_coverage.py
+++ b/api/tests/test_intended_use_coverage.py
@@ -1,0 +1,213 @@
+"""
+Every output path has to say what this system is.
+
+`docs/REGULATORY_FRAMEWORK.md` section 3 lists the clinical validation gates and
+none is met, so nothing here has been shown fit to inform a treatment decision.
+That was written down in the documentation and enforced almost nowhere.
+
+Two gaps these tests close.
+
+The results payload carried no statement of its own. The only disclaimer in it
+was nested inside `patient_summary`, which is built inside a `try` and set to
+None when generation fails. That failure path exists, is logged, and reports
+itself in `generation_errors`, and after it the response still returns
+`summary`, `plain_language_summary`, `has_targetable_mutation`, `target_gene`
+and per-mutation OncoKB levels. A disclaimer that disappears exactly when
+generation goes wrong is not a control.
+
+The FHIR export carried nothing at all, and it is the path that matters most,
+because it exists to be ingested by an EMR where a DiagnosticReport looks like
+one a validated laboratory produced. It also reported `status: final`, which in
+FHIR R4 means complete and verified. The only thing verified was that the
+pipeline finished.
+"""
+from __future__ import annotations
+
+import pytest
+
+from services.fhir_export import build_diagnostic_report, build_observation, _map_status
+from services.intended_use import (
+    INTENDED_USE,
+    RESEARCH_USE_STATEMENT,
+    intended_use_payload,
+)
+
+
+class _Submission:
+    id = "sub-1"
+    cancer_type = "Lung adenocarcinoma"
+    status = "complete"
+    completed_at = None
+    submitted_at = None
+    sample_qc = None
+
+
+class _Result:
+    has_targetable_mutation = True
+    target_gene = "EGFR"
+    summary_text = "EGFR L858R detected."
+    plain_language_summary = "A change was found in the EGFR gene."
+    report_pdf_s3_key = None
+    oncologist_reviewed = False
+    ranked_candidates = []
+    evidence_provenance = None
+    algorithm_version = "v1"
+    oncologist_notes = None
+    cbioportal_data = None
+    cosmic_sample_count = None
+
+
+class _Mutation:
+    id = "mut-1"
+    submission_id = "sub-1"
+    gene = "EGFR"
+    hgvs_notation = "p.L858R"
+    mutation_type = "missense"
+    classification = "pathogenic"
+    oncokb_level = "1"
+    is_targetable = True
+    alphamissense_score = 0.9
+    chromosome = "7"
+    position = 55191822
+    ref_allele = "T"
+    alt_allele = "G"
+    created_at = None
+    allele_fraction = None
+
+
+def _report(reviewed: bool = False) -> dict:
+    result = _Result()
+    result.oncologist_reviewed = reviewed
+    return build_diagnostic_report(
+        submission=_Submission(),
+        result=result,
+        mutations=[_Mutation()],
+        patient_id_fhir="Patient/p-1",
+    )
+
+
+# ── The statement itself ─────────────────────────────────────────────────────
+
+def test_intended_use_is_research_and_says_so():
+    payload = intended_use_payload()
+    assert payload["intended_use"] == "research"
+    assert payload["clinical_use_approved"] is False
+    assert payload["regulator_cleared"] is False
+    assert "RESEARCH USE ONLY" in payload["statement"]
+
+
+def test_review_flag_is_reported_and_defaults_to_unreviewed():
+    assert intended_use_payload()["clinician_reviewed"] is False
+    assert intended_use_payload(clinician_reviewed=True)["clinician_reviewed"] is True
+
+
+# ── FHIR DiagnosticReport ────────────────────────────────────────────────────
+
+def test_diagnostic_report_is_tagged_as_research_output():
+    tags = _report()["meta"]["tag"]
+    assert any(t["code"] == INTENDED_USE for t in tags)
+
+
+def test_diagnostic_report_conclusion_leads_with_the_statement():
+    """
+    Leading rather than trailing: EMR summary views truncate, and a trailing
+    disclaimer is the part that gets cut.
+    """
+    conclusion = _report()["conclusion"]
+    assert conclusion.startswith(RESEARCH_USE_STATEMENT)
+    assert "EGFR L858R detected." in conclusion
+
+
+def test_diagnostic_report_carries_the_intended_use_extension():
+    urls = [e["url"] for e in _report()["extension"]]
+    assert "http://openoncology.org/fhir/StructureDefinition/intended-use" in urls
+
+
+def test_unreviewed_report_is_preliminary_not_final():
+    """
+    FHIR R4 `final` means complete and verified. Nothing verified this. A
+    completed pipeline run is not a clinician's sign-off, and status is the one
+    field an ingesting system cannot ignore.
+    """
+    assert _report(reviewed=False)["status"] == "preliminary"
+
+
+def test_reviewed_report_becomes_final():
+    assert _report(reviewed=True)["status"] == "final"
+
+
+def test_unreviewed_report_is_tagged_unreviewed():
+    codes = [t["code"] for t in _report(reviewed=False)["meta"]["tag"]]
+    assert "unreviewed" in codes
+    assert "unreviewed" not in [t["code"] for t in _report(reviewed=True)["meta"]["tag"]]
+
+
+@pytest.mark.parametrize(
+    "submission_status,expected",
+    [
+        ("queued", "registered"),
+        ("processing", "partial"),
+        ("awaiting_ai", "partial"),
+        ("failed", "cancelled"),
+        ("nonsense", "unknown"),
+    ],
+)
+def test_other_statuses_are_unchanged(submission_status, expected):
+    """Only the completed case was over-claiming; the rest keep their mapping."""
+    assert _map_status(submission_status) == expected
+    assert _map_status(submission_status, True) == expected
+
+
+# ── FHIR Observation ─────────────────────────────────────────────────────────
+
+def test_observation_carries_the_marker_on_its_own():
+    """
+    Observations are individually addressable at /api/fhir/Observation/{id} and
+    leave the bundle alone, so inheriting the report's tag is not enough.
+    """
+    obs = build_observation(_Mutation())
+    assert any(t["code"] == INTENDED_USE for t in obs["meta"]["tag"])
+
+
+def test_unreviewed_observation_is_preliminary():
+    assert build_observation(_Mutation())["status"] == "preliminary"
+    assert build_observation(_Mutation(), clinician_reviewed=True)["status"] == "final"
+
+
+# ── The results API ──────────────────────────────────────────────────────────
+
+async def test_results_response_carries_intended_use(client, seeded_submission):
+    """
+    The payload states it unconditionally, at the top level, rather than
+    nesting it in a section that is allowed to fail.
+    """
+    resp = await client.get(f"/api/results/{seeded_submission.id}")
+    assert resp.status_code == 200
+
+    body = resp.json()
+    assert body["intended_use"]["intended_use"] == "research"
+    assert body["intended_use"]["clinical_use_approved"] is False
+    assert "RESEARCH USE ONLY" in body["intended_use"]["statement"]
+
+
+async def test_intended_use_survives_a_failed_patient_summary(
+    client, seeded_submission, monkeypatch
+):
+    """
+    The case the old placement could not handle. When the section carrying the
+    disclaimer fails to generate, the response still returns drug and
+    actionability content, so the statement has to outlive it.
+    """
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError("patient summary generation failed")
+
+    monkeypatch.setattr("services.patient_summary.generate_patient_summary", _boom)
+
+    resp = await client.get(f"/api/results/{seeded_submission.id}")
+    assert resp.status_code == 200
+
+    body = resp.json()
+    assert body["patient_summary"] is None
+    assert "patient_summary" in body["generation_errors"]
+    assert body["intended_use"]["intended_use"] == "research"
+    assert "RESEARCH USE ONLY" in body["intended_use"]["statement"]

--- a/docs/risk_analysis.md
+++ b/docs/risk_analysis.md
@@ -660,6 +660,78 @@ Those two branches need a reachable dump and a token to execute, so they are
 pinned by reading the call shape in the source rather than by running them.
 Checking the shape is what is available; leaving them unpinned was not.
 
+### F18. Output left the system without saying what it was (H5, H3) — FIXED
+
+Every clinical validation gate in `REGULATORY_FRAMEWORK.md` section 3 is unmet,
+so no output here has been shown fit to inform a treatment decision. That was
+recorded in the documentation and enforced in two renderers: `patient_summary.py`
+carried `DISCLAIMER` for the patient letter and `oncologist_report.py` carried
+`ONCOLOGIST_DISCLAIMER` for the clinician report, with two more hardcoded strings
+in `pdf_export.py`. Nothing related them and nothing said which paths were
+covered. Two were not.
+
+**The FHIR export carried no marker at all.** `services/fhir_export.py` exists to
+be ingested by an EMR; its own docstring names Epic, Cerner and OpenEMR, and
+cites the ONC Final Rule. Once a `DiagnosticReport` is filed in a chart it is
+indistinguishable from one a validated laboratory produced, and this one arrived
+with nothing to distinguish it. This is the highest-consequence instance of H5 in
+the system: not a benchmark figure overstating performance in a document someone
+may read sceptically, but an unvalidated result entering the record that clinical
+decisions are made from, wearing the format reserved for validated ones.
+
+It also reported `status: "final"` for any completed submission. In FHIR R4
+`final` means the report is complete **and verified**. The only thing verified
+was that the pipeline had finished. The resource asserted a clinician sign-off
+that `oncologist_reviewed` recorded as absent three fields away in the same
+database row.
+
+**The results API had no statement of its own.** The only disclaimer in that
+payload was nested inside `patient_summary`, which `routes/results.py` builds
+inside a `try` and sets to `None` on failure. That path is real, is logged, and
+names itself in `generation_errors`, which is the F10 control working as
+designed. But the response after it still carries `summary`,
+`plain_language_summary`, `has_targetable_mutation`, `target_gene` and
+per-mutation OncoKB levels. So the disclaimer was present exactly when nothing
+had gone wrong and absent exactly when something had, which is H3 turned inside
+out: not a failure presented as a negative result, but a failure that removes the
+warning while leaving the recommendation.
+
+Found by asking which output paths state the limitation rather than checking
+that the two known disclaimers were still in place. The same question that found
+F11 and F14, applied to egress instead of access.
+
+Fixed in `services/intended_use.py`, which declares the statements once. The
+results payload carries `intended_use` at the top level, typed in
+`ResultsResponse` with a default factory whose every default is the conservative
+answer, so a response that fails to populate it still says research output and
+unreviewed. That typing was load-bearing rather than decorative: `response_model`
+filters the returned dict to declared fields, so the first attempt returned 200
+with the key silently dropped. The FHIR resources carry a `meta.tag`, an
+extension, and the statement at the **head** of `conclusion` rather than the
+tail, because EMR summary views truncate. An unreviewed report is `preliminary`,
+FHIR's code for complete but unverified, and reaches `final` only once
+`oncologist_reviewed` is true. Observations carry the marker themselves, since
+they are individually addressable and leave the bundle alone.
+`api/tests/test_intended_use_coverage.py` pins all of it, including the case
+where patient summary generation fails and the statement has to outlive it.
+Before this the FHIR path had no tests whatsoever.
+
+**Residual risk, and it is the important part of this entry.** Labelling is not
+validation. Nothing here moves any gate in `REGULATORY_FRAMEWORK.md` section 3,
+and a correctly labelled unvalidated result is still an unvalidated result. The
+entry belongs in this document because an unlabelled one is worse, not because
+the labelled one is safe.
+
+Three narrower limits. `meta.tag` and extensions can be dropped by an ingesting
+system, so the load-bearing signals are `status` and `conclusion`, and
+`conclusion` can be truncated. `preliminary` communicates "not verified", which
+is true but weaker than "produced by software that has never been clinically
+validated"; FHIR has no code for the latter and the tag under this project's own
+namespace is not one a receiving system will recognise. And coverage is enforced
+only where it is tested: a renderer added later can still omit the statement, the
+same way these two did.
+
+
 ---
 
 ## 3. What is not yet analysed
@@ -724,6 +796,12 @@ Verified present, not merely intended:
 - Every route under a PHI prefix is asserted to require a credential, or named
   in an exemption list with the reason it is public
   (`api/tests/test_marketplace_phi_disclosure.py`).
+- Intended use stated on every machine-readable output path: `intended_use` at
+  the top level of `ResultsResponse`, typed with conservative defaults so an
+  unpopulated field still reads as research output, and `meta.tag`, an extension
+  and a leading `conclusion` statement on both FHIR resources. An unreviewed
+  report is `preliminary`, not `final` (`api/services/intended_use.py`,
+  `api/tests/test_intended_use_coverage.py`).
 - Generated patient text is validated before it is returned, and failing text
   falls back to the deterministic template rather than being published with a
   warning (`api/services/llm_output_guard.py`).
@@ -742,9 +820,9 @@ column is asserted, not enforced.
 |---|---|---|---|
 | H1 resistance ignored | F1, F7, F9, F17 | Static-table resistance floor reachable on the worker path; rejected calls dropped; VAF carried onto the mutation | `test_ai_worker_oncokb_levels.py`, `test_vcf_ingestion_safety.py` |
 | H2 actionable variant missed | F2, F8, F15 | Wire format mapped onto `OncoKBLevel`; each ALT allele emitted separately | `test_ai_worker_oncokb_levels.py`, `test_vcf_ingestion_safety.py` |
-| H3 lookup failure read as a negative | F3, F10, F11, F14 | `evidence_provenance` returned with the answer; QC verdict persisted and rendered; audit coverage derived from the mounted route table; `generation_errors` names a failed section | `test_evidence_provenance.py`, `test_genomic_worker_qc_persistence.py`, `test_middleware_audit.py::TestEveryMountedPhiRouteIsAudited`, `test_marketplace_phi_disclosure.py`, `test_evidence_lookup_status.py` |
+| H3 lookup failure read as a negative | F3, F10, F11, F14, F18 | `evidence_provenance` returned with the answer; QC verdict persisted and rendered; audit coverage derived from the mounted route table; `generation_errors` names a failed section; the intended-use statement sits at the top level of the payload rather than inside a section that is allowed to fail | `test_evidence_provenance.py`, `test_genomic_worker_qc_persistence.py`, `test_middleware_audit.py::TestEveryMountedPhiRouteIsAudited`, `test_marketplace_phi_disclosure.py`, `test_evidence_lookup_status.py`, `test_intended_use_coverage.py` |
 | H4 stale evidence base | F4 | Provenance stamped onto the result at production time; static fallback logged at `WARNING` | `test_evidence_provenance.py` |
-| H5 overstated figures | F5, F12, F13, F16 | Circularity gate on the answer key; webhook event ids claimed before handling; Connect return route no longer varies by id | `scripts/detect_label_circularity.py` in CI, `test_webhook_and_stripe_disclosure.py` |
+| H5 overstated figures | F5, F12, F13, F16, F18 | Circularity gate on the answer key; webhook event ids claimed before handling; Connect return route no longer varies by id; intended use stated on the results payload and both FHIR resources, unreviewed reports reported as `preliminary` | `scripts/detect_label_circularity.py` in CI, `test_webhook_and_stripe_disclosure.py`, `test_intended_use_coverage.py` |
 | H6 wrong variant call | F6, F7 | **None for calling accuracy.** F7 removes calls the caller itself rejected, which is not the same thing. The gate's measuring instrument exists but has never been given caller output | `test_vcf_ingestion_safety.py` and `test_variant_calling_validation.py` cover the harness, not the caller |
 
 H6 has no control. The row is here so that absence does not read as coverage by


### PR DESCRIPTION
Every clinical validation gate in `REGULATORY_FRAMEWORK.md` section 3 is unmet,
so nothing this system produces has been shown fit to inform a treatment
decision. That was recorded in the documentation and enforced in two renderers.
Two output paths had no statement at all, and one of them actively claimed the
opposite.

Recorded as F18 in `docs/risk_analysis.md`, against H5 and H3.

## The FHIR export carried no marker, and said the report was verified

`services/fhir_export.py` exists to be ingested by an EMR. Its own docstring
names Epic, Cerner and OpenEMR and cites the ONC Final Rule. Once a
`DiagnosticReport` is filed in a chart it is indistinguishable from one a
validated laboratory produced, and this one arrived with nothing to distinguish
it: no tag, no extension, nothing in the conclusion.

It also mapped any completed submission to `status: "final"`. In FHIR R4 `final`
means the report is complete **and verified**. The only thing verified was that
the pipeline had finished. The resource asserted a clinician sign-off that
`oncologist_reviewed` recorded as absent three fields away in the same row.

An unreviewed report is now `preliminary`, FHIR's code for complete but
unverified, and reaches `final` only once `oncologist_reviewed` is true. The
change went into `status` deliberately. Tags and extensions can be dropped on
ingest; a receiving system has to read status to decide how to file the report.

The statement also leads `conclusion` rather than trailing it, because EMR
summary views truncate and a trailing disclaimer is the part that gets cut.
Observations carry the marker themselves rather than inheriting it, since they
are individually addressable at `/api/fhir/Observation/{id}` and travel out of
the bundle alone.

## The results API had no statement of its own

The only disclaimer in that payload was nested inside `patient_summary`, which
`routes/results.py` builds inside a `try` and sets to `None` on failure. That
path is real, is logged, and names itself in `generation_errors`, which is the
F10 control working as designed.

But the response after that failure still carries `summary`,
`plain_language_summary`, `has_targetable_mutation`, `target_gene` and
per-mutation OncoKB levels. The disclaimer was present exactly when nothing had
gone wrong and absent exactly when something had. That is H3 turned inside out:
not a failure presented as a negative result, but a failure that removes the
warning and leaves the recommendation.

`intended_use` is now a top-level field, typed in `ResultsResponse` with a
default factory whose every default is the conservative answer, so a response
that fails to populate it still says research output and unreviewed. Same shape
`sample_qc` and `evidence_provenance` already use.

Declaring it in the schema was load-bearing rather than tidy. `response_model`
filters the returned dict to declared fields, so the first version of this
returned 200 with the key silently dropped, which is a small demonstration of
the same class of problem the PR is about.

## One source

The statements live in `services/intended_use.py`. They were spread across
`patient_summary.DISCLAIMER`, `oncologist_report.ONCOLOGIST_DISCLAIMER` and two
hardcoded strings in `pdf_export.py`, with no relationship between them and no
way to tell which paths were covered. Those keep their own wording, which is
tuned to their readers; this module is what the API and FHIR paths use.

## What this does not do

Labelling is not validation. Nothing here moves a gate in
`REGULATORY_FRAMEWORK.md` section 3, and a correctly labelled unvalidated result
is still an unvalidated result. This is in the register because an unlabelled one
is worse, not because the labelled one is safe.

Three narrower limits, all recorded in F18. `meta.tag` and extensions can be
dropped by an ingesting system, so the load-bearing signals are `status` and
`conclusion`, and `conclusion` can be truncated. `preliminary` says "not
verified", which is true but weaker than "produced by software that has never
been clinically validated"; FHIR has no code for that and a tag under this
project's own namespace is not one a receiving system will recognise. And
coverage holds only where a test enforces it, so a renderer added later can omit
the statement exactly as these two did.

Section 3 of the risk analysis already notes that nobody has tested whether
disclaimers are read at all. This makes the statement present, not effective.

## Verification

ruff clean. 1124 api tests and 42 ai tests passing, up from 1107 and 42.
Coverage 61.39% against the 52 gate. The FHIR export had no tests of any kind
before this.

## Base

Branched from `main`, not from `fix/deployment-and-auth-hardening`, so this is
not stacked on #130 and either can merge first. Both carry the four OO-4 backlog
chores that are sitting unpushed on local `main`; whichever merges first takes
them, and the other's diff shrinks accordingly.
