### PR TITLE
OO-4: Refresh the stale figures in the pyproject coverage comment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,11 +56,21 @@ omit = [
 #
 # [tool.coverage.run] above omits */tests/* from coverage. A test module is
 # ~100% covered by the act of running it, and 34 of them were being averaged
-# into the headline. On identical coverage data the same suite reads 70% with
-# tests counted and 53.93% without. Coverage did not fall by 17 points; the
-# earlier figures were partly measuring the tests.
+# into the headline. On the coverage data of the day the same suite read 70%
+# with tests counted and 53.93% without. Coverage did not fall by 17 points; the
+# earlier figures were partly measuring the tests. Those two numbers are the
+# before and after of that one change, not a current measurement.
 #
-# 53.93% over 8,353 production statements, 844 api + 42 ai tests passing. Gate
-# at 52 leaves about a point, which is the spread observed between the CI runner
-# and a local Windows run.
+# Measured locally on 2026-08-29 (make test-backend, Windows): 61.75% over 8,895
+# production statements, 1,168 api tests passing with 2 xfailed, plus 42 ai
+# tests. When the gate was set at 52 it sat about a point under the total, the
+# spread between the CI runner and a local run. The suite has grown faster than
+# the gate, so the slack is now close to ten points: 52 catches a large
+# regression, not a small one. Re-measure before reading it as tight.
+#
+# This figure goes out of date on any commit that adds a test or a module, which
+# is most of them, so treat the date as part of the number. Unlike fail_under
+# itself, which test_coverage_threshold_consistency.py pins across the README,
+# CONTRIBUTING and the workflow, nothing can pin a measurement to a moving
+# suite. It was already stale by two merges when this refresh landed.
 fail_under = 52


### PR DESCRIPTION
Closes OO-4.

The comment under `[tool.coverage.report]` quoted 53.93% over 8,353 statements
and 844 api tests, which were the numbers from when the gate was set. A local
run now measures **61.75% over 8,895 production statements, 1,168 api tests
passing with 2 xfailed, plus 42 ai tests**.

That gap changes how the gate reads. At the time, 52 sat about a point under the
total, which was the spread between the CI runner and a local Windows run. It
now sits close to ten points under, so it catches a large regression and not a
small one. The comment described the first situation while the suite had quietly
become the second.

`fail_under` stays at 52. The omit list is untouched. The 63 / 69 / 52 history
stays as it was, with the 70-vs-53.93 pair now marked as the before and after of
omitting `*/tests/*` rather than reading as a current measurement.

## One addition beyond a straight refresh

This entry has now been overtaken twice while it was open, which is worth
recording in the file rather than only in a backlog entry nobody reads at the
point of confusion.

The branch was cut on 2026-08-25 and measured 60.74% over 8,798 statements with
1,107 api tests. #130 and #131 then merged, adding 61 tests and 97 statements
between them, so the figures this branch was about to land were already wrong by
two merges before it opened. The commit that would have fixed the staleness had
itself gone stale.

`fail_under` cannot drift, because `test_coverage_threshold_consistency.py` pins
it across the README badge, `CONTRIBUTING.md` and the workflow. A measurement of
a moving suite has no equivalent: there is nothing to pin it to. So the comment
now says that outright and carries its date as part of the number rather than
beside it, which is the honest version of a figure that is correct on the day
and approximate thereafter.

## Verification

`pytest api/tests/test_coverage_threshold_consistency.py` passes, 5 tests. The
figures come from a full local `make test-backend`-equivalent run on this tree
rather than from the backlog entry. Only comment lines changed, so the gate's
behaviour is identical.
