### PR TITLE
Reconcile the backlog after #130 and #131, and record what OO-5 turned out to be

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -32,6 +32,10 @@ Sections are ordered by pipeline position. `/next` pulls from the top of
   - Worker, beat, api and web pods each keep egress to Postgres, Redis and 443
   - A test asserts every NetworkPolicy podSelector matches at least one rendered pod
   - `helm template` output passes kubeconform in the `validate-manifests` job
+- **Topology found while scoping this, and it invalidates a verbatim port**: the chart runs *two* Postgres instances. `values.yaml` enables the Bitnami `postgresql` sub-chart and `openoncology.databaseUrl` points the app at `{release}-postgresql`; separately `templates/postgres.yaml` renders an ungated StatefulSet at `{fullname}-postgres` carrying `component: postgres`, and that one is Keycloak's database (`keycloak.yaml:32`). So an egress rule allowing `component: postgres` reaches Keycloak's database and not the application's. The Bitnami pods carry Bitnami's labels, not this chart's, and those differ by sub-chart version. Redis is Bitnami-only; there is no chart-local template for it.
+  Workers also render four distinct component values (`worker-genomic`, `worker-ai`, `worker-notify`, `worker-gdpr`), so one selector cannot match them by `component` and needs either a shared label or `matchExpressions`.
+  The gdpr worker needs egress the others do not: it calls Keycloak's admin API to delete users and MinIO to delete objects (`workers/gdpr_worker.py`). A policy modelled on the other three silently breaks erasure, which is the obligation #130 just restored.
+- **Recommended shape**: gate the whole set behind `networkPolicy.enabled`, default **false**. A wrong policy fails closed, there is no cluster to test against here, and default-on means the first person to find out is whoever deploys it. Drive the datastore selectors from values so an operator can match their actual sub-chart labels.
 - **Out of scope**: the raw `infra/k8s` manifests, which already have this
 - **Risk**: medium — a wrong policy fails closed and silently
 
@@ -46,12 +50,28 @@ Sections are ordered by pipeline position. `/next` pulls from the top of
 - **Out of scope**: the conda-only modules, which pin exact versions already; choosing different tool versions
 - **Risk**: low
 
+### OO-9: Keycloak's database is sized by the application database's setting
+- **Why**: `templates/postgres.yaml` is Keycloak's database, not the application's, which uses the Bitnami `postgresql` sub-chart. Its `volumeClaimTemplates` requests `.Values.postgresql.primary.persistence.size`, the sub-chart's value. `values.production.yaml` sets that to 200Gi, so Keycloak's realm database, a few megabytes of users and clients, claims a 200Gi volume, and anyone resizing the application database silently resizes Keycloak's too. Found while scoping OO-5.
+- **Files**: infra/helm/templates/postgres.yaml, infra/helm/values.yaml, infra/helm/values.production.yaml
+- **Acceptance**:
+  - Keycloak's database size comes from its own value, defaulted to something proportionate
+  - The two databases are distinguishable by name or comment, so the next reader does not assume `postgres.yaml` is the application's
+  - `helm template` still renders and passes kubeconform
+- **Out of scope**: consolidating the two databases, which is a data-migration decision rather than a chart one
+- **Risk**: low to change, but note `volumeClaimTemplates` is immutable on an existing StatefulSet, so an in-place `helm upgrade` will reject the edit. The entry is only safe on a fresh install or with a documented recreate step, and that caveat is the reason it is filed rather than done in passing.
+
 ---
 
 ## In progress
 
 <!-- One entry maximum. An entry stranded here means a session died mid-work;
      /standup will surface it. -->
+
+---
+
+## In review
+
+<!-- Entry plus PR URL. Cleared by hand when merged. -->
 
 ### OO-4: Refresh the stale figures in the pyproject coverage comment
 - **Why**: The comment moved into `[tool.coverage.report]` by OO-2 cites 53.93% over 8,353 production statements with 844 api tests. The suite has grown since: it now measures about 61% over 8,798 statements with 1,102 api tests. Anyone reading the comment concludes the gate sits a point below the measured total, when it actually sits nine points below, so the gate catches less than the comment claims it does.
@@ -65,11 +85,9 @@ Sections are ordered by pipeline position. `/next` pulls from the top of
 - **Out of scope**: changing the threshold; the `omit` list; README and CONTRIBUTING, which quote the gate rather than the measurement.
 - **Risk**: low
 
----
-
-## In review
-
-<!-- Entry plus PR URL. Cleared by hand when merged. -->
+**PR**: [#132](https://github.com/immortal71/openoncology/pull/132). Rebased onto
+`main` after #130 and #131 merged, and the figures re-measured: the ones the
+branch was carrying had themselves gone stale by two merges while it sat open.
 
 ---
 
@@ -123,6 +141,35 @@ Sections are ordered by pipeline position. `/next` pulls from the top of
 ## Done
 
 <!-- Merged entries, newest first. Trim periodically. -->
+
+### Intended use stated on every output path
+Merged in [#131](https://github.com/immortal71/openoncology/pull/131), recorded as
+F18 in [risk_analysis.md](docs/risk_analysis.md). The FHIR export carried no
+research-use marker and reported `status: final`, which in FHIR R4 means complete
+and verified; the only thing verified was that the pipeline had finished. Unreviewed
+reports are now `preliminary`. The results payload's only disclaimer lived inside
+`patient_summary`, which fails to None, so it vanished exactly when generation went
+wrong and the response still carried drug names and OncoKB levels. `intended_use` is
+now a top-level typed field with conservative defaults.
+
+Labelling is not validation. Nothing here moves a gate in `REGULATORY_FRAMEWORK.md`
+section 3.
+
+### Deployment path: unconsumed gdpr queue, missing beat, readiness probe, JWKS auth
+Merged in [#130](https://github.com/immortal71/openoncology/pull/130). Four absences
+that no check could catch because every check asserted a positive about something
+present. `task_routes` sent erasure tasks to a `gdpr` queue nothing consumed, so
+`DELETE /api/me` promised deletion within 30 days and the message sat in Redis. The
+chart had no Celery Beat, so neither periodic task had ever fired in Kubernetes. The
+readiness probe asked `/health`, which answers 200 unconditionally. Auth refetched
+one Keycloak key per request and passed `audience` with `verify_aud: False`.
+
+A `validate-manifests` job now renders the chart through kubeconform. Its first
+version passed in eight seconds having rendered nothing: helm's dependency error went
+to stderr, kubeconform read empty stdin and reported "Valid: 0", and the pipe returned
+kubeconform's status. Fixed in the same PR under `pipefail` with assertions on the
+rendered output, which is the section 7 lesson arriving inside the commit that was
+about the same failure.
 
 ### OO-3: Add a drift guard test for the coverage threshold
 Merged in [#128](https://github.com/immortal71/openoncology/pull/128).

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -60,6 +60,28 @@ Sections are ordered by pipeline position. `/next` pulls from the top of
 - **Out of scope**: consolidating the two databases, which is a data-migration decision rather than a chart one
 - **Risk**: low to change, but note `volumeClaimTemplates` is immutable on an existing StatefulSet, so an in-place `helm upgrade` will reject the edit. The entry is only safe on a fresh install or with a documented recreate step, and that caveat is the reason it is filed rather than done in passing.
 
+### OO-10: The FASTQ path aligns paired-end reads as single-end
+- **Why**: `main.nf:116` channels the input with `Channel.fromPath`, not `fromFilePairs`; `trimmomatic.nf` runs `trimmomatic SE` against `TruSeq3-SE.fa`; `bwa_mem2.nf` passes one read file to `bwa-mem2 mem`. Nothing pairs a mate file at any point. Essentially all clinical sequencing is paired-end, and so is the GIAB HG002 data the 3.1 validation gate is measured against, so mate-pair information is discarded exactly where it resolves the repetitive regions in which variants are missed. Found while writing `docs/RUNBOOK_VARIANT_CALLING_VALIDATION.md`, and it is why that runbook recommends the BAM route first.
+- **Files**: pipeline/main.nf, pipeline/modules/trimmomatic.nf, pipeline/modules/bwa_mem2.nf
+- **Acceptance**:
+  - A paired FASTQ input is consumed as one sample, not as two independent runs
+  - Trimmomatic runs `PE` with paired adapters, and its unpaired outputs are handled deliberately rather than dropped by accident
+  - `bwa-mem2 mem` receives both mates
+  - Single-end input still works, or its removal is a stated decision rather than a side effect
+  - A test asserts a paired input produces one BAM per sample
+- **Out of scope**: the somatic and RNA-seq paths, beyond what falls out of the same change
+- **Risk**: medium. This changes what the pipeline computes, so it invalidates any variant-calling measurement taken before it. Either sequence it ahead of the run in the runbook, or record which configuration produced which number.
+
+### OO-11: BWA-MEM2 rebuilds the reference index on every alignment task
+- **Why**: `BWA_MEM2_ALIGN` declares `path ref_fasta` as its only reference input, so Nextflow stages the FASTA into the task work directory and none of the index files beside it. The script then runs `bwa-mem2 index $ref_fasta`, which `pipeline/scripts/download_references.sh` puts at roughly 30 minutes and 12 GB of RAM, and the result is discarded with the work directory. Setup builds the index and the pipeline never sees it, so every sample pays the cost again and every retry pays it once more.
+- **Files**: pipeline/modules/bwa_mem2.nf, pipeline/main.nf
+- **Acceptance**:
+  - The index files are staged as inputs alongside the FASTA
+  - `bwa-mem2 index` is gone from the alignment script, or runs only when the index is genuinely absent
+  - A missing index fails with a message pointing at `download_references.sh`, rather than silently costing half an hour
+- **Out of scope**: whether to ship or cache a prebuilt index, which is a distribution decision
+- **Risk**: low
+
 ---
 
 ## In progress


### PR DESCRIPTION
Backlog state after #130 and #131, plus what scoping OO-5 turned up.

## Done

Entries for #130 and #131, neither of which had one. The #130 entry records the
manifest job that passed in eight seconds having rendered nothing, because that
is the kind of thing the file exists to stop the next person rediscovering.

## In review

OO-4 moves out of In progress, where it had been stranded since a session died
mid-work, and picks up #132. Worth noting on the entry: the figures its branch
was carrying had themselves gone stale by two merges while it sat there, so the
commit that was going to fix the staleness had gone stale.

## OO-5 was not what the entry said it was

The entry assumed one missing label. Scoping it found three separate reasons a
verbatim port would be wrong, none visible from the entry as written.

**The chart runs two Postgres instances.** `values.yaml` enables the Bitnami
`postgresql` sub-chart and `openoncology.databaseUrl` points the app at
`{release}-postgresql`. Separately, `templates/postgres.yaml` renders an ungated
StatefulSet at `{fullname}-postgres` labelled `component: postgres`, and that one
is Keycloak's database (`keycloak.yaml:32`). An egress rule allowing
`component: postgres` therefore reaches Keycloak's database and not the
application's. I nearly deleted it as orphaned before checking what referenced
it.

**Workers render four component values**, `worker-genomic`, `worker-ai`,
`worker-notify` and `worker-gdpr`, so no single selector matches them by
`component`.

**The gdpr worker needs egress the others do not.** It calls Keycloak's admin
API to delete users and MinIO to delete objects. A policy modelled on its three
neighbours silently breaks the erasure path #130 just restored, which would be a
poor way to repay that fix.

The entry now carries all of this plus a recommended shape: gate the set behind
`networkPolicy.enabled`, default **false**. A wrong policy fails closed, nothing
in this repository can test against a real cluster, and default-on means the
first person to discover the mistake is whoever deploys it.

## OO-9, new

Keycloak's database sizes its volume from
`.Values.postgresql.primary.persistence.size`, which is the application
sub-chart's value. `values.production.yaml` sets that to 200Gi, so a realm
database holding a few megabytes of users and clients claims a 200Gi volume, and
resizing the application database silently resizes Keycloak's.

Filed rather than fixed: `volumeClaimTemplates` is immutable on an existing
StatefulSet, so an in-place `helm upgrade` rejects the edit. It is safe on a
fresh install or with a documented recreate step, and that caveat is the reason
it is not a passing fix.

No code changes here.
