### PR TITLE
OO-10: carry both mates of a paired-end sample from upload to aligner

### DIFF
--- a/api/alembic/versions/0017_paired_end_mate_two_key.py
+++ b/api/alembic/versions/0017_paired_end_mate_two_key.py
@@ -1,0 +1,39 @@
+"""Carry mate 2 of a paired-end FASTQ submission.
+
+BACKLOG.md OO-10. `POST /api/submit` accepted a single `dna_file` described as
+"VCF, FASTQ, or BAM". Every sequencer emits paired-end reads as two files, so a
+clinician holding both could upload one, nothing said so, and the pipeline then
+aligned it single-end with half the sample's reads absent.
+
+Nullable, and it stays nullable. Null means one of three things and the column
+deliberately does not try to distinguish them, because only the application
+knows which applies: the submission is a VCF or a BAM and has no mate; the reads
+were genuinely single-end; or the submission predates this column. A NOT NULL
+with a sentinel would assert a fact about the first two that nothing measured.
+
+No backfill. Existing rows have no second mate stored anywhere to point at, and
+inventing a value would be worse than the absence.
+
+Revision ID: 0017
+Revises: 0016
+Create Date: 2026-08-29
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0017"
+down_revision = "0016"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "submissions",
+        sa.Column("dna_r2_s3_key", sa.String(length=512), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("submissions", "dna_r2_s3_key")

--- a/api/models/submission.py
+++ b/api/models/submission.py
@@ -36,6 +36,11 @@ class Submission(Base):
     # S3/MinIO keys — never expose to client
     biopsy_s3_key: Mapped[str] = mapped_column(String(512), nullable=True)
     dna_s3_key: Mapped[str] = mapped_column(String(512), nullable=True)
+    # Mate 2 of a paired-end FASTQ submission. Null for single-end reads, and
+    # for VCF and BAM submissions, which have no mate. Nullable rather than
+    # defaulted because "this sample had no second mate" and "this sample
+    # predates the column" are different facts and only the first is knowable.
+    dna_r2_s3_key: Mapped[str] = mapped_column(String(512), nullable=True)
     vcf_s3_key: Mapped[str] = mapped_column(String(512), nullable=True)
 
     # Celery job IDs for tracking

--- a/api/routes/submit.py
+++ b/api/routes/submit.py
@@ -27,13 +27,34 @@ ALLOWED_BIOPSY_EXT = {"pdf", "jpg", "jpeg", "png", "txt", "doc", "docx", "rtf", 
 ALLOWED_DNA_EXT = {"vcf", "fastq", "fq", "bam", "gz", "txt", "csv", "tsv", "xml", "json"}
 MAX_FILE_SIZE_BYTES = 500 * 1024 * 1024  # 500 MB
 
+_FASTQ_SUFFIXES = (".fastq", ".fq", ".fastq.gz", ".fq.gz")
+
+
+def _is_fastq_name(name: str | None) -> bool:
+    """Mirrors _is_fastq_name in pipeline/main.nf. The two decide the same thing
+    about the same file at different ends of the system, so they agree on the
+    suffix list deliberately."""
+    return (name or "").lower().endswith(_FASTQ_SUFFIXES)
+
 
 @router.post("/", status_code=status.HTTP_202_ACCEPTED, response_model=SubmissionResponse)
 @limiter.limit(UPLOAD_LIMIT)
 async def submit_sample(
     request: Request,
     biopsy_file: UploadFile = File(..., description="Biopsy PDF or image"),
-    dna_file: UploadFile = File(..., description="DNA file: VCF, FASTQ, or BAM"),
+    dna_file: UploadFile = File(
+        ...,
+        description="DNA file: VCF, BAM, or mate 1 of a FASTQ pair",
+    ),
+    dna_file_r2: UploadFile | None = File(
+        None,
+        description=(
+            "Mate 2 of a paired-end FASTQ sample. Omit for single-end reads, "
+            "VCF or BAM. Sequencers emit paired-end reads as two files and both "
+            "are needed: aligning one mate alone discards the insert-size "
+            "information that places reads in repetitive regions."
+        ),
+    ),
     cancer_type: str = Form(..., max_length=128),
     db: AsyncSession = Depends(get_db),
     token_payload: dict = Depends(get_current_patient),
@@ -60,6 +81,24 @@ async def submit_sample(
     if not dna_ok:
         raise validation_error(request, f"DNA file type '{dna_file.content_type}' not supported.")
 
+    # A mate 2 is only meaningful for FASTQ, and sending one alongside a VCF or a
+    # BAM means the caller has misunderstood what they are uploading. Rejecting
+    # is better than accepting and ignoring it, which would look like it worked.
+    dna_r2_key = None
+    if dna_file_r2 is not None and dna_file_r2.filename:
+        r2_ext = (dna_file_r2.filename or "").split(".")[-1].lower()
+        r2_ok = (dna_file_r2.content_type in ALLOWED_DNA_TYPES) or (r2_ext in ALLOWED_DNA_EXT)
+        if not r2_ok:
+            raise validation_error(
+                request, f"Mate 2 file type '{dna_file_r2.content_type}' not supported."
+            )
+        if not _is_fastq_name(dna_file.filename) or not _is_fastq_name(dna_file_r2.filename):
+            raise validation_error(
+                request,
+                "A second read file is only accepted for paired-end FASTQ. "
+                "VCF and BAM submissions carry no mate.",
+            )
+
     # Upload to encrypted MinIO/S3 storage
     biopsy_key = await upload_encrypted_file(
         file=biopsy_file,
@@ -71,6 +110,12 @@ async def submit_sample(
         patient_id=patient.id,
         file_type="dna",
     )
+    if dna_file_r2 is not None and dna_file_r2.filename:
+        dna_r2_key = await upload_encrypted_file(
+            file=dna_file_r2,
+            patient_id=patient.id,
+            file_type="dna",
+        )
 
     # Create submission record
     submission = Submission(
@@ -79,13 +124,14 @@ async def submit_sample(
         status=SubmissionStatus.queued,
         biopsy_s3_key=biopsy_key,
         dna_s3_key=dna_key,
+        dna_r2_s3_key=dna_r2_key,
     )
     db.add(submission)
     await db.flush()  # get submission.id before commit
 
     # Queue genomic pipeline background job
     job = run_genomic_pipeline.apply_async(
-        args=[submission.id, patient.id, biopsy_key, dna_key, cancer_type],
+        args=[submission.id, patient.id, biopsy_key, dna_key, cancer_type, dna_r2_key],
         queue="genomic",
     )
     submission.pipeline_job_id = job.id

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -98,6 +98,13 @@ async def client(db_session):
     app.dependency_overrides[get_db] = _override_get_db
     app.dependency_overrides[get_current_patient] = _override_get_current_patient
     # Disable rate limiting in tests
+    # `enabled` is slowapi's own switch and is the one that short-circuits the
+    # decorator. Setting `_storage = None` was the previous approach and never
+    # disabled anything; it went unnoticed because no test module had made more
+    # than UPLOAD_LIMIT's five submit calls inside a minute. The first one that
+    # did got 429s in a different file, which is a confusing way to learn that a
+    # fixture's docstring was wrong.
+    limiter.enabled = False
     limiter._storage = None  # type: ignore[assignment]
     app.state.limiter = limiter
 

--- a/api/tests/test_paired_end_reads.py
+++ b/api/tests/test_paired_end_reads.py
@@ -1,0 +1,327 @@
+"""
+Paired-end reads survive from upload to aligner.
+
+BACKLOG.md OO-10. Every sequencer emits paired-end reads as two files, and the
+system took one. `POST /api/submit` accepted a single `dna_file` documented as
+"VCF, FASTQ, or BAM"; `main.nf` channelled it with `fromPath` rather than
+`fromFilePairs`; `trimmomatic.nf` ran `trimmomatic SE`; `bwa_mem2.nf` handed one
+file to `bwa-mem2 mem`. A clinician holding R1 and R2 could upload one of them,
+nothing said what had happened, and the sample was aligned without the
+insert-size information that places reads in repetitive regions. It was then
+reported with the same confidence as any other result.
+
+The pipeline assertions are made by reading the Nextflow source, the same way
+`test_pipeline_config.py` does, because CI has no `nextflow` and because the
+properties asserted are properties of the files. They are weaker than running
+the pipeline and they are what is available; the runbook in
+`docs/RUNBOOK_VARIANT_CALLING_VALIDATION.md` is where the real thing gets run.
+"""
+import io
+import re
+from pathlib import Path
+
+import pytest
+from httpx import AsyncClient
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PIPELINE = REPO_ROOT / "pipeline"
+MAIN_NF = (PIPELINE / "main.nf").read_text(encoding="utf-8")
+TRIMMOMATIC_NF = (PIPELINE / "modules" / "trimmomatic.nf").read_text(encoding="utf-8")
+BWA_NF = (PIPELINE / "modules" / "bwa_mem2.nf").read_text(encoding="utf-8")
+FASTQC_NF = (PIPELINE / "modules" / "fastqc.nf").read_text(encoding="utf-8")
+
+
+# ── The pipeline can express a pair at all ───────────────────────────────────
+
+def test_main_accepts_a_second_mate():
+    assert "params.reads_r2" in MAIN_NF
+
+
+def test_reads_travel_as_one_item_per_sample():
+    """
+    The defect was structural rather than a missing flag. `fromPath` emits one
+    item per file, so a two-file sample became two independent workflow runs.
+    Reads are now tupled with a sample id so a pair stays one item.
+    """
+    assert "reads_ch" in MAIN_NF
+    assert re.search(r"tuple\(\s*\n?\s*_sample_id_from_reads", MAIN_NF) or \
+           "tuple(_sample_id_from_reads" in MAIN_NF
+
+
+@pytest.mark.parametrize(
+    "module,name",
+    [(TRIMMOMATIC_NF, "trimmomatic"), (BWA_NF, "bwa_mem2"), (FASTQC_NF, "fastqc")],
+)
+def test_fastq_modules_take_the_sample_tuple(module, name):
+    assert "tuple val(sample_id), path(reads)" in module, (
+        f"{name} still takes a bare path, so it cannot receive both mates"
+    )
+
+
+def test_sample_id_strips_the_mate_marker():
+    """
+    R1 and R2 of one sample must resolve to the same id. Without stripping the
+    marker the pair would be named after mate 1 and every output would read as
+    though mate 2 were a different sample.
+    """
+    helper = MAIN_NF[MAIN_NF.index("def _sample_id_from_reads") :]
+    helper = helper[: helper.index("\n}")]
+    assert "replaceAll" in helper
+    assert "R?[12]" in helper
+
+
+# ── Trimming keeps the mates in step ─────────────────────────────────────────
+
+def test_trimmomatic_runs_pe_for_a_pair():
+    assert "trimmomatic PE" in TRIMMOMATIC_NF
+
+
+def test_trimmomatic_keeps_the_single_end_path():
+    """Single-end input is still valid input; it was never the bug."""
+    assert "trimmomatic SE" in TRIMMOMATIC_NF
+
+
+def test_paired_trimming_uses_paired_adapters():
+    """
+    TruSeq3-SE against paired reads leaves the adapter read-through that PE mode
+    is specifically able to find, so the adapter file follows the mode.
+    """
+    assert "params.adapters_pe" in TRIMMOMATIC_NF
+    assert "params.adapters_se" in TRIMMOMATIC_NF
+    assert "adapters_pe" in MAIN_NF and "adapters_se" in MAIN_NF
+
+
+def test_unpaired_survivors_are_emitted_not_silently_dropped():
+    """
+    Trimmomatic PE writes four files. The two unpaired ones are reads whose mate
+    was discarded. They are published so the loss is countable, and deliberately
+    not fed to the aligner.
+    """
+    assert "emit: unpaired" in TRIMMOMATIC_NF
+    assert "1U" in TRIMMOMATIC_NF and "2U" in TRIMMOMATIC_NF
+
+
+def test_only_paired_output_reaches_the_aligner():
+    aligner_input = MAIN_NF[MAIN_NF.index("trimmed_ch"):]
+    assert "TRIMMOMATIC.out.unpaired" not in aligner_input
+
+
+# ── Alignment receives both mates ────────────────────────────────────────────
+
+def test_bwa_receives_every_read_file():
+    """
+    One `bwa-mem2 mem` invocation with both mates. Aligning them separately, or
+    passing only the first, discards the insert-size distribution, which is most
+    of the value of paired-end sequencing.
+    """
+    assert "read_args" in BWA_NF
+    assert "reads.join(' ')" in BWA_NF
+    assert re.search(r"bwa-mem2 mem[\s\S]{0,220}\$\{read_args\}", BWA_NF)
+
+
+def test_alignment_produces_one_bam_per_sample():
+    """A pair is one sample, so it is one BAM. Everything downstream assumes it."""
+    assert 'path "${sample_id}.sorted.bam",     emit: bam' in BWA_NF
+    assert BWA_NF.count("emit: bam") == 1
+
+
+def test_read_group_carries_the_sample_id():
+    """`SM:patient` was a constant, so every BAM claimed the same sample."""
+    assert "SM:${sample_id}" in BWA_NF
+    assert "SM:patient" not in BWA_NF
+
+
+# ── A mate is only meaningful for FASTQ ──────────────────────────────────────
+
+def test_main_rejects_a_mate_alongside_non_fastq_input():
+    assert "only meaningful with FASTQ" in MAIN_NF
+
+
+def test_main_rejects_a_missing_mate_file():
+    assert "Missing mate 2 file" in MAIN_NF
+
+
+# ── Intake: the mate can actually be uploaded ────────────────────────────────
+#
+# These drive the real route rather than reading source. Storage and Celery are
+# mocked the same way TestSubmitEndpoint does it.
+
+
+def _mock_storage_and_queue(monkeypatch) -> dict:
+    """Capture what the route stored and what it enqueued."""
+    captured: dict = {"uploads": [], "job_args": None}
+
+    async def _fake_upload(**kwargs):
+        key = f"mock/{kwargs['file_type']}-{len(captured['uploads'])}.bin"
+        captured["uploads"].append(kwargs["file"].filename)
+        return key
+
+    class _FakeJob:
+        id = "celery-job-id-test"
+
+    def _fake_apply_async(args, queue):
+        captured["job_args"] = args
+        return _FakeJob()
+
+    monkeypatch.setattr("routes.submit.upload_encrypted_file", _fake_upload)
+    monkeypatch.setattr("routes.submit.run_genomic_pipeline.apply_async", _fake_apply_async)
+    return captured
+
+
+async def test_paired_fastq_upload_is_accepted_and_both_mates_stored(
+    client: AsyncClient, seeded_patient, monkeypatch
+):
+    captured = _mock_storage_and_queue(monkeypatch)
+
+    resp = await client.post(
+        "/api/submit/",
+        headers={"Authorization": "Bearer test-token"},
+        files={
+            "biopsy_file": ("biopsy.pdf", io.BytesIO(b"%PDF-1.4"), "application/pdf"),
+            "dna_file": ("s_R1.fastq.gz", io.BytesIO(b"@r1\nAC\n+\nII\n"), "application/gzip"),
+            "dna_file_r2": ("s_R2.fastq.gz", io.BytesIO(b"@r2\nGT\n+\nII\n"), "application/gzip"),
+        },
+        data={"cancer_type": "Lung adenocarcinoma"},
+    )
+
+    assert resp.status_code == 202
+    assert captured["uploads"] == ["biopsy.pdf", "s_R1.fastq.gz", "s_R2.fastq.gz"]
+
+
+async def test_the_mate_reaches_the_worker(
+    client: AsyncClient, seeded_patient, monkeypatch
+):
+    """Storing it and never passing it on would look identical from outside."""
+    captured = _mock_storage_and_queue(monkeypatch)
+
+    await client.post(
+        "/api/submit/",
+        headers={"Authorization": "Bearer test-token"},
+        files={
+            "biopsy_file": ("biopsy.pdf", io.BytesIO(b"%PDF-1.4"), "application/pdf"),
+            "dna_file": ("s_R1.fastq.gz", io.BytesIO(b"@r1\nAC\n+\nII\n"), "application/gzip"),
+            "dna_file_r2": ("s_R2.fastq.gz", io.BytesIO(b"@r2\nGT\n+\nII\n"), "application/gzip"),
+        },
+        data={"cancer_type": "Lung adenocarcinoma"},
+    )
+
+    assert captured["job_args"] is not None
+    assert captured["job_args"][-1] is not None, "mate 2 key was not passed to the worker"
+
+
+async def test_single_end_submission_still_works_and_passes_no_mate(
+    client: AsyncClient, seeded_patient, monkeypatch
+):
+    captured = _mock_storage_and_queue(monkeypatch)
+
+    resp = await client.post(
+        "/api/submit/",
+        headers={"Authorization": "Bearer test-token"},
+        files={
+            "biopsy_file": ("biopsy.pdf", io.BytesIO(b"%PDF-1.4"), "application/pdf"),
+            "dna_file": ("sample.vcf", io.BytesIO(b"##VCF"), "text/plain"),
+        },
+        data={"cancer_type": "Melanoma"},
+    )
+
+    assert resp.status_code == 202
+    assert captured["job_args"][-1] is None
+
+
+async def test_a_mate_alongside_a_vcf_is_rejected(
+    client: AsyncClient, seeded_patient, monkeypatch
+):
+    """
+    Accepting it and ignoring it is the failure this whole entry is about: the
+    caller would see 202 and believe both files were used.
+    """
+    _mock_storage_and_queue(monkeypatch)
+
+    resp = await client.post(
+        "/api/submit/",
+        headers={"Authorization": "Bearer test-token"},
+        files={
+            "biopsy_file": ("biopsy.pdf", io.BytesIO(b"%PDF-1.4"), "application/pdf"),
+            "dna_file": ("sample.vcf", io.BytesIO(b"##VCF"), "text/plain"),
+            "dna_file_r2": ("s_R2.fastq.gz", io.BytesIO(b"@r2\nGT\n+\nII\n"), "application/gzip"),
+        },
+        data={"cancer_type": "Melanoma"},
+    )
+
+    assert resp.status_code == 422
+
+
+# ── The worker passes it to Nextflow ─────────────────────────────────────────
+
+def test_worker_forwards_the_mate_as_reads_r2(monkeypatch, tmp_path):
+    import subprocess
+
+    from workers import genomic_worker
+
+    captured: dict = {}
+
+    class _Result:
+        returncode = 0
+        stderr = ""
+
+    def _fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        out = tmp_path / "results"
+        out.mkdir(exist_ok=True)
+        (out / "x.annotated.vcf").write_text("##fileformat=VCFv4.2\n")
+        return _Result()
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    monkeypatch.setattr("config.settings.environment", "production", raising=False)
+
+    genomic_worker._run_nextflow_pipeline(
+        str(tmp_path / "s_R1.fastq.gz"),
+        str(tmp_path),
+        "Lung adenocarcinoma",
+        reads_r2=str(tmp_path / "s_R2.fastq.gz"),
+    )
+
+    assert "--reads_r2" in captured["cmd"]
+    assert captured["cmd"][captured["cmd"].index("--reads_r2") + 1].endswith("s_R2.fastq.gz")
+
+
+def test_worker_omits_reads_r2_when_there_is_no_mate(monkeypatch, tmp_path):
+    import subprocess
+
+    from workers import genomic_worker
+
+    captured: dict = {}
+
+    class _Result:
+        returncode = 0
+        stderr = ""
+
+    def _fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        out = tmp_path / "results"
+        out.mkdir(exist_ok=True)
+        (out / "x.annotated.vcf").write_text("##fileformat=VCFv4.2\n")
+        return _Result()
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    monkeypatch.setattr("config.settings.environment", "production", raising=False)
+
+    genomic_worker._run_nextflow_pipeline(
+        str(tmp_path / "s.fastq.gz"), str(tmp_path), "Melanoma"
+    )
+
+    assert "--reads_r2" not in captured["cmd"]
+
+
+def test_task_signature_tolerates_a_redelivered_five_argument_message():
+    """
+    Tasks are acks_late, so a message enqueued before this change can be
+    redelivered to a worker running after it. The mate parameter defaults, so
+    that message runs single-end instead of raising.
+    """
+    import inspect
+
+    from workers.genomic_worker import run_genomic_pipeline
+
+    sig = inspect.signature(run_genomic_pipeline)
+    assert sig.parameters["dna_r2_s3_key"].default is None

--- a/api/workers/genomic_worker.py
+++ b/api/workers/genomic_worker.py
@@ -35,10 +35,17 @@ def run_genomic_pipeline(
     biopsy_s3_key: str,
     dna_s3_key: str,
     cancer_type: str,
+    dna_r2_s3_key: str | None = None,
 ):
     """
     Main genomic pipeline task.
     Runs synchronously inside the Celery worker process.
+
+    `dna_r2_s3_key` is mate 2 of a paired-end FASTQ sample and defaults to None.
+    The default is not cosmetic: tasks are `acks_late`, so a message enqueued by
+    the previous five-argument signature can still be sitting in Redis when a
+    worker running this code picks it up. Without the default that redelivery
+    raises instead of running single-end, which is what it did before.
     """
     from workers._db_sync import get_sync_session
     from models.submission import Submission, SubmissionStatus
@@ -59,9 +66,14 @@ def run_genomic_pipeline(
         with tempfile.TemporaryDirectory() as workdir:
             # 1. Download DNA file from MinIO
             dna_local = _download_from_minio(dna_s3_key, workdir)
+            dna_r2_local = (
+                _download_from_minio(dna_r2_s3_key, workdir) if dna_r2_s3_key else None
+            )
 
             # 2. Run Nextflow pipeline
-            vcf_path = _run_nextflow_pipeline(dna_local, workdir, cancer_type)
+            vcf_path = _run_nextflow_pipeline(
+                dna_local, workdir, cancer_type, reads_r2=dna_r2_local
+            )
 
             # 3. Parse VCF and annotate mutations
             mutations_data = _parse_and_annotate_vcf(vcf_path)
@@ -147,7 +159,9 @@ def _download_from_minio(s3_key: str, workdir: str) -> str:
     return local_path
 
 
-def _run_nextflow_pipeline(dna_file: str, workdir: str, cancer_type: str) -> str:
+def _run_nextflow_pipeline(
+    dna_file: str, workdir: str, cancer_type: str, reads_r2: str | None = None
+) -> str:
     """
     Execute the Nextflow pipeline. Returns path to output VCF.
     Nextflow handles: FastQC → Trimmomatic → BWA-MEM2 → GATK → OpenCRAVAT
@@ -187,6 +201,9 @@ def _run_nextflow_pipeline(dna_file: str, workdir: str, cancer_type: str) -> str
         "-work-dir", os.path.join(workdir, "work"),
         "-with-report",
     ]
+
+    if reads_r2:
+        cmd += ["--reads_r2", reads_r2]
 
     result = subprocess.run(
         cmd,

--- a/pipeline/main.nf
+++ b/pipeline/main.nf
@@ -17,6 +17,18 @@ nextflow.enable.dsl=2
  *     --cancer_type "Lung adenocarcinoma" \
  *     --caller somatic
  *
+ *   # Paired-end FASTQ. Both mates, because that is what a sequencer produces,
+ *   # and aligning one alone throws away the insert-size information that
+ *   # places reads in repetitive regions:
+ *   nextflow run main.nf \
+ *     --input_file sample_R1.fastq.gz \
+ *     --reads_r2 sample_R2.fastq.gz \
+ *     --output_dir ./results \
+ *     --caller germline
+ *
+ *   # A {1,2} glob on --input_file does NOT pair the mates. It runs the
+ *   # workflow twice, once per file. Use --reads_r2.
+ *
  *   # Full multi-omic (WES tumour/normal pair):
  *   nextflow run main.nf \
  *     --input_file tumour.bam \
@@ -28,6 +40,14 @@ nextflow.enable.dsl=2
  */
 
 params.input_file  = null
+// Mate 2 of a paired-end FASTQ sample. Empty means single-end.
+//
+// Paired-end is what every sequencer emits and what all of the reference data
+// this pipeline is validated against uses. Until this existed the FASTQ path
+// ran `trimmomatic SE` and handed one file to `bwa-mem2 mem`, so a paired
+// sample could only be submitted one mate at a time and was aligned without the
+// insert-size information that resolves ambiguous placements.
+params.reads_r2    = ""
 params.output_dir  = "./results"
 params.cancer_type = "unknown"
 params.genome      = "GRCh38"
@@ -38,6 +58,12 @@ params.dbsnp       = "${projectDir}/references/dbsnp_146.hg38.vcf.gz"
 params.caller       = "germline"   // germline | somatic
 params.normal_bam   = ""           // matched normal BAM for somatic calling
 params.germline_vcf = ""           // gnomAD VCF for Mutect2 germline resource
+
+// Trimmomatic adapter files. Parameters rather than literals because the paths
+// differ by execution profile: these defaults are where the bioconda package
+// puts them, and a container image will not agree.
+params.adapters_se  = "/opt/conda/share/trimmomatic/adapters/TruSeq3-SE.fa"
+params.adapters_pe  = "/opt/conda/share/trimmomatic/adapters/TruSeq3-PE.fa"
 
 // Multi-omic flags
 params.run_cnv      = false        // Run CNVkit for copy number alterations
@@ -70,6 +96,18 @@ def _is_bam_name(String name) {
 def _is_vcf_name(String name) {
     def n = (name ?: '').toLowerCase()
     return n.endsWith('.vcf') || n.endsWith('.vcf.gz')
+}
+
+/*
+ * Sample id from a read filename, with the mate marker removed so R1 and R2 of
+ * one sample agree. Without stripping it the pair would be named after mate 1
+ * and every output would read as though mate 2 belonged to a different sample.
+ */
+def _sample_id_from_reads(String name) {
+    def base = (name ?: '')
+        .replaceAll(/\.(fastq|fq)(\.gz)?$/, '')
+        .replaceAll(/[._-](R?[12])$/, '')
+    return base ?: 'sample'
 }
 
 def _resolve_first_existing_path(String primary, List<String> fallbacks = []) {
@@ -114,6 +152,26 @@ workflow {
     }
 
     input_ch = Channel.fromPath(params.input_file, checkIfExists: true)
+
+    // Reads travel as (sample_id, [mates]) so one sample stays one item through
+    // QC, trimming and alignment. Passing a {1,2} glob to --input_file does not
+    // do this: fromPath emits two independent items and the workflow would run
+    // twice, once per mate, which is what used to happen.
+    def r2_given = params.reads_r2 ? params.reads_r2.toString().trim() : ""
+    if (r2_given && !is_fastq) {
+        error "ERROR: --reads_r2 is only meaningful with FASTQ input; --input_file is ${params.input_file}"
+    }
+    if (r2_given && !file(r2_given).exists()) {
+        error "ERROR: Missing mate 2 file: ${r2_given}"
+    }
+
+    reads_ch = r2_given
+        ? Channel.of(tuple(
+              _sample_id_from_reads(file(params.input_file).name),
+              [file(params.input_file), file(r2_given)]
+          ))
+        : input_ch.map { r -> tuple(_sample_id_from_reads(r.name), [r]) }
+
     normal_bam_ch = params.normal_bam ? Channel.fromPath(params.normal_bam) : Channel.value(file("NO_NORMAL"))
     germline_vcf_ch = params.germline_vcf ? Channel.fromPath(params.germline_vcf) : Channel.value(file("NO_GERMLINE"))
     targets_bed_ch = params.targets_bed ? Channel.fromPath(params.targets_bed) : Channel.value(file("FLAT"))
@@ -153,9 +211,14 @@ workflow {
     }
 
     // ── FASTQ path: full QC → trim → align → call → annotate ────────────────
-    FASTQC(input_ch)
-    TRIMMOMATIC(input_ch)
-    BWA_MEM2_ALIGN(TRIMMOMATIC.out.trimmed, resolved_ref_fasta)
+    FASTQC(reads_ch)
+    TRIMMOMATIC(reads_ch)
+
+    // Trimmomatic emits the paired channel for a pair and the single-end one
+    // otherwise, exactly one of which carries an item for any given sample.
+    trimmed_ch = TRIMMOMATIC.out.trimmed.mix(TRIMMOMATIC.out.trimmed_se)
+
+    BWA_MEM2_ALIGN(trimmed_ch, resolved_ref_fasta)
 
     if (params.caller == "somatic") {
         MUTECT2(BWA_MEM2_ALIGN.out.bam, normal_bam_ch.first(), Channel.value(resolved_ref_fasta), germline_vcf_ch.first())

--- a/pipeline/modules/bwa_mem2.nf
+++ b/pipeline/modules/bwa_mem2.nf
@@ -1,33 +1,40 @@
 /*
  * BWA-MEM2 — align reads to GRCh38 reference genome
+ *
+ * Takes a sample id and one or two read files. Two mates are passed to a single
+ * `bwa-mem2 mem` invocation so the aligner can use the insert-size distribution
+ * to place reads whose own sequence is ambiguous. That is most of the value of
+ * paired-end sequencing, and aligning each mate separately discards it.
+ *
+ * One BAM per sample either way, so everything downstream is unchanged.
  */
 process BWA_MEM2_ALIGN {
-    tag "$reads"
+    tag "$sample_id"
     publishDir "${params.output_dir}/bam", mode: 'copy'
 
     label "process_high"
-    conda 'bioconda::bwa-mem2=2.2.1 bioconda::samtools=1.19'
+    conda "bioconda::bwa-mem2=2.2.1 bioconda::samtools=1.19"
 
     input:
-    path reads
+    tuple val(sample_id), path(reads)
     path ref_fasta
 
     output:
-    path "*.sorted.bam",     emit: bam
-    path "*.sorted.bam.bai", emit: bai
+    path "${sample_id}.sorted.bam",     emit: bam
+    path "${sample_id}.sorted.bam.bai", emit: bai
 
     script:
-    def base = reads.baseName
+    def read_args = reads instanceof List ? reads.join(' ') : "${reads}"
     """
     bwa-mem2 index $ref_fasta
 
-    bwa-mem2 mem \
-        -t ${task.cpus} \
-        -R "@RG\\tID:openoncology\\tSM:patient\\tPL:ILLUMINA" \
-        $ref_fasta \
-        $reads | \
-    samtools sort -@ ${task.cpus} -o ${base}.sorted.bam -
+    bwa-mem2 mem \\
+        -t ${task.cpus} \\
+        -R "@RG\\tID:openoncology\\tSM:${sample_id}\\tPL:ILLUMINA" \\
+        $ref_fasta \\
+        ${read_args} | \\
+    samtools sort -@ ${task.cpus} -o ${sample_id}.sorted.bam -
 
-    samtools index ${base}.sorted.bam
+    samtools index ${sample_id}.sorted.bam
     """
 }

--- a/pipeline/modules/fastqc.nf
+++ b/pipeline/modules/fastqc.nf
@@ -1,15 +1,19 @@
 /*
  * FastQC — DNA read quality control
+ *
+ * Both mates are reported when the sample is paired. FastQC writes one report
+ * per input file, which is what you want: mate 2 is routinely worse than mate 1
+ * and averaging them would hide it.
  */
 process FASTQC {
-    tag "$reads"
+    tag "$sample_id"
     publishDir "${params.output_dir}/fastqc", mode: 'copy'
 
     label "process_low"
-    conda 'bioconda::fastqc=0.12.1'
+    conda "bioconda::fastqc=0.12.1"
 
     input:
-    path reads
+    tuple val(sample_id), path(reads)
 
     output:
     path "*.html", emit: report

--- a/pipeline/modules/trimmomatic.nf
+++ b/pipeline/modules/trimmomatic.nf
@@ -1,29 +1,55 @@
 /*
  * Trimmomatic — adapter trimming and quality filtering
+ *
+ * Takes a sample id and one or two read files. Two means paired-end, and the
+ * pair is trimmed together: Trimmomatic PE decides jointly whether both mates
+ * survive, which is what keeps them in step for the aligner. Trimming each mate
+ * as a separate SE run desynchronises them and the pairing is then unusable.
+ *
+ * The unpaired outputs are the reads whose mate was dropped. They are written
+ * out so the loss is visible and countable, and they are deliberately not
+ * emitted to the aligner: adding them back means a second single-end alignment
+ * pass with different error characteristics mixed into one BAM. Discarding them
+ * is the conventional choice and it is a choice, not an oversight.
  */
 process TRIMMOMATIC {
-    tag "$reads"
+    tag "$sample_id"
     publishDir "${params.output_dir}/trimmed", mode: 'copy'
 
     label "process_low"
-    conda 'bioconda::trimmomatic=0.39'
+    conda "bioconda::trimmomatic=0.39"
 
     input:
-    path reads
+    tuple val(sample_id), path(reads)
 
     output:
-    path "*_trimmed.fastq.gz", emit: trimmed
+    tuple val(sample_id), path("*_trimmed_{1,2}P.fastq.gz"), emit: trimmed,   optional: true
+    tuple val(sample_id), path("*_trimmed.fastq.gz"),        emit: trimmed_se, optional: true
+    path "*_trimmed_{1,2}U.fastq.gz",                        emit: unpaired,   optional: true
 
     script:
-    def base = reads.baseName.replaceAll(/\.fastq(\.gz)?$/, "")
-    """
-    trimmomatic SE -threads ${task.cpus} \
-        $reads \
-        ${base}_trimmed.fastq.gz \
-        ILLUMINACLIP:/opt/conda/share/trimmomatic/adapters/TruSeq3-SE.fa:2:30:10 \
-        LEADING:3 \
-        TRAILING:3 \
-        SLIDINGWINDOW:4:15 \
-        MINLEN:36
-    """
+    def paired = reads instanceof List && reads.size() == 2
+    if (paired)
+        """
+        trimmomatic PE -threads ${task.cpus} \\
+            ${reads[0]} ${reads[1]} \\
+            ${sample_id}_trimmed_1P.fastq.gz ${sample_id}_trimmed_1U.fastq.gz \\
+            ${sample_id}_trimmed_2P.fastq.gz ${sample_id}_trimmed_2U.fastq.gz \\
+            ILLUMINACLIP:${params.adapters_pe}:2:30:10 \\
+            LEADING:3 \\
+            TRAILING:3 \\
+            SLIDINGWINDOW:4:15 \\
+            MINLEN:36
+        """
+    else
+        """
+        trimmomatic SE -threads ${task.cpus} \\
+            ${reads instanceof List ? reads[0] : reads} \\
+            ${sample_id}_trimmed.fastq.gz \\
+            ILLUMINACLIP:${params.adapters_se}:2:30:10 \\
+            LEADING:3 \\
+            TRAILING:3 \\
+            SLIDINGWINDOW:4:15 \\
+            MINLEN:36
+        """
 }


### PR DESCRIPTION
## Summary

The FASTQ path processed paired-end sequencing data as single-end at every
stage, and the submission endpoint accepted only one of the two files a
sequencer produces. Both mates are now carried from upload through to alignment.

Closes `OO-10`.

## Problem

Paired-end sequencing produces two files per sample. Four independent points
prevented the second from being used:

| Location | Behaviour |
|---|---|
| `api/routes/submit.py` | Accepted a single `dna_file`, documented as "VCF, FASTQ, or BAM" |
| `pipeline/main.nf` | Channelled input with `fromPath`, not `fromFilePairs`, so two files would have produced two independent workflow runs |
| `pipeline/modules/trimmomatic.nf` | Ran `trimmomatic SE` against `TruSeq3-SE.fa` |
| `pipeline/modules/bwa_mem2.nf` | Passed one read file to `bwa-mem2 mem` |

A submitter holding R1 and R2 could upload one. Nothing recorded that half the
sample was absent, and the reads were aligned without the insert-size
distribution used to place reads in repetitive regions. The result was returned
with the same confidence as any other.

## Changes

**Pipeline**

- Reads are channelled as `(sample_id, [mates])`, so a pair remains a single
  item through QC, trimming and alignment, and one sample yields one BAM.
- Sample id derivation strips the mate marker, so R1 and R2 resolve to the same
  sample.
- Trimmomatic runs `PE` with paired adapters when two mates are present, and
  retains its `SE` path otherwise. Paired mode is required for the mates to stay
  synchronised for the aligner.
- Unpaired survivors are published as a separate output and are not passed to
  the aligner. Including them would mix a second single-end pass into one BAM.
- `bwa-mem2 mem` receives both mates in a single invocation.
- Trimmomatic adapter paths moved from hardcoded conda paths to parameters,
  since the paired mode required a second such path.
- Read groups now carry the sample id. They previously carried the literal
  `SM:patient`, so every BAM produced by this pipeline reported the same sample
  name.

**Intake**

- `dna_file_r2` added, optional, accepted for FASTQ only. A second file
  submitted alongside a VCF or BAM is rejected rather than ignored.
- Migration `0017` adds `submissions.dna_r2_s3_key`, nullable, no backfill. Null
  is not disambiguated in the schema because three cases produce it and only the
  application can distinguish them: no mate, single-end reads, or a row
  predating the column.
- `run_genomic_pipeline` gains a trailing parameter defaulting to `None`. Tasks
  are `acks_late`, so a message enqueued under the previous five-argument
  signature can be redelivered to a worker running this code; the default allows
  that message to run single-end rather than raise.

**Test infrastructure**

`api/tests/conftest.py` documented the rate limiter as disabled and implemented
it as `limiter._storage = None`, which does not disable it. This surfaced as
HTTP 429 in `test_routes.py` once a module exceeded `UPLOAD_LIMIT` within a
minute. `limiter.enabled` is now set. No test asserted rate-limiting behaviour.

## Impact

This changes pipeline output. Variant-calling measurements taken before this
change are not comparable with measurements taken after it, which is relevant to
the procedure in `docs/RUNBOOK_VARIANT_CALLING_VALIDATION.md`.

Single-end input remains supported. Existing VCF and BAM submissions are
unaffected.

## Verification

| Check | Result |
|---|---|
| `ruff check api/` | Clean |
| api suite | 1191 passed, 2 xfailed (previously 1168) |
| ai suite | 42 passed |
| Coverage | 61.83% against the 52 gate |
| `scripts/check_migration_chain.py` | 18 revisions, single root, single head |
| `alembic upgrade head` and `alembic check` | Pass in CI against PostgreSQL |
| `scripts/hard_benchmark_gate.py` | PASS, unchanged |

Nextflow behaviour is asserted by reading module source, consistent with
`test_pipeline_config.py`, because CI has no `nextflow` available. These
assertions are weaker than executing the pipeline.

## Not included

`OO-11`, the reference index rebuild in `bwa_mem2.nf`, is adjacent to these
changes and remains filed separately rather than being folded in.
