### PR TITLE
Two HIPAA controls marked satisfied were never implemented

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -85,6 +85,39 @@ Sections are ordered by pipeline position. `/next` pulls from the top of
 - **Out of scope**: whether to ship or cache a prebuilt index, which is a distribution decision
 - **Risk**: low
 
+### OO-12: There is no backup of patient data, and the compliance checklist said there was
+- **Why**: Nothing in this repository backs up the application database or object storage. No `archive_mode`, `archive_command` or `wal_level`; no MinIO versioning; no `pg_dump`, pgBackRest, wal-g or Velero anywhere. The Bitnami `postgresql` sub-chart has persistence, and persistence is not backup: a deleted PVC, a bad migration or a ransomware event loses every submission, mutation and result permanently, with no recovery path. `HIPAA_COMPLIANCE.md` carried ✅ against §164.308 contingency planning, citing "PostgreSQL WAL + MinIO versioning (see `infra/helm/postgres.yaml`)", and that file is Keycloak's database rather than the application's. The claim has been corrected; the gap it was covering is this entry.
+- **Files**: infra/helm/values.yaml, infra/helm/values.production.yaml, infra/helm/templates/, docs/HIPAA_COMPLIANCE.md, docs/SETUP.md
+- **Acceptance**:
+  - The application database has scheduled backups with a stated retention, and object storage has versioning or an equivalent
+  - A **restore** has been performed into a scratch namespace and the result checked, because an unexercised backup is a belief rather than a control
+  - RPO and RTO are written down, even if the numbers are modest
+  - `HIPAA_COMPLIANCE.md` moves to ✅ only after that restore, and names what was restored and when
+- **Out of scope**: choosing a managed database, which is a hosting decision
+- **Risk**: high while open. This is the one entry where the failure mode is unrecoverable rather than merely wrong.
+
+### OO-13: Prometheus scrapes metrics that can never alert anyone
+- **Why**: `infra/prometheus.yml` has `alertmanagers: []` and `rule_files: []`, and no rule file exists anywhere in the repository. Every metric is collected and nothing can ever fire. The consequences are specific rather than general: the sustained static-fallback alarm from risk_analysis open action 4 escalates a **log line** to ERROR, and `/ready` reports Postgres and Redis health to Kubernetes but to nobody else, so a degraded evidence base, a stalled `genomic` queue, or a worker crash-looping are all invisible unless a person happens to be reading logs.
+- **Files**: infra/prometheus.yml, infra/helm/templates/, infra/alerts/
+- **Acceptance**:
+  - An Alertmanager target and at least one rule file are configured
+  - Rules cover: sustained degraded evidence, queue depth or task age on `genomic` and `gdpr`, `/ready` failing, and worker absence
+  - Each rule names where it routes; a rule with no receiver is the same absence in a different place
+  - A deliberately triggered rule has been observed to fire
+- **Out of scope**: paging rotas and escalation policy, which are operational rather than repository concerns
+- **Risk**: medium
+
+### OO-14: A compliance ✅ should have to cite something that exists
+- **Why**: Two rows in `HIPAA_COMPLIANCE.md` carried ✅ against controls that were never implemented, one citing a file that is a different database. Both read as verified for as long as nobody checked. This is the same shape as the coverage-threshold drift that OO-3 closed with a test, and the same shape as F11, F14 and F18: an assertion about something present, with nothing asserting the absence. The document is the one a compliance officer would be handed.
+- **Files**: api/tests/test_compliance_claims.py, docs/HIPAA_COMPLIANCE.md
+- **Acceptance**:
+  - Every ✅ row whose Implementation cites a repository path is checked: the path exists
+  - Where a row cites a specific mechanism that is greppable (`archive_mode`, `data_checksums`, an env var, a middleware module), the test asserts it is actually present
+  - Rows that cannot be checked mechanically are listed explicitly with the reason, the way `test_marketplace_phi_disclosure.py` handles its exemptions, so the uncheckable set is visible rather than implied
+  - The test fails today against the pre-correction version of the document
+- **Out of scope**: the substance of HIPAA compliance, which is a legal question and not a test
+- **Risk**: low
+
 ---
 
 ## In progress

--- a/docs/HIPAA_COMPLIANCE.md
+++ b/docs/HIPAA_COMPLIANCE.md
@@ -6,6 +6,20 @@
 
 ---
 
+> **On the accuracy of this checklist.** Two rows below carried ✅ against
+> controls that were never implemented: the contingency plan cited WAL archiving
+> and MinIO versioning, neither of which is configured anywhere, and pointed at
+> the wrong database; data-at-rest integrity cited PostgreSQL checksums, which
+> are off. Both were corrected on 2026-08-29 after being checked against the
+> infrastructure rather than read.
+>
+> A ✅ here should mean someone has verified the control in the deployed
+> configuration, not that it was intended. Anything not verified that way belongs
+> at ⬜ with the gap named, which costs nothing and is the only version of this
+> document that is safe to rely on.
+
+---
+
 ## 1. Administrative Safeguards (§164.308)
 
 | Control | Status | Implementation |
@@ -16,7 +30,7 @@
 | Sanction policy | ⬜ | Document disciplinary procedure for policy violations |
 | Access management policy | ✅ | Keycloak RBAC — roles: `patient`, `oncologist`, `admin` |
 | Audit controls policy | ✅ | `api/middleware/audit.py` — structured PHI access log |
-| Contingency plan (backup) | ✅ | PostgreSQL WAL + MinIO versioning (see `infra/helm/postgres.yaml`) |
+| Contingency plan (backup) | ⬜ | **Nothing implements this.** No `archive_mode`, `archive_command` or `wal_level` is set anywhere, and no MinIO versioning is enabled. `infra/helm/templates/postgres.yaml`, which this row used to cite, is Keycloak's database: the application uses the Bitnami `postgresql` sub-chart. Persistence is not backup, so a deleted PVC or a bad migration loses every submission and result permanently. See BACKLOG.md OO-12 |
 | Business Associate Agreements | ⬜ | Required with: AWS/GCP, Stripe, Resend, Keycloak cloud hosting |
 
 ---
@@ -56,7 +70,7 @@
 | Control | Status | Implementation |
 |---|---|---|
 | PHI transmission integrity | ✅ | HTTPS enforced (HSTS header in `values.production.yaml`) |
-| Data at rest integrity | ✅ | PostgreSQL checksums enabled; MinIO ETag validation |
+| Data at rest integrity | ⬜ | MinIO ETag validation is present. PostgreSQL data checksums are **not** enabled: nothing sets `data_checksums`, and the pinned PostgreSQL 16 defaults it off. Enabling it requires `initdb --data-checksums`, so it is a fresh-cluster decision rather than a config change. See BACKLOG.md OO-12 |
 
 ### 3.4 Transmission Security (§164.312(e))
 


### PR DESCRIPTION
## Summary

`docs/HIPAA_COMPLIANCE.md` marked two safeguards as implemented that are not
implemented anywhere in this repository. Both rows are corrected to "not
implemented" with the gap stated, and the three underlying gaps are filed as
backlog entries.

Documentation and backlog only. No code or infrastructure changes.

## Findings

Each row was verified against the infrastructure rather than taken from the
document.

**§164.308, contingency plan (backup).** Cited "PostgreSQL WAL + MinIO
versioning (see `infra/helm/postgres.yaml`)".

| Claim | Verified state |
|---|---|
| PostgreSQL WAL archiving | No `archive_mode`, `archive_command` or `wal_level` set anywhere in the repository |
| MinIO versioning | Not enabled in `infra/`, `api/services/storage.py`, or `docker-compose.yml` |
| Any other backup mechanism | No `pg_dump`, pgBackRest, wal-g or Velero configuration present |
| Cited file | `infra/helm/templates/postgres.yaml` provisions Keycloak's database. The application uses the Bitnami `postgresql` sub-chart, reached via `openoncology.databaseUrl` |

Consequence: there is no backup of application data. The Bitnami sub-chart
provides persistence, which is not equivalent. Loss of the PersistentVolume, a
failed migration, or data corruption is unrecoverable for every submission,
mutation and result.

**§164.312(c), data at rest integrity.** Cited "PostgreSQL checksums enabled;
MinIO ETag validation".

| Claim | Verified state |
|---|---|
| PostgreSQL data checksums | `data_checksums` is not set; PostgreSQL 16, which the chart pins, defaults it off |
| MinIO ETag validation | Present. Retained in the corrected row |

Enabling checksums requires `initdb --data-checksums` and therefore a new
cluster, not a configuration change. The corrected row states this.

## Changes

- Both rows changed from implemented to not implemented, each naming the
  specific missing mechanism and linking the backlog entry that tracks it.
- Added a note defining what an implemented mark means in this document:
  verified in the deployed configuration, not intended. Unverifiable controls
  belong in the not-implemented column with the gap named.
- Filed `OO-12` (backup and restore), `OO-13` (alerting), `OO-14` (a test
  asserting compliance claims cite something that exists).

## Impact

The document is the artefact a compliance reviewer would be given. Before this
change it reported a contingency plan that does not exist. No runtime behaviour
changes.

`OO-12` is filed at high risk. It is currently the only backlog entry whose
failure mode is unrecoverable rather than incorrect, and its acceptance criteria
require a restore to have been exercised, not only a backup configured.

`OO-13` is separate but related: `infra/prometheus.yml` sets `alertmanagers: []`
and `rule_files: []`, and no rule file exists in the repository, so metrics are
collected and no alert can fire. The sustained static-fallback alarm described in
`risk_analysis.md` open action 4 escalates a log line only.

## Verification

Each claim above was checked by search across `infra/`, `api/`,
`docker-compose.yml` and the Helm templates. The cited file's role was confirmed
by following `keycloak.yaml` and the `openoncology.databaseUrl` helper.

No tests were added here. `OO-14` proposes the check that would have caught this
class of error, in the same form as `OO-3` for the coverage threshold.

## Follow-ups

`OO-12`, `OO-13` and `OO-14` in `BACKLOG.md`. None is addressed by this PR.
