### PR TITLE
Stage the BWA-MEM2 index instead of rebuilding it in every alignment task

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -75,16 +75,6 @@ Sections are ordered by pipeline position. `/next` pulls from the top of
 - **Out of scope**: the somatic and RNA-seq paths, beyond what falls out of the same change
 - **Risk**: medium. This changes what the pipeline computes, so it invalidates any variant-calling measurement taken before it. Either sequence it ahead of the run in the runbook, or record which configuration produced which number.
 
-### OO-11: BWA-MEM2 rebuilds the reference index on every alignment task
-- **Why**: `BWA_MEM2_ALIGN` declares `path ref_fasta` as its only reference input, so Nextflow stages the FASTA into the task work directory and none of the index files beside it. The script then runs `bwa-mem2 index $ref_fasta`, which `pipeline/scripts/download_references.sh` puts at roughly 30 minutes and 12 GB of RAM, and the result is discarded with the work directory. Setup builds the index and the pipeline never sees it, so every sample pays the cost again and every retry pays it once more.
-- **Files**: pipeline/modules/bwa_mem2.nf, pipeline/main.nf
-- **Acceptance**:
-  - The index files are staged as inputs alongside the FASTA
-  - `bwa-mem2 index` is gone from the alignment script, or runs only when the index is genuinely absent
-  - A missing index fails with a message pointing at `download_references.sh`, rather than silently costing half an hour
-- **Out of scope**: whether to ship or cache a prebuilt index, which is a distribution decision
-- **Risk**: low
-
 ### OO-12: There is no backup of patient data, and the compliance checklist said there was
 - **Why**: Nothing in this repository backs up the application database or object storage. No `archive_mode`, `archive_command` or `wal_level`; no MinIO versioning; no `pg_dump`, pgBackRest, wal-g or Velero anywhere. The Bitnami `postgresql` sub-chart has persistence, and persistence is not backup: a deleted PVC, a bad migration or a ransomware event loses every submission, mutation and result permanently, with no recovery path. `HIPAA_COMPLIANCE.md` carried ✅ against §164.308 contingency planning, citing "PostgreSQL WAL + MinIO versioning (see `infra/helm/postgres.yaml`)", and that file is Keycloak's database rather than the application's. The claim has been corrected; the gap it was covering is this entry.
 - **Files**: infra/helm/values.yaml, infra/helm/values.production.yaml, infra/helm/templates/, docs/HIPAA_COMPLIANCE.md, docs/SETUP.md

--- a/api/tests/test_paired_end_reads.py
+++ b/api/tests/test_paired_end_reads.py
@@ -48,11 +48,9 @@ def test_reads_travel_as_one_item_per_sample():
            "tuple(_sample_id_from_reads" in MAIN_NF
 
 
-@pytest.mark.parametrize(
-    "module,name",
-    [(TRIMMOMATIC_NF, "trimmomatic"), (BWA_NF, "bwa_mem2"), (FASTQC_NF, "fastqc")],
-)
-def test_fastq_modules_take_the_sample_tuple(module, name):
+@pytest.mark.parametrize("name", ["trimmomatic", "bwa_mem2", "fastqc"])
+def test_fastq_modules_take_the_sample_tuple(name):
+    module = (PIPELINE / "modules" / f"{name}.nf").read_text(encoding="utf-8")
     assert "tuple val(sample_id), path(reads)" in module, (
         f"{name} still takes a bare path, so it cannot receive both mates"
     )
@@ -325,3 +323,47 @@ def test_task_signature_tolerates_a_redelivered_five_argument_message():
 
     sig = inspect.signature(run_genomic_pipeline)
     assert sig.parameters["dna_r2_s3_key"].default is None
+
+
+# ── The reference index is an input, not something alignment rebuilds ────────
+#
+# OO-11. BWA_MEM2_ALIGN declared only the FASTA, so Nextflow staged the FASTA and
+# none of the index files beside it, and the script ran `bwa-mem2 index` to
+# rebuild what pipeline/scripts/download_references.sh had already built. About
+# 30 minutes and 12 GB per task by that script's own estimate, discarded with the
+# work directory.
+
+def test_alignment_does_not_rebuild_the_index():
+    bwa = (PIPELINE / "modules" / "bwa_mem2.nf").read_text(encoding="utf-8")
+    script = bwa[bwa.index("script:"):]
+    assert "bwa-mem2 index" not in script, (
+        "the alignment script still builds the index; setup already did"
+    )
+
+
+def test_alignment_declares_the_index_as_an_input():
+    bwa = (PIPELINE / "modules" / "bwa_mem2.nf").read_text(encoding="utf-8")
+    inputs = bwa[bwa.index("input:"):bwa.index("output:")]
+    assert "path ref_index" in inputs, (
+        "without declaring the index files Nextflow stages only the FASTA"
+    )
+
+
+def test_main_names_every_bwa_index_suffix():
+    """
+    A missing suffix stages an incomplete index, which fails inside the aligner
+    rather than at the check. bwa-mem2 writes all five.
+    """
+    helper = MAIN_NF[MAIN_NF.index("def _bwa_index_files"):]
+    helper = helper[: helper.index("\n}")]
+    for suffix in (".0123", ".amb", ".ann", ".bwt.2bit.64", ".pac"):
+        assert suffix in helper, f"index suffix {suffix} not staged"
+
+
+def test_a_missing_index_fails_before_alignment_starts():
+    assert "Missing BWA-MEM2 index" in MAIN_NF
+    assert "download_references.sh" in MAIN_NF
+
+
+def test_the_aligner_receives_the_index():
+    assert "BWA_MEM2_ALIGN(trimmed_ch, resolved_ref_fasta, _bwa_index_files(" in MAIN_NF

--- a/pipeline/main.nf
+++ b/pipeline/main.nf
@@ -110,6 +110,16 @@ def _sample_id_from_reads(String name) {
     return base ?: 'sample'
 }
 
+/*
+ * The files `bwa-mem2 index` writes beside the FASTA. They are inputs to the
+ * alignment process rather than something it builds, so they have to be named
+ * for Nextflow to stage them.
+ */
+def _bwa_index_files(String fasta) {
+    def suffixes = ['.0123', '.amb', '.ann', '.bwt.2bit.64', '.pac']
+    return suffixes.collect { file("${fasta}${it}") }
+}
+
 def _resolve_first_existing_path(String primary, List<String> fallbacks = []) {
     for (candidate in [primary, *fallbacks]) {
         if (candidate && file(candidate).exists()) {
@@ -148,6 +158,15 @@ workflow {
         }
         if (!file(resolved_dbsnp).exists()) {
             error "ERROR: Missing dbSNP VCF: ${resolved_dbsnp}. Run pipeline/scripts/download_references.sh or set --dbsnp to a valid dbSNP VCF."
+        }
+    }
+
+    if (is_fastq) {
+        // Fail here, with the fix named, rather than half an hour into an
+        // alignment task that would silently rebuild the index itself.
+        def missing_index = _bwa_index_files(resolved_ref_fasta).findAll { !it.exists() }
+        if (missing_index) {
+            error "ERROR: Missing BWA-MEM2 index for ${resolved_ref_fasta}: ${missing_index*.name.join(', ')}. Run pipeline/scripts/download_references.sh, which builds it once."
         }
     }
 
@@ -218,7 +237,7 @@ workflow {
     // otherwise, exactly one of which carries an item for any given sample.
     trimmed_ch = TRIMMOMATIC.out.trimmed.mix(TRIMMOMATIC.out.trimmed_se)
 
-    BWA_MEM2_ALIGN(trimmed_ch, resolved_ref_fasta)
+    BWA_MEM2_ALIGN(trimmed_ch, resolved_ref_fasta, _bwa_index_files(resolved_ref_fasta))
 
     if (params.caller == "somatic") {
         MUTECT2(BWA_MEM2_ALIGN.out.bam, normal_bam_ch.first(), Channel.value(resolved_ref_fasta), germline_vcf_ch.first())

--- a/pipeline/modules/bwa_mem2.nf
+++ b/pipeline/modules/bwa_mem2.nf
@@ -7,6 +7,14 @@
  * paired-end sequencing, and aligning each mate separately discards it.
  *
  * One BAM per sample either way, so everything downstream is unchanged.
+ *
+ * The index is an input, not something this process builds. It used to declare
+ * only the FASTA, so Nextflow staged the FASTA and none of the index files
+ * beside it, and the script then ran `bwa-mem2 index` to recreate what
+ * pipeline/scripts/download_references.sh had already built. By that script's
+ * own estimate that is about 30 minutes and 12 GB of RAM, per task, thrown away
+ * with the work directory. Declaring the index files means they are staged and
+ * the work is done once, at setup.
  */
 process BWA_MEM2_ALIGN {
     tag "$sample_id"
@@ -18,6 +26,7 @@ process BWA_MEM2_ALIGN {
     input:
     tuple val(sample_id), path(reads)
     path ref_fasta
+    path ref_index
 
     output:
     path "${sample_id}.sorted.bam",     emit: bam
@@ -26,8 +35,6 @@ process BWA_MEM2_ALIGN {
     script:
     def read_args = reads instanceof List ? reads.join(' ') : "${reads}"
     """
-    bwa-mem2 index $ref_fasta
-
     bwa-mem2 mem \\
         -t ${task.cpus} \\
         -R "@RG\\tID:openoncology\\tSM:${sample_id}\\tPL:ILLUMINA" \\


### PR DESCRIPTION
## Summary

`BWA_MEM2_ALIGN` rebuilt the reference index inside every alignment task,
duplicating work that `pipeline/scripts/download_references.sh` performs once at
setup. The index files are now staged as process inputs and the rebuild is
removed.

Closes `OO-11`.

## Problem

The process declared `path ref_fasta` as its only reference input. Nextflow
stages declared inputs into the task work directory, so the FASTA was staged and
the five index files beside it were not. The script compensated by running
`bwa-mem2 index` itself.

By the download script's own estimate that is approximately 30 minutes and 12 GB
of RAM. It ran per alignment task, and the result was discarded with the work
directory, so a retry repeated it.

A second consequence: an absent index was undetectable. The process would build
one and succeed, so a run where setup had been skipped completed normally and
slowly rather than reporting the missing prerequisite.

## Changes

- `pipeline/modules/bwa_mem2.nf`: added `path ref_index` as an input; removed
  `bwa-mem2 index` from the script.
- `pipeline/main.nf`: added `_bwa_index_files()`, naming the five suffixes
  bwa-mem2 produces (`.0123`, `.amb`, `.ann`, `.bwt.2bit.64`, `.pac`), and passed
  the result to the process.
- `pipeline/main.nf`: a missing index now fails at the same point as the existing
  missing-FASTA and missing-dbSNP checks, naming `download_references.sh`.
- Five assertions added to `api/tests/test_paired_end_reads.py` covering the
  absence of the rebuild, the input declaration, all five suffixes, the failure
  message, and the call site.

## Impact

Alignment output is unchanged. The index bwa-mem2 builds is deterministic for a
given reference, so staging the prebuilt one produces the same alignments.

Runs now require `download_references.sh` to have been executed. Previously that
was optional in effect, because the pipeline would rebuild what was missing.
This is stated in the failure message.

## Not included

`GATK_HAPLOTYPE` stages neither the `.fai` nor the sequence dictionary and calls
`samtools faidx ... || true`. That is the same pattern in a different module and
is left as is, since `OO-11` named this process. Not currently filed.

## Verification

| Check | Result |
|---|---|
| `ruff check api/` | Clean |
| api suite | 1196 passed, 2 xfailed |
| ai suite | 42 passed |
| Coverage | 61.83% against the 52 gate |

Nextflow behaviour is asserted by reading module source, consistent with
`test_pipeline_config.py`, because CI has no `nextflow` available. The staging
behaviour itself is a Nextflow guarantee about declared inputs and is not
exercised here.
