### PR TITLE
Add Prometheus alerting rules, and correct the scrape targets that do not exist

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -96,17 +96,6 @@ Sections are ordered by pipeline position. `/next` pulls from the top of
 - **Out of scope**: choosing a managed database, which is a hosting decision
 - **Risk**: high while open. This is the one entry where the failure mode is unrecoverable rather than merely wrong.
 
-### OO-13: Prometheus scrapes metrics that can never alert anyone
-- **Why**: `infra/prometheus.yml` has `alertmanagers: []` and `rule_files: []`, and no rule file exists anywhere in the repository. Every metric is collected and nothing can ever fire. The consequences are specific rather than general: the sustained static-fallback alarm from risk_analysis open action 4 escalates a **log line** to ERROR, and `/ready` reports Postgres and Redis health to Kubernetes but to nobody else, so a degraded evidence base, a stalled `genomic` queue, or a worker crash-looping are all invisible unless a person happens to be reading logs.
-- **Files**: infra/prometheus.yml, infra/helm/templates/, infra/alerts/
-- **Acceptance**:
-  - An Alertmanager target and at least one rule file are configured
-  - Rules cover: sustained degraded evidence, queue depth or task age on `genomic` and `gdpr`, `/ready` failing, and worker absence
-  - Each rule names where it routes; a rule with no receiver is the same absence in a different place
-  - A deliberately triggered rule has been observed to fire
-- **Out of scope**: paging rotas and escalation policy, which are operational rather than repository concerns
-- **Risk**: medium
-
 ### OO-14: A compliance ✅ should have to cite something that exists
 - **Why**: Two rows in `HIPAA_COMPLIANCE.md` carried ✅ against controls that were never implemented, one citing a file that is a different database. Both read as verified for as long as nobody checked. This is the same shape as the coverage-threshold drift that OO-3 closed with a test, and the same shape as F11, F14 and F18: an assertion about something present, with nothing asserting the absence. The document is the one a compliance officer would be handed.
 - **Files**: api/tests/test_compliance_claims.py, docs/HIPAA_COMPLIANCE.md
@@ -117,6 +106,27 @@ Sections are ordered by pipeline position. `/next` pulls from the top of
   - The test fails today against the pre-correction version of the document
 - **Out of scope**: the substance of HIPAA compliance, which is a legal question and not a test
 - **Risk**: low
+
+### OO-16: Deploy the exporters the monitoring config was scraping
+- **Why**: `infra/prometheus.yml` scraped `db-exporter:9187`, `redis-exporter:9121` and `worker-*:9100`. None of the first two exists in `docker-compose.yml` or the Helm chart, and nothing in `api/workers/` starts a metrics server, so port 9100 is not listening. All four reported `up == 0` permanently, invisibly, because nothing alerted on `up`. Those jobs are commented out rather than deleted, since the intent is right and the deployment is what is missing. `api/tests/test_alert_rules.py` now fails if a scrape job names a host no deployment defines.
+- **Files**: docker-compose.yml, infra/helm/templates/, infra/prometheus.yml, api/workers/__init__.py
+- **Acceptance**:
+  - postgres_exporter and redis_exporter are deployed in both deployment paths, or the jobs stay commented and the reason is recorded here
+  - Celery workers expose a metrics endpoint, or the celery-exporter is deployed against the broker instead
+  - Each job is uncommented only once its exporter is actually reachable, and `test_alert_rules.py` passes with it active
+  - Queue depth and task age on `genomic` and `gdpr` become alertable, which is what OO-13 could not cover
+- **Out of scope**: dashboards
+- **Risk**: low
+
+### OO-17: The degraded-evidence alarm emits no metric, and two metrics emit nothing
+- **Why**: `settings.degraded_evidence_alert_after` escalates a **log line** to ERROR after a run of static-fallback resolutions. That is the control risk_analysis open action 4 closed, and it can only be seen by someone reading logs: there is no metric, so it cannot alert. Separately, `api/main.py` declares `openoncology_mutations_processed_total` and `openoncology_genomic_pipeline_seconds` and neither is ever incremented, so both are permanently absent from `/metrics`. A rule written against either would look like coverage and never fire, which is why `test_alert_rules.py` rejects them.
+- **Files**: api/main.py, api/services/oncokb_evidence.py, api/workers/genomic_worker.py, infra/alerts/openoncology.rules.yml
+- **Acceptance**:
+  - A counter or gauge reflects consecutive static-fallback resolutions, and an alert fires on a sustained run
+  - The two declared metrics are either incremented at the points they describe, or removed
+  - `test_alert_rules.py`'s allowed-metric set grows only alongside the code that emits them
+- **Out of scope**: what the alert threshold should be, which is the same policy question as `degraded_evidence_alert_after` itself
+- **Risk**: low to implement. Worth noting the evidence path is adjacent to ranking, so the metric should be emitted where the fallback is already logged rather than anywhere new.
 
 ---
 

--- a/api/tests/test_alert_rules.py
+++ b/api/tests/test_alert_rules.py
@@ -1,0 +1,164 @@
+"""
+An alert rule must reference a metric something actually emits.
+
+BACKLOG.md OO-13. `infra/prometheus.yml` set `rule_files: []` and
+`alertmanagers: []`, so every metric was scraped and no alert could fire. Four
+of its seven scrape jobs also pointed at exporters that exist nowhere in this
+repository, which reported `up == 0` permanently and would have paged
+continuously the moment any rule watched `up`.
+
+A rule written against a metric nobody exports is the same defect as no rule at
+all, and harder to notice, because the rule file looks like coverage. This
+module fails the build when that happens.
+
+The permitted set is deliberately small: Prometheus' own `up` and `scrape_*`
+series, and the default metrics `prometheus_fastapi_instrumentator` installs in
+`api/main.py`. Adding a metric to this list should mean adding the exporter that
+emits it.
+"""
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INFRA = REPO_ROOT / "infra"
+PROM_CONFIG = INFRA / "prometheus.yml"
+RULES_DIR = INFRA / "alerts"
+
+# Emitted by Prometheus itself for every target.
+PROMETHEUS_INTERNAL = {"up", "scrape_duration_seconds", "scrape_samples_scraped"}
+
+# The default set installed by prometheus_fastapi_instrumentator, which
+# api/main.py wires up. Suffixes are the Prometheus histogram/counter families.
+INSTRUMENTATOR_BASE = {
+    "http_requests_total",
+    "http_request_duration_seconds",
+    "http_request_duration_highr_seconds",
+    "http_request_size_bytes",
+    "http_response_size_bytes",
+}
+_SUFFIXES = ("", "_bucket", "_count", "_sum", "_created")
+ALLOWED_METRICS = PROMETHEUS_INTERNAL | {
+    base + suffix for base in INSTRUMENTATOR_BASE for suffix in _SUFFIXES
+}
+
+# PromQL functions and keywords that appear where a metric name would, and are
+# not metrics.
+_PROMQL_TOKENS = {
+    "sum", "rate", "irate", "avg", "min", "max", "count", "count_values", "by",
+    "without", "on", "ignoring", "group_left", "group_right", "increase",
+    "histogram_quantile", "clamp_min", "clamp_max", "le", "job", "instance",
+    "status", "handler", "method", "and", "or", "unless", "offset", "bool",
+    "absent", "time", "delta", "deriv", "topk", "bottomk", "quantile",
+}
+
+
+def _rule_files() -> list[Path]:
+    return sorted(RULES_DIR.glob("*.rules.yml"))
+
+
+def _rules() -> list[tuple[str, dict]]:
+    out = []
+    for path in _rule_files():
+        doc = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        for group in doc.get("groups", []):
+            for rule in group.get("rules", []):
+                out.append((f"{path.name}:{group.get('name')}:{rule.get('alert')}", rule))
+    return out
+
+
+def _metric_names(expr: str) -> set[str]:
+    """Identifiers in a PromQL expression that are used as metric selectors."""
+    names = set()
+    for match in re.finditer(r"\b([a-zA-Z_][a-zA-Z0-9_]*)\b(\s*[({\[]|\s|$)", expr):
+        token, tail = match.group(1), match.group(2)
+        if token in _PROMQL_TOKENS:
+            continue
+        # A bare identifier followed by ( is a function call, not a metric.
+        if tail.strip().startswith("("):
+            continue
+        names.add(token)
+    return names
+
+
+# ── The wiring exists at all ─────────────────────────────────────────────────
+
+def test_prometheus_config_loads_rule_files():
+    config = yaml.safe_load(PROM_CONFIG.read_text(encoding="utf-8"))
+    assert config.get("rule_files"), (
+        "rule_files is empty, so no alert can fire regardless of what alerts/ contains"
+    )
+
+
+def test_rule_files_exist_and_are_not_empty():
+    files = _rule_files()
+    assert files, f"rule_files is set but {RULES_DIR} contains no *.rules.yml"
+    assert _rules(), "rule files parsed but define no alerts"
+
+
+def test_every_rule_file_is_valid_yaml_in_the_expected_shape():
+    for path in _rule_files():
+        doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+        assert isinstance(doc, dict) and "groups" in doc, f"{path.name} has no groups"
+        for group in doc["groups"]:
+            assert group.get("name"), f"{path.name} has an unnamed group"
+            assert group.get("rules"), f"{path.name}:{group.get('name')} has no rules"
+
+
+# ── Rules reference metrics that exist ───────────────────────────────────────
+
+@pytest.mark.parametrize("rule_id,rule", _rules(), ids=[r[0] for r in _rules()])
+def test_rule_references_only_exported_metrics(rule_id, rule):
+    """
+    The defect this module exists for. A rule on a metric nothing emits never
+    fires, and reads as coverage.
+    """
+    unknown = _metric_names(rule["expr"]) - ALLOWED_METRICS
+    assert not unknown, (
+        f"{rule_id} references metrics that nothing in this repository exports: "
+        f"{sorted(unknown)}. Either add the exporter, or do not write the rule."
+    )
+
+
+@pytest.mark.parametrize("rule_id,rule", _rules(), ids=[r[0] for r in _rules()])
+def test_rule_is_actionable(rule_id, rule):
+    """Severity routes it; `for` stops a single scrape blip paging someone;
+    a summary is what the person woken up actually reads."""
+    assert rule.get("for"), f"{rule_id} has no `for`, so one bad scrape pages"
+    assert rule.get("labels", {}).get("severity"), f"{rule_id} has no severity"
+    assert rule.get("annotations", {}).get("summary"), f"{rule_id} has no summary"
+
+
+# ── Scrape targets are real ──────────────────────────────────────────────────
+
+def test_no_active_scrape_job_targets_an_undeployed_exporter():
+    """
+    Four jobs pointed at `db-exporter`, `redis-exporter` and `worker-*:9100`,
+    none of which is deployed by docker-compose.yml or the Helm chart, and the
+    workers start no metrics server. Each reported `up == 0` forever. With a rule
+    watching `up` that pages continuously, which trains whoever is on call to
+    ignore the one signal that matters.
+    """
+    config = yaml.safe_load(PROM_CONFIG.read_text(encoding="utf-8"))
+    compose = (REPO_ROOT / "docker-compose.yml").read_text(encoding="utf-8")
+    helm = "\n".join(
+        p.read_text(encoding="utf-8")
+        for p in (INFRA / "helm").rglob("*.yaml")
+    )
+
+    undeployed = []
+    for job in config.get("scrape_configs", []):
+        for static in job.get("static_configs", []):
+            for target in static.get("targets", []):
+                host = target.split(":")[0]
+                if host in ("localhost", "127.0.0.1"):
+                    continue
+                if host not in compose and host not in helm:
+                    undeployed.append(f"{job.get('job_name')} -> {target}")
+
+    assert not undeployed, (
+        "scrape jobs target hosts that no deployment defines: "
+        f"{undeployed}. Comment the job out until its exporter is deployed."
+    )

--- a/infra/alerts/openoncology.rules.yml
+++ b/infra/alerts/openoncology.rules.yml
@@ -1,0 +1,95 @@
+# Alerting rules for OpenOncology.
+#
+# BACKLOG.md OO-13. Before this file existed, infra/prometheus.yml set
+# `rule_files: []` and `alertmanagers: []`, so every metric was scraped and no
+# alert could ever fire.
+#
+# Every rule here is written against a metric that is genuinely exported:
+# `up` and `scrape_*` come from Prometheus itself, and the `http_*` series come
+# from prometheus_fastapi_instrumentator's default set, which api/main.py
+# installs. `api/tests/test_alert_rules.py` fails the build if a rule references
+# anything outside that set, because an alert on a metric nobody emits is
+# indistinguishable from no alert at all.
+#
+# Two things deliberately have no rule yet, and both are filed rather than
+# faked:
+#
+#   * Celery queue depth and task age. No exporter emits them. See OO-16.
+#   * The degraded-evidence condition. `settings.degraded_evidence_alert_after`
+#     escalates a log line to ERROR and emits no metric, so there is nothing to
+#     alert on from here. See OO-17.
+
+groups:
+  - name: openoncology-availability
+    rules:
+      - alert: TargetDown
+        expr: up == 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Prometheus target {{ $labels.job }} is not responding"
+          description: >-
+            {{ $labels.job }} at {{ $labels.instance }} has failed every scrape
+            for five minutes. For the api job this means the service is
+            unreachable, not merely unhealthy: /ready is excluded from
+            instrumentation, so a pod that is up but degraded still scrapes
+            successfully and will not trigger this.
+
+      - alert: PrometheusScrapesNothing
+        expr: count(up == 1) < 2
+        for: 10m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Fewer than two Prometheus targets are up"
+          description: >-
+            Prometheus scrapes itself, so a healthy deployment has at least
+            Prometheus and the API. One target means only Prometheus is
+            answering and monitoring is effectively blind.
+
+  - name: openoncology-api
+    rules:
+      - alert: ApiErrorRateHigh
+        expr: >-
+          sum(rate(http_requests_total{status=~"5.."}[5m]))
+          / clamp_min(sum(rate(http_requests_total[5m])), 0.001) > 0.05
+        for: 10m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Over 5% of API responses are server errors"
+          description: >-
+            Sustained 5xx rate above five percent for ten minutes. The
+            denominator is clamped so an idle service cannot divide by zero and
+            produce a spurious alert.
+
+      - alert: ApiLatencyHigh
+        expr: >-
+          histogram_quantile(
+            0.95,
+            sum(rate(http_request_duration_seconds_bucket[10m])) by (le)
+          ) > 5
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "API 95th percentile latency above 5 seconds"
+          description: >-
+            Submission and results endpoints do real work, so this is set well
+            above a typical web threshold. It is meant to catch a stuck
+            dependency rather than ordinary load.
+
+      - alert: ApiServingNoTraffic
+        expr: sum(rate(http_requests_total[30m])) == 0
+        for: 30m
+        labels:
+          severity: warning
+        annotations:
+          summary: "API has served no requests for 30 minutes"
+          description: >-
+            Expected to be noisy on a low-traffic or research deployment. Route
+            it to a low-priority receiver or silence it there rather than
+            deleting it, because on a deployment that should have traffic it is
+            the only rule here that catches an ingress or DNS failure in front
+            of a healthy pod.

--- a/infra/prometheus.yml
+++ b/infra/prometheus.yml
@@ -2,10 +2,18 @@ global:
   scrape_interval: 15s
   evaluation_interval: 15s
 
+# Set to the Alertmanager reachable from this Prometheus. Left unset here
+# because the address differs per environment and a wrong one fails silently:
+# rules evaluate, alerts fire, and nothing receives them. Whoever deploys this
+# has to fill it in, and OO-13's acceptance criteria require observing a rule
+# actually reach a receiver rather than merely evaluating.
 alerting:
   alertmanagers: []
+    # - static_configs:
+    #     - targets: ["alertmanager:9093"]
 
-rule_files: []
+rule_files:
+  - alerts/*.rules.yml
 
 scrape_configs:
   - job_name: prometheus
@@ -17,25 +25,47 @@ scrape_configs:
     static_configs:
       - targets: ["api:8000"]
 
-  - job_name: postgres
-    static_configs:
-      - targets: ["db-exporter:9187"]
-
-  - job_name: redis
-    static_configs:
-      - targets: ["redis-exporter:9121"]
-
-  - job_name: celery-worker-genomic
-    metrics_path: /metrics
-    static_configs:
-      - targets: ["worker-genomic:9100"]
-
-  - job_name: celery-worker-ai
-    metrics_path: /metrics
-    static_configs:
-      - targets: ["worker-ai:9100"]
-
-  - job_name: celery-worker-notify
-    metrics_path: /metrics
-    static_configs:
-      - targets: ["worker-notify:9100"]
+  # ── Targets that were configured but never deployed ──────────────────────
+  #
+  # The four jobs below were scraping endpoints that do not exist anywhere in
+  # this repository, so each reported `up == 0` permanently. That was invisible
+  # while nothing alerted on `up`; with the rules in alerts/ it would page
+  # continuously and train whoever is on call to ignore the one signal that
+  # matters.
+  #
+  # They are commented rather than deleted because the intent is right and the
+  # deployment is what is missing:
+  #
+  #   postgres  db-exporter:9187     no such service in docker-compose.yml or
+  #                                  the Helm chart
+  #   redis     redis-exporter:9121  same
+  #   celery-*  worker-*:9100        the worker services exist in
+  #                                  docker-compose.yml, but nothing in
+  #                                  api/workers/ starts a metrics server, so
+  #                                  port 9100 is not listening
+  #
+  # Deploying the exporters and giving the workers a metrics endpoint is
+  # BACKLOG.md OO-16. Uncomment each job as its exporter is actually deployed.
+  #
+  # - job_name: postgres
+  #   static_configs:
+  #     - targets: ["db-exporter:9187"]
+  #
+  # - job_name: redis
+  #   static_configs:
+  #     - targets: ["redis-exporter:9121"]
+  #
+  # - job_name: celery-worker-genomic
+  #   metrics_path: /metrics
+  #   static_configs:
+  #     - targets: ["worker-genomic:9100"]
+  #
+  # - job_name: celery-worker-ai
+  #   metrics_path: /metrics
+  #   static_configs:
+  #     - targets: ["worker-ai:9100"]
+  #
+  # - job_name: celery-worker-notify
+  #   metrics_path: /metrics
+  #   static_configs:
+  #     - targets: ["worker-notify:9100"]


### PR DESCRIPTION
## Summary

`infra/prometheus.yml` set `rule_files: []` and `alertmanagers: []`, so metrics
were collected and no alert could fire. This adds alerting rules, and corrects
the scrape configuration that adding them exposed.

Closes `OO-13`. Files `OO-16` and `OO-17` for what it cannot cover.

## Problem

Two defects, and the second only becomes harmful once the first is fixed.

**No alerting.** No rule file existed anywhere in the repository. The
consequences are specific: the sustained static-fallback condition described in
`risk_analysis.md` open action 4 escalates a log line to ERROR, and `/ready`
reports dependency health to Kubernetes and to nothing else. A degraded evidence
base, a stalled queue or a crash-looping worker were visible only to someone
reading logs.

**Four of seven scrape jobs targeted exporters that do not exist.**

| Job | Target | State |
|---|---|---|
| `postgres` | `db-exporter:9187` | Not defined in `docker-compose.yml` or the Helm chart |
| `redis` | `redis-exporter:9121` | Not defined in either |
| `celery-worker-genomic` | `worker-genomic:9100` | Service exists in compose; nothing in `api/workers/` starts a metrics server |
| `celery-worker-ai`, `celery-worker-notify` | `worker-*:9100` | Same |

Each reported `up == 0` permanently. That was harmless only while nothing
watched `up`. With an availability rule in place it pages continuously, which
trains an on-call responder to ignore the one signal worth having.

## Changes

- `infra/alerts/openoncology.rules.yml`. Five rules over `up`, `scrape_*` and
  the default `http_*` series that `prometheus_fastapi_instrumentator` installs
  in `api/main.py`: target down, monitoring blind, 5xx rate, p95 latency, and no
  traffic.
- `infra/prometheus.yml`. `rule_files` now loads `alerts/*.rules.yml`. The four
  undeployed jobs are commented out with the reason and a pointer to `OO-16`,
  rather than deleted, since the intent is correct and the deployment is what is
  absent.
- `alertmanagers` remains empty with the address commented. A wrong value fails
  silently: rules evaluate, alerts fire, nothing receives them. `OO-13`'s
  acceptance criteria require observing a rule reach a receiver, which is a
  deployment step.
- `api/tests/test_alert_rules.py`. Fails the build when a rule references a
  metric nothing exports, or a scrape job names a host no deployment defines.

Two details in the rules worth review. `ApiErrorRateHigh` clamps its denominator
so an idle service cannot divide by zero into a spurious page.
`ApiServingNoTraffic` is expected to be noisy on a low-traffic research
deployment; the annotation says to route it low or silence it there rather than
delete it, because it is the only rule that catches an ingress failure in front
of a healthy pod.

## Impact

Configuration and tests only. No application behaviour changes.

Prometheus will now load rule files. On a deployment with no Alertmanager
configured, rules evaluate and alerts have no receiver, which is the same
observable state as before this change.

## Verification

| Check | Result |
|---|---|
| `ruff check api/` | Clean |
| api suite | 1205 passed, 2 xfailed |
| ai suite | 42 passed |
| Coverage | 61.83% against the 52 gate |
| Guard against the previous `prometheus.yml` | Fails on both the empty `rule_files` and the undeployed targets |
| Guard against a rule using `openoncology_mutations_processed_total` | Rejected. That metric is declared in `api/main.py` and never incremented, so a rule on it could not fire |

`promtool check rules` was not run; it is not available in this environment. The
rule files are validated structurally by the test rather than by Prometheus.

## Follow-ups

`OO-16` deploys the exporters, which is what makes queue depth and task age on
`genomic` and `gdpr` alertable at all. `OO-17` covers the degraded-evidence
condition, which emits no metric, and the two metrics declared in `api/main.py`
that nothing increments.
