### PR TITLE
Back up the application database, and document how to restore it

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -94,7 +94,8 @@ Sections are ordered by pipeline position. `/next` pulls from the top of
   - RPO and RTO are written down, even if the numbers are modest
   - `HIPAA_COMPLIANCE.md` moves to ✅ only after that restore, and names what was restored and when
 - **Out of scope**: choosing a managed database, which is a hosting decision
-- **Risk**: high while open. This is the one entry where the failure mode is unrecoverable rather than merely wrong.
+- **Progress 2026-08-29**: nightly `pg_dump` CronJob added to the chart, enabled by default, writing to object storage with a manifest and 30 day retention, plus `docs/RUNBOOK_BACKUP_RESTORE.md`. The entry **stays open**: its acceptance requires an exercised restore, and nobody has run one. Object storage versioning is still absent, so a database-only restore yields rows referencing missing files, and Keycloak's database is still unbacked.
+- **Risk**: high while open. This is the one entry where the failure mode is unrecoverable rather than merely wrong. Lower than it was, since a dump now exists; not closed, because a backup nobody has restored is a belief about a file.
 
 ### OO-13: Prometheus scrapes metrics that can never alert anyone
 - **Why**: `infra/prometheus.yml` has `alertmanagers: []` and `rule_files: []`, and no rule file exists anywhere in the repository. Every metric is collected and nothing can ever fire. The consequences are specific rather than general: the sustained static-fallback alarm from risk_analysis open action 4 escalates a **log line** to ERROR, and `/ready` reports Postgres and Redis health to Kubernetes but to nobody else, so a degraded evidence base, a stalled `genomic` queue, or a worker crash-looping are all invisible unless a person happens to be reading logs.

--- a/api/tests/test_deployment_manifests.py
+++ b/api/tests/test_deployment_manifests.py
@@ -278,3 +278,63 @@ def test_workers_declare_a_grace_period(routed_queues, helm_values):
         grace = cfg.get("terminationGracePeriodSeconds")
         assert grace is not None, f"worker {queue!r} has no terminationGracePeriodSeconds"
         assert grace > 30, f"worker {queue!r} grace period {grace}s is at or below the default"
+
+
+# ── The database is backed up ────────────────────────────────────────────────
+#
+# OO-12. Nothing backed the application database up, and HIPAA_COMPLIANCE.md
+# claimed otherwise, citing WAL archiving that was never configured. Persistence
+# is not backup: losing the PVC took every submission and result with it.
+
+def test_the_chart_defines_a_database_backup(helm_values):
+    backup = HELM / "templates" / "backup-cronjob.yaml"
+    assert backup.exists(), "the chart has no database backup"
+    assert helm_values["backup"]["enabled"] is True, (
+        "a backup that must be switched on is off in the deployment that needed it"
+    )
+
+
+def test_the_backup_targets_the_application_database_not_keycloaks():
+    """
+    The chart runs two PostgreSQL instances. `{release}-postgresql` is the
+    Bitnami sub-chart the application uses; `{fullname}-postgres` is Keycloak's.
+    The compliance document previously cited the second while describing the
+    first.
+    """
+    text = (HELM / "templates" / "backup-cronjob.yaml").read_text(encoding="utf-8")
+    assert "-postgresql" in text
+    assert 'openoncology.fullname" . }}-postgres"' not in text
+
+
+def test_the_backup_fails_loudly():
+    """
+    A backup that fails quietly is worse than none, because it is believed. No
+    `|| true` on the dump or the upload, and a size floor so an empty dump is an
+    error rather than a small file.
+    """
+    text = (HELM / "templates" / "backup-cronjob.yaml").read_text(encoding="utf-8")
+    assert "set -euo pipefail" in text
+    assert "backup aborted" in text, "no size floor on the dump"
+    script = text[text.index("set -euo pipefail"):]
+    dump_line = [ln for ln in script.splitlines() if "pg_dump" in ln]
+    assert dump_line and "|| true" not in dump_line[0]
+
+
+def test_the_backup_writes_a_manifest():
+    """A restore is verified against recorded bytes, not against a file existing;
+    a zero-byte object is also a file."""
+    text = (HELM / "templates" / "backup-cronjob.yaml").read_text(encoding="utf-8")
+    assert "manifest.json" in text
+    assert '"bytes"' in text
+
+
+def test_a_restore_procedure_is_documented():
+    """
+    OO-12's acceptance requires an exercised restore. The runbook is the
+    prerequisite for that, and it states plainly that the drill has not been run.
+    """
+    runbook = REPO_ROOT / "docs" / "RUNBOOK_BACKUP_RESTORE.md"
+    assert runbook.exists()
+    text = runbook.read_text(encoding="utf-8")
+    assert "alembic_version" in text, "a restore is not verified without a schema check"
+    assert "Restore drill" in text

--- a/docs/RUNBOOK_BACKUP_RESTORE.md
+++ b/docs/RUNBOOK_BACKUP_RESTORE.md
@@ -1,0 +1,130 @@
+# Runbook: database backup and restore
+
+**What exists.** A CronJob (`infra/helm/templates/backup-cronjob.yaml`) takes a
+nightly `pg_dump` of the application database, gzips it, and writes it to object
+storage with a manifest recording the timestamp, database and byte count.
+Retention is 30 days by default.
+
+**What does not exist yet, and why OO-12 stays open.** Nobody has performed a
+restore. Until someone has, this is a job that produces files, not a contingency
+plan. `HIPAA_COMPLIANCE.md` keeps §164.308 at not-implemented until the drill in
+this document has been run and dated, which is deliberate: the previous version
+of that row was marked satisfied on the strength of an intention.
+
+---
+
+## What is and is not covered
+
+| Data | Covered | Notes |
+|---|---|---|
+| Application database | Yes | Nightly logical dump |
+| Keycloak database | **No** | A separate PostgreSQL (`templates/postgres.yaml`). Losing it loses user accounts and the realm, though not patient data. See OO-9 |
+| Object storage: raw uploads, VCFs, reports | **No** | Versioning is still not enabled. The dump carries the database rows that reference these objects, so a database-only restore yields records pointing at absent files |
+| Redis | No, by design | Broker and cache. Losing it loses in-flight tasks, which are `acks_late` and redeliverable |
+
+The second and third rows are gaps, not decisions. They are recorded here rather
+than left for someone to discover mid-incident.
+
+## Recovery objectives
+
+Not yet agreed. Stating the implied ones so they can be argued with:
+
+- **RPO**, worst-case data loss: up to 24 hours, set by the nightly schedule.
+- **RTO**, time to restore: unmeasured. The drill below is what measures it.
+
+A 24 hour RPO is a decision someone should make deliberately for clinical data,
+not inherit from a default cron expression.
+
+---
+
+## Verify a backup exists and is plausible
+
+Do this weekly. It takes a minute and is the only thing standing between a
+believed backup and a real one.
+
+```bash
+mc ls store/openoncology-backups/db/ | tail -5
+mc cat store/openoncology-backups/db/<STAMP>.manifest.json
+```
+
+The manifest records the byte count the job measured. Compare it against the
+object's actual size:
+
+```bash
+mc stat store/openoncology-backups/db/<STAMP>.sql.gz
+```
+
+A mismatch means a truncated upload. The job aborts on a dump under 1 KiB, so a
+missing database produces a failed job rather than a small file, but a partial
+upload is not something the job can detect from inside.
+
+## Restore drill
+
+Run into a scratch namespace or a local container. Never into production as a
+first attempt.
+
+```bash
+mc cp store/openoncology-backups/db/<STAMP>.sql.gz ./restore.sql.gz
+
+docker run -d --name restore-test \
+  -e POSTGRES_PASSWORD=scratch -e POSTGRES_DB=openoncology \
+  -e POSTGRES_USER=openoncology postgres:16
+
+gunzip -c restore.sql.gz | docker exec -i restore-test \
+  psql -U openoncology -d openoncology
+```
+
+Then check the restore is a database and not merely a successful command:
+
+```bash
+docker exec restore-test psql -U openoncology -d openoncology -c "
+  SELECT
+    (SELECT count(*) FROM submissions) AS submissions,
+    (SELECT count(*) FROM mutations)   AS mutations,
+    (SELECT count(*) FROM results)     AS results,
+    (SELECT max(version_num) FROM alembic_version) AS schema_version;
+"
+```
+
+Three things to confirm, in this order:
+
+1. **Row counts are non-zero and roughly match production.** A dump that
+   restores cleanly and is empty is the failure this is looking for.
+2. **`alembic_version` matches the migration head the application expects.** A
+   dump from before a migration restores into a schema the running code cannot
+   use. Compare against `python scripts/check_migration_chain.py`.
+3. **Object references resolve.** Take a handful of `submissions.dna_s3_key`
+   values and confirm the objects exist. They will not, if object storage was
+   lost too, and that is the gap in the table above rather than a restore
+   failure.
+
+Record the date, the dump restored, the row counts and the elapsed time. That
+elapsed time is the RTO, and it is the number this document currently cannot
+state.
+
+## Restoring into production
+
+Only after the drill has been run at least once.
+
+1. Stop the API and every worker, so nothing writes during the restore. Scale
+   the `api`, `worker-*` and `beat` deployments to zero.
+2. Confirm the target database is the one you mean. There are two PostgreSQL
+   instances in this chart and the application's is the Bitnami sub-chart at
+   `{release}-postgresql`, not `{release}-openoncology-postgres`, which is
+   Keycloak's.
+3. Restore into a fresh database, not over the live one. Rename the damaged
+   database rather than dropping it; it may be the only copy of anything the
+   backup missed.
+4. Run `alembic upgrade head` if the dump predates the deployed code.
+5. Bring workers up before the API, so the queues drain before new work arrives.
+
+## Known limitations
+
+- Logical dumps, so no point-in-time recovery. The most recent 24 hours of
+  writes are lost in a total-loss scenario. WAL archiving would fix this and
+  belongs to the Bitnami sub-chart's configuration.
+- The backup image is pinned by tag, not digest, so the tool versions can move
+  under a restore. Same class as OO-6 for the pipeline containers.
+- Nothing alerts on a failed backup. The CronJob fails loudly in Kubernetes, and
+  Kubernetes tells nobody. `OO-16` deploys the exporters that would make
+  `kube_job_failed` alertable.

--- a/infra/helm/templates/backup-cronjob.yaml
+++ b/infra/helm/templates/backup-cronjob.yaml
@@ -1,0 +1,133 @@
+{{/*
+Scheduled logical backup of the application database into object storage.
+
+BACKLOG.md OO-12. Nothing backed this data up. The Bitnami sub-chart provides a
+PersistentVolume, and persistence is not backup: losing the PVC, a failed
+migration, or corruption took every submission, mutation and result with no
+recovery path. HIPAA_COMPLIANCE.md claimed a contingency plan existed, citing
+WAL archiving that was never configured.
+
+`pg_dump` rather than WAL archiving on purpose. WAL gives point-in-time recovery
+and needs archive storage wired into the database server itself, which is the
+Bitnami sub-chart's territory and changes with its version. A logical dump is
+coarser, is entirely inside this chart, and can be restored into a different
+PostgreSQL version, which is what actually gets used when someone is recovering
+under pressure. Point-in-time recovery is a later decision, not a prerequisite
+for having any backup at all.
+
+Two properties this deliberately has:
+
+  * It fails loudly. `set -euo pipefail`, no `|| true`, and
+    `backoffLimit: 2`. A backup that fails quietly is worse than none, because
+    it is believed.
+  * It writes a manifest beside each dump recording the timestamp, the database
+    and the byte count. A restore is verified against that rather than against
+    the existence of a file, since a zero-byte object is also a file.
+
+What this does NOT provide, and OO-12 stays open until it does: an exercised
+restore. A backup nobody has restored is a belief about a file.
+*/}}
+{{- if .Values.backup.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "openoncology.fullname" . }}-db-backup
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "openoncology.labels" . | nindent 4 }}
+    app.kubernetes.io/component: db-backup
+spec:
+  schedule: {{ .Values.backup.schedule | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: {{ .Values.backup.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.backup.failedJobsHistoryLimit }}
+  # Kubernetes drops a scheduled run silently if the controller was unavailable
+  # past this window. Without it a missed backup leaves no trace at all.
+  startingDeadlineSeconds: {{ .Values.backup.startingDeadlineSeconds }}
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        metadata:
+          labels:
+            {{- include "openoncology.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: db-backup
+        spec:
+          restartPolicy: Never
+          serviceAccountName: {{ include "openoncology.serviceAccountName" . }}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+            fsGroup: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: backup
+              image: "{{ .Values.backup.image.repository }}:{{ .Values.backup.image.tag }}"
+              imagePullPolicy: {{ .Values.backup.image.pullPolicy }}
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: ["ALL"]
+              env:
+                - name: PGHOST
+                  value: {{ printf "%s-postgresql" .Release.Name | quote }}
+                - name: PGPORT
+                  value: "5432"
+                - name: PGUSER
+                  value: {{ .Values.postgresql.auth.username | quote }}
+                - name: PGDATABASE
+                  value: {{ .Values.postgresql.auth.database | quote }}
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.postgresql.auth.existingSecret }}
+                      key: {{ .Values.postgresql.auth.secretKeys.userPasswordKey }}
+                - name: MC_HOST_store
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.backup.objectStore.credentialsSecret }}
+                      key: {{ .Values.backup.objectStore.credentialsKey }}
+                - name: BACKUP_BUCKET
+                  value: {{ .Values.backup.objectStore.bucket | quote }}
+                - name: RETENTION_DAYS
+                  value: {{ .Values.backup.retentionDays | quote }}
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -euo pipefail
+                  STAMP="$(date -u +%Y-%m-%dT%H-%M-%SZ)"
+                  DUMP="/tmp/${PGDATABASE}-${STAMP}.sql.gz"
+
+                  pg_dump --format=plain --no-owner --no-privileges \
+                    | gzip -9 > "$DUMP"
+
+                  BYTES="$(wc -c < "$DUMP")"
+                  # A dump smaller than this is not a database. Catching it here
+                  # is the difference between a failed backup and a believed one.
+                  if [ "$BYTES" -lt 1024 ]; then
+                    echo "backup aborted: dump is ${BYTES} bytes" >&2
+                    exit 1
+                  fi
+
+                  printf '{"timestamp":"%s","database":"%s","bytes":%s,"format":"pg_dump-plain-gzip"}\n' \
+                    "$STAMP" "$PGDATABASE" "$BYTES" > /tmp/manifest.json
+
+                  mc cp "$DUMP" "store/${BACKUP_BUCKET}/db/${STAMP}.sql.gz"
+                  mc cp /tmp/manifest.json "store/${BACKUP_BUCKET}/db/${STAMP}.manifest.json"
+
+                  mc rm --recursive --force --older-than "${RETENTION_DAYS}d" \
+                    "store/${BACKUP_BUCKET}/db/" || true
+
+                  echo "backup complete: ${STAMP}, ${BYTES} bytes"
+              volumeMounts:
+                - name: tmp
+                  mountPath: /tmp
+              resources:
+                {{- toYaml .Values.backup.resources | nindent 16 }}
+          volumes:
+            - name: tmp
+              emptyDir: {}
+{{- end }}

--- a/infra/helm/values.yaml
+++ b/infra/helm/values.yaml
@@ -158,6 +158,43 @@ beat:
       cpu: "200m"
       memory: "256Mi"
 
+# ── Database backup ───────────────────────────────────────────────────────────
+# Nothing backed the application database up before this existed, and
+# HIPAA_COMPLIANCE.md claimed otherwise. Persistence is not backup: losing the
+# PVC, a failed migration or corruption took every submission and result with it.
+#
+# Enabled by default. A backup that has to be switched on is one that is off in
+# the deployment that needed it, and the failure is only discovered during a
+# recovery. It requires `objectStore.credentialsSecret` to exist; if it does not,
+# the CronJob fails visibly rather than skipping quietly.
+backup:
+  enabled: true
+  # 02:00 UTC, before the 03:00 GDPR retention sweep in beat_schedule, so a day's
+  # backup captures the rows that sweep is about to delete.
+  schedule: "0 2 * * *"
+  retentionDays: 30
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 7
+  # A run skipped because the controller was down leaves no trace otherwise.
+  startingDeadlineSeconds: 3600
+  image:
+    # Carries both pg_dump and mc. Pin to a digest before relying on this.
+    repository: bitnami/postgresql
+    tag: "16"
+    pullPolicy: IfNotPresent
+  objectStore:
+    bucket: openoncology-backups
+    # An `MC_HOST_store` alias URL, e.g. https://KEY:SECRET@minio.example:9000
+    credentialsSecret: openoncology-backup-secrets
+    credentialsKey: mc-host-url
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "256Mi"
+    limits:
+      cpu: "500m"
+      memory: "1Gi"
+
 # ── PostgreSQL (Bitnami sub-chart) ────────────────────────────────────────────
 postgresql:
   enabled: true


### PR DESCRIPTION
## Summary

Adds a nightly logical backup of the application database to object storage, and
a runbook covering verification, a restore drill and production recovery.

Addresses `OO-12` in part. The entry stays open: its acceptance criteria require
an exercised restore, and none has been performed.

## Problem

Nothing backed up the application database. The Bitnami sub-chart provides a
PersistentVolume, which is not a backup. Loss of the PVC, a failed migration, or
corruption would take every submission, mutation and result with no recovery
path.

`HIPAA_COMPLIANCE.md` recorded §164.308 contingency planning as satisfied,
citing WAL archiving and object-store versioning. Neither was configured, and
the file it cited provisions Keycloak's database rather than the application's.
That row was corrected in an earlier change; this addresses the gap behind it.

## Approach

`pg_dump` rather than WAL archiving. WAL provides point-in-time recovery and
requires archive storage configured inside the database server, which belongs to
the Bitnami sub-chart and varies with its version. A logical dump is coarser,
lives entirely within this chart, and restores into a different PostgreSQL
version, which is the situation that arises during an actual recovery.
Point-in-time recovery remains a later decision rather than a prerequisite for
having any backup.

## Changes

- `infra/helm/templates/backup-cronjob.yaml`. Nightly `pg_dump`, gzipped,
  uploaded with a manifest recording timestamp, database and byte count. 30 day
  retention. Scheduled 02:00 UTC, an hour before the GDPR retention sweep in
  `beat_schedule`, so each backup contains the rows that sweep will delete.
- `infra/helm/values.yaml`. `backup.*`, enabled by default.
- `docs/RUNBOOK_BACKUP_RESTORE.md`. Weekly verification, restore drill,
  production procedure, and an explicit statement of what is not covered.
- Five assertions in `api/tests/test_deployment_manifests.py`.

Two properties worth review:

**It fails loudly.** `set -euo pipefail`, no `|| true` on the dump or upload,
`backoffLimit: 2`, and an abort if the dump is under 1 KiB. A dump that restores
cleanly and is empty is the failure this is written to catch.

**It targets the right database.** The chart runs two PostgreSQL instances. The
job addresses `{release}-postgresql`, the Bitnami sub-chart the application uses,
not `{fullname}-postgres`, which is Keycloak's. A test asserts this, because the
compliance document previously confused exactly these two.

## Impact

Adds a CronJob and requires `backup.objectStore.credentialsSecret` to exist. If
it does not, the job fails visibly rather than skipping.

Enabled by default rather than opt-in. A backup that must be switched on is off
in the deployment that needed it, and that is discovered during a recovery.

No application behaviour changes.

## What this does not cover

Stated in the runbook rather than left to be found during an incident.

| Gap | Consequence |
|---|---|
| Object storage has no versioning | A database-only restore produces rows referencing absent files |
| Keycloak's database is not backed up | Losing it loses accounts and the realm, though not patient data. See `OO-9` |
| No alert on a failed backup | The CronJob fails to Kubernetes, which notifies nobody until `OO-16` deploys the exporters |
| Logical dumps only | Up to 24 hours of writes lost in a total-loss scenario |

RPO is 24 hours by implication of the schedule, which is a decision someone
should make deliberately for clinical data. RTO is unmeasured; the drill is what
measures it.

## Verification

| Check | Result |
|---|---|
| `ruff check api/` | Clean |
| api suite | 1196 passed, 2 xfailed |
| ai suite | 42 passed |
| Coverage | 61.83% against the 52 gate |
| Helm render and kubeconform | Runs in the `validate-manifests` CI job |

The CronJob has not been executed. No cluster is available in this environment,
so the dump, the upload and the retention sweep are unexercised. That is the
substance of what `OO-12` still has open.
