### PR TITLE
Network policies for the Helm chart, off by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,6 +315,59 @@ jobs:
           check 'terminationGracePeriodSeconds' 'shutdown is given a grace period'
           exit $fail
 
+      # NetworkPolicies are off by default, so the render above never sees them.
+      # A policy that fails to render, or whose podSelector matches no pod the
+      # chart creates, is a policy that silently denies traffic in production.
+      - name: Render and check the network policies
+        shell: bash
+        run: |
+          set -euo pipefail
+          helm template openoncology infra/helm             --values infra/helm/values.yaml             --values infra/helm/values.production.yaml             --set networkPolicy.enabled=true             --api-versions autoscaling/v2             --namespace openoncology > rendered-netpol.yaml
+          test -s rendered-netpol.yaml
+          kubeconform -strict -summary -ignore-missing-schemas             -kubernetes-version 1.29.0 rendered-netpol.yaml
+          # Inline rather than a helper under scripts/, which is covered by the
+          # PreToolUse guard and is not a path to add tooling to casually.
+          python3 - rendered-netpol.yaml <<'CHECK'
+          import sys, yaml
+
+          docs = [d for d in yaml.safe_load_all(open(sys.argv[1])) if d]
+          policies = [d for d in docs if d.get("kind") == "NetworkPolicy"]
+          pods = [d for d in docs if d.get("kind") in ("Deployment", "StatefulSet")]
+          cronjobs = [d for d in docs if d.get("kind") == "CronJob"]
+
+          def pod_labels(d):
+              if d["kind"] == "CronJob":
+                  return d["spec"]["jobTemplate"]["spec"]["template"]["metadata"].get("labels", {})
+              return d["spec"]["template"]["metadata"].get("labels", {})
+
+          workloads = [pod_labels(d) for d in pods + cronjobs]
+          assert policies, "networkPolicy.enabled=true rendered no NetworkPolicy"
+          assert workloads, "no workloads rendered to check selectors against"
+
+          def matches(sel, labels):
+              for k, v in (sel.get("matchLabels") or {}).items():
+                  if labels.get(k) != v:
+                      return False
+              for e in (sel.get("matchExpressions") or []):
+                  got = labels.get(e["key"])
+                  if e["operator"] == "In" and got not in e["values"]:
+                      return False
+              return True
+
+          unmatched = []
+          for p in policies:
+              sel = p["spec"].get("podSelector", {})
+              if not sel:
+                  continue  # {} is the default-deny, matches everything
+              if not any(matches(sel, w) for w in workloads):
+                  unmatched.append(p["metadata"]["name"])
+
+          if unmatched:
+              print("podSelector matches no workload the chart renders:", unmatched)
+              sys.exit(1)
+          print(f"ok: {len(policies)} policies, every podSelector matches a rendered workload")
+          CHECK
+
       - name: Validate the standalone k8s manifests
         run: |
           kubeconform -strict -summary -ignore-missing-schemas \

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -24,21 +24,6 @@ Sections are ordered by pipeline position. `/next` pulls from the top of
 - **Risk**: low
 -->
 
-### OO-5: Port the NetworkPolicy set from infra/k8s into the Helm chart
-- **Why**: `infra/k8s/namespace.yaml` carries default-deny plus four allow rules; the chart carries none, and the chart is what production deploys from. Same drift class as the readiness probe and the missing beat Deployment, both fixed on `fix/deployment-and-auth-hardening`. Not fixed alongside them because it cannot be ported verbatim: `allow-workers-egress` selects on `app.kubernetes.io/part-of: openoncology-workers`, and `_helpers.tpl` never emits that label, so the rule as written selects nothing. Shipping a default-deny policy whose allow rules match no pods severs every worker from Postgres and Redis, and it renders and lints clean.
-- **Files**: infra/helm/templates/networkpolicy.yaml, infra/helm/templates/_helpers.tpl, infra/helm/values.yaml, api/tests/test_deployment_manifests.py
-- **Acceptance**:
-  - Every allow rule's selector matches labels the chart actually emits, verified against `helm template` output rather than read off the k8s copy
-  - Worker, beat, api and web pods each keep egress to Postgres, Redis and 443
-  - A test asserts every NetworkPolicy podSelector matches at least one rendered pod
-  - `helm template` output passes kubeconform in the `validate-manifests` job
-- **Topology found while scoping this, and it invalidates a verbatim port**: the chart runs *two* Postgres instances. `values.yaml` enables the Bitnami `postgresql` sub-chart and `openoncology.databaseUrl` points the app at `{release}-postgresql`; separately `templates/postgres.yaml` renders an ungated StatefulSet at `{fullname}-postgres` carrying `component: postgres`, and that one is Keycloak's database (`keycloak.yaml:32`). So an egress rule allowing `component: postgres` reaches Keycloak's database and not the application's. The Bitnami pods carry Bitnami's labels, not this chart's, and those differ by sub-chart version. Redis is Bitnami-only; there is no chart-local template for it.
-  Workers also render four distinct component values (`worker-genomic`, `worker-ai`, `worker-notify`, `worker-gdpr`), so one selector cannot match them by `component` and needs either a shared label or `matchExpressions`.
-  The gdpr worker needs egress the others do not: it calls Keycloak's admin API to delete users and MinIO to delete objects (`workers/gdpr_worker.py`). A policy modelled on the other three silently breaks erasure, which is the obligation #130 just restored.
-- **Recommended shape**: gate the whole set behind `networkPolicy.enabled`, default **false**. A wrong policy fails closed, there is no cluster to test against here, and default-on means the first person to find out is whoever deploys it. Drive the datastore selectors from values so an operator can match their actual sub-chart labels.
-- **Out of scope**: the raw `infra/k8s` manifests, which already have this
-- **Risk**: medium — a wrong policy fails closed and silently
-
 ### OO-6: Pin the pipeline's container images by digest
 - **Why**: `pipeline/modules/*.nf` pin containers by tag (`broadinstitute/gatk:4.5.0.0`, `etal/cnvkit:0.9.10`, `docker.io/szarate/manta:1.6.0`, two biocontainers). A tag is mutable. The variant-calling validation gate asks which pipeline produced a call set, and a tag cannot answer it: the same tag six months apart is a different image and possibly different calls. `nextflow.config` now declares `gatk_version` once, so the GATK pair can no longer diverge, but neither is pinned to an immutable reference.
 - **Files**: pipeline/nextflow.config, pipeline/modules/*.nf, api/tests/test_pipeline_config.py
@@ -128,6 +113,17 @@ Sections are ordered by pipeline position. `/next` pulls from the top of
   - `test_alert_rules.py`'s allowed-metric set grows only alongside the code that emits them
 - **Out of scope**: what the alert threshold should be, which is the same policy question as `degraded_evidence_alert_after` itself
 - **Risk**: low to implement. Worth noting the evidence path is adjacent to ranking, so the metric should be emitted where the fallback is already logged rather than anywhere new.
+### OO-18: The chart points the application at a MinIO that it never deploys
+- **Why**: `configmap.yaml:18` sets `MINIO_ENDPOINT` to `{release}-minio:9000` and `values.yaml` carries a `minio:` block with an image, a 200Gi persistence size and a `secretRef`. No template creates a MinIO Deployment, StatefulSet or Service, and `Chart.yaml` lists only `postgresql` and `redis` as dependencies. A `helm install` therefore produces an application configured to reach object storage that does not exist. Every VCF upload, report write and GDPR object deletion fails, and so does the backup CronJob added in #141, which writes dumps through `mc`. Object storage is where patient genomic files live, so this is not a peripheral gap. Found while scoping OO-5, because a NetworkPolicy cannot grant egress to a pod nothing creates.
+- **Files**: infra/helm/templates/minio.yaml, infra/helm/Chart.yaml, infra/helm/values.yaml, api/tests/test_deployment_manifests.py
+- **Acceptance**:
+  - MinIO is deployed by the chart, or added as a sub-chart dependency, or `values.yaml` and the ConfigMap are rewritten to describe an external object store the operator supplies
+  - `MINIO_ENDPOINT` resolves to something the chart or its dependencies actually create
+  - `networkPolicy.datastores.objectStore` selects the pods that result
+  - A test asserts every service the ConfigMap names is created by the chart or declared as a dependency, which is the general form of this defect
+- **Out of scope**: whether to run MinIO in-cluster at all, which is a hosting decision
+- **Risk**: high. The deployment cannot store a patient file. It ranks below OO-12 only because it fails loudly on first use rather than silently until a recovery.
+
 ---
 
 ## In progress

--- a/api/tests/test_deployment_manifests.py
+++ b/api/tests/test_deployment_manifests.py
@@ -338,3 +338,117 @@ def test_a_restore_procedure_is_documented():
     text = runbook.read_text(encoding="utf-8")
     assert "alembic_version" in text, "a restore is not verified without a schema check"
     assert "Restore drill" in text
+
+
+# ── Network policies ─────────────────────────────────────────────────────────
+#
+# OO-5. infra/k8s/namespace.yaml carried a default-deny set and the chart carried
+# none. It could not be ported verbatim: `allow-workers-egress` selects on
+# `app.kubernetes.io/part-of`, a label _helpers.tpl never emits, so the rule
+# matched nothing and a default-deny alongside it would have severed every
+# worker from Postgres and Redis while rendering and linting clean.
+#
+# The rendered check lives in the validate-manifests CI job, which can run helm.
+# These assert the properties that are visible in the template.
+
+NETPOL = HELM / "templates" / "networkpolicy.yaml"
+
+
+def test_the_chart_has_network_policies():
+    assert NETPOL.exists()
+
+
+def test_network_policies_are_off_by_default(helm_values):
+    """
+    A NetworkPolicy fails closed and nothing here can test one against a real
+    cluster. On by default means the first person to discover a wrong selector
+    is whoever deploys it.
+    """
+    assert helm_values["networkPolicy"]["enabled"] is False
+
+
+def test_dns_egress_is_allowed():
+    """
+    The rule everything else depends on. Under default-deny, egress to kube-dns
+    must be explicit or every lookup fails, and the symptom is every dependency
+    appearing to be down at once.
+    """
+    text = NETPOL.read_text(encoding="utf-8")
+    assert "allow-dns" in text
+    assert "port: 53" in text
+    assert "protocol: UDP" in text
+
+
+def _netpol_without_comments() -> str:
+    """
+    Helm comment blocks explain why the k8s copy could not be ported, and quote
+    the label that made it unusable. Scanning them as if they were selectors is
+    how the first version of this test failed on its own documentation.
+    """
+    return re.sub(r"\{\{/\*.*?\*/\}\}", "", NETPOL.read_text(encoding="utf-8"), flags=re.S)
+
+
+def test_no_policy_selects_on_a_label_the_chart_never_emits():
+    """
+    The specific defect that made the k8s copy unusable here.
+    `app.kubernetes.io/part-of` is selected on there and emitted nowhere.
+    """
+    text = _netpol_without_comments()
+    emitted = (HELM / "templates" / "_helpers.tpl").read_text(encoding="utf-8")
+    # component is set inline by each template rather than by the helper.
+    known = set(re.findall(r"(app\.kubernetes\.io/[a-z-]+):", emitted)) | {
+        "app.kubernetes.io/component"
+    }
+    # Two forms, and missing the second is how the first version of this guard
+    # passed a deliberately broken policy: matchLabels writes `label: value`,
+    # matchExpressions writes `key: label`.
+    selectors = set(re.findall(r"(app\.kubernetes\.io/[a-z-]+):", text))
+    selectors |= set(re.findall(r"key:\s*(app\.kubernetes\.io/[a-z-]+)", text))
+    unknown = sorted(selectors - known)
+    assert not unknown, f"policies select on labels no template emits: {unknown}"
+
+
+def test_workers_are_matched_by_expression_not_equality(helm_values):
+    """
+    workers.yaml renders one Deployment per queue, each with its own component
+    value, so a single equality selector cannot reach them all.
+    """
+    text = NETPOL.read_text(encoding="utf-8")
+    assert "matchExpressions" in text
+    assert "operator: In" in text
+    assert len(helm_values["workers"]) >= 4
+
+
+def test_the_gdpr_worker_keeps_its_keycloak_egress():
+    """
+    erase_patient_data calls Keycloak's admin API to delete the user. A policy
+    modelled on the other three workers breaks erasure silently, which is the
+    obligation #130 restored.
+    """
+    text = NETPOL.read_text(encoding="utf-8")
+    assert "worker-gdpr" in text
+    gdpr = text[text.index("worker-gdpr-keycloak"):]
+    assert "component: keycloak" in gdpr
+
+
+def test_datastore_selectors_are_values_not_literals(helm_values):
+    """
+    Bitnami has changed these labels between chart majors, and a wrong one
+    denies the database while rendering perfectly.
+    """
+    stores = helm_values["networkPolicy"]["datastores"]
+    assert set(stores) >= {"postgresql", "redis", "objectStore"}
+    text = NETPOL.read_text(encoding="utf-8")
+    assert "$np.datastores.postgresql" in text
+
+
+def test_the_application_database_is_not_confused_with_keycloaks():
+    """
+    `component: postgres` is Keycloak's StatefulSet. The application uses the
+    Bitnami sub-chart. An egress rule on the former allows the wrong database
+    and denies the right one.
+    """
+    text = NETPOL.read_text(encoding="utf-8")
+    api_policy = text[text.index("-api\n"):text.index("-web\n")]
+    assert "$np.datastores.postgresql" in api_policy
+    assert "component: postgres\n" not in api_policy

--- a/infra/helm/templates/networkpolicy.yaml
+++ b/infra/helm/templates/networkpolicy.yaml
@@ -1,0 +1,325 @@
+{{/*
+NetworkPolicies for the chart.
+
+BACKLOG.md OO-5. infra/k8s/namespace.yaml has carried a default-deny set since
+the beginning and the chart, which is what production deploys from, had none.
+This is not a verbatim port: the k8s copy could not have worked here, for three
+reasons found while scoping it.
+
+  * `allow-workers-egress` selects on `app.kubernetes.io/part-of:
+    openoncology-workers`, and `_helpers.tpl` emits no such label. The rule
+    matched nothing.
+  * Workers render four distinct component values, so no single equality
+    selector reaches them. They are matched with `In` here.
+  * `component: postgres` is *Keycloak's* database. The application talks to the
+    Bitnami sub-chart at `{release}-postgresql`, which carries Bitnami's labels
+    and not this chart's. An egress rule written against `component: postgres`
+    allows the wrong database and denies the right one.
+
+DEFAULT OFF. A NetworkPolicy fails closed, nothing in this repository can be
+tested against a real cluster, and the labels of the sub-chart pods vary by
+sub-chart version. Enabling it is a deliberate act by someone who can watch what
+happens. `helm template --set networkPolicy.enabled=true` is rendered and
+validated in CI, which proves it renders, not that it is correct for your
+cluster.
+
+THE DNS RULE IS LOAD-BEARING. Under default-deny, egress to kube-dns must be
+allowed explicitly or every name lookup fails, and the symptom is every
+dependency appearing to be down at once. It is first below for that reason.
+
+Sub-chart selectors are values, not literals, because Bitnami has changed these
+labels between chart majors and a wrong one here denies the database silently.
+Check them against `kubectl get pod --show-labels` before enabling.
+*/}}
+{{- if .Values.networkPolicy.enabled }}
+{{- $fullName := include "openoncology.fullname" . }}
+{{- $ns := .Values.namespace }}
+{{- $np := .Values.networkPolicy }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ $fullName }}-default-deny
+  namespace: {{ $ns }}
+  labels:
+    {{- include "openoncology.labels" . | nindent 4 }}
+spec:
+  podSelector: {}
+  policyTypes: [Ingress, Egress]
+---
+{{/* Without this, nothing resolves and every dependency looks unreachable. */}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ $fullName }}-allow-dns
+  namespace: {{ $ns }}
+  labels:
+    {{- include "openoncology.labels" . | nindent 4 }}
+spec:
+  podSelector: {}
+  policyTypes: [Egress]
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ $np.dnsNamespace }}
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ $fullName }}-api
+  namespace: {{ $ns }}
+  labels:
+    {{- include "openoncology.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "openoncology.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: api
+  policyTypes: [Ingress, Egress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ $np.ingressNamespace }}
+    # The web pod calls the API server-side as well as through the browser.
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "openoncology.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: web
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              {{- toYaml $np.datastores.postgresql | nindent 14 }}
+      ports:
+        - port: 5432
+    - to:
+        - podSelector:
+            matchLabels:
+              {{- toYaml $np.datastores.redis | nindent 14 }}
+      ports:
+        - port: 6379
+    - to:
+        - podSelector:
+            matchLabels:
+              {{- toYaml $np.datastores.objectStore | nindent 14 }}
+      ports:
+        - port: 9000
+    - to:
+        - podSelector:
+            matchLabels:
+              {{- include "openoncology.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: keycloak
+      ports:
+        - port: 8080
+    # OncoKB, OpenTargets, ChEMBL, AlphaFold, Stripe, Resend, Sentry.
+    - ports:
+        - port: 443
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ $fullName }}-web
+  namespace: {{ $ns }}
+  labels:
+    {{- include "openoncology.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "openoncology.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: web
+  policyTypes: [Ingress, Egress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ $np.ingressNamespace }}
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              {{- include "openoncology.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: api
+      ports:
+        - port: {{ .Values.api.port }}
+    - ports:
+        - port: 443
+---
+{{/*
+Workers and beat. `In` rather than equality because workers.yaml renders one
+Deployment per queue and each carries its own component value, so no single
+equality selector reaches them all.
+*/}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ $fullName }}-workers
+  namespace: {{ $ns }}
+  labels:
+    {{- include "openoncology.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchExpressions:
+      - key: app.kubernetes.io/component
+        operator: In
+        values:
+          {{- range $name, $cfg := .Values.workers }}
+          - worker-{{ $name }}
+          {{- end }}
+          - beat
+  policyTypes: [Egress]
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              {{- toYaml $np.datastores.postgresql | nindent 14 }}
+      ports:
+        - port: 5432
+    - to:
+        - podSelector:
+            matchLabels:
+              {{- toYaml $np.datastores.redis | nindent 14 }}
+      ports:
+        - port: 6379
+    - to:
+        - podSelector:
+            matchLabels:
+              {{- toYaml $np.datastores.objectStore | nindent 14 }}
+      ports:
+        - port: 9000
+    - ports:
+        - port: 443
+---
+{{/*
+The gdpr worker alone needs Keycloak: erase_patient_data calls the admin API to
+delete the user. Policies are additive, so this grants that on top of the shared
+worker rules above. Omitting it breaks erasure silently, which is the obligation
+#130 restored.
+*/}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ $fullName }}-worker-gdpr-keycloak
+  namespace: {{ $ns }}
+  labels:
+    {{- include "openoncology.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "openoncology.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: worker-gdpr
+  policyTypes: [Egress]
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              {{- include "openoncology.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: keycloak
+      ports:
+        - port: 8080
+---
+{{/*
+Keycloak talks to the chart-local StatefulSet, which is a different database
+from the application's. Getting this backwards is the mistake the k8s copy
+would have made.
+*/}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ $fullName }}-keycloak
+  namespace: {{ $ns }}
+  labels:
+    {{- include "openoncology.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "openoncology.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: keycloak
+  policyTypes: [Ingress, Egress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ $np.ingressNamespace }}
+        - podSelector:
+            matchLabels:
+              {{- include "openoncology.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: api
+        - podSelector:
+            matchLabels:
+              {{- include "openoncology.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: worker-gdpr
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              {{- include "openoncology.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: postgres
+      ports:
+        - port: 5432
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ $fullName }}-keycloak-postgres
+  namespace: {{ $ns }}
+  labels:
+    {{- include "openoncology.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "openoncology.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: postgres
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "openoncology.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: keycloak
+      ports:
+        - port: 5432
+{{- if .Values.backup.enabled }}
+---
+{{/*
+The backup CronJob reads the application database and writes to object storage.
+Denying it produces a backup that fails every night, and nothing alerts on that
+until OO-16.
+*/}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ $fullName }}-db-backup
+  namespace: {{ $ns }}
+  labels:
+    {{- include "openoncology.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "openoncology.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: db-backup
+  policyTypes: [Egress]
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              {{- toYaml $np.datastores.postgresql | nindent 14 }}
+      ports:
+        - port: 5432
+    - to:
+        - podSelector:
+            matchLabels:
+              {{- toYaml $np.datastores.objectStore | nindent 14 }}
+      ports:
+        - port: 9000
+    # An off-cluster object store.
+    - ports:
+        - port: 443
+{{- end }}
+{{- end }}

--- a/infra/helm/values.yaml
+++ b/infra/helm/values.yaml
@@ -158,6 +158,40 @@ beat:
       cpu: "200m"
       memory: "256Mi"
 
+# ── Network policies ──────────────────────────────────────────────────────────
+# Default deny plus explicit allows. infra/k8s/namespace.yaml has carried these
+# since the beginning; the chart, which is what production deploys from, had
+# none.
+#
+# OFF by default, and that is not timidity. A NetworkPolicy fails closed, nothing
+# in this repository can test one against a real cluster, and the sub-chart pod
+# labels below vary by sub-chart version. A wrong selector denies the database
+# and renders perfectly. Enable it while watching, not on a Friday.
+#
+# Before enabling, check the datastore selectors against
+# `kubectl get pod -n openoncology --show-labels`. Bitnami has changed these
+# between chart majors.
+networkPolicy:
+  enabled: false
+  # Namespace labels, not names. Most clusters set
+  # kubernetes.io/metadata.name automatically; some do not.
+  dnsNamespace: kube-system
+  ingressNamespace: ingress-nginx
+  datastores:
+    # The Bitnami postgresql sub-chart, which is the APPLICATION database.
+    # Not `component: postgres`, which is the chart-local StatefulSet that
+    # belongs to Keycloak.
+    postgresql:
+      app.kubernetes.io/name: postgresql
+    redis:
+      app.kubernetes.io/name: redis
+    # MinIO is referenced by configmap.yaml and deployed by nothing in this
+    # chart. See BACKLOG.md OO-18. This selector is what it would carry once
+    # something creates it; until then the rule matches no pod, which under
+    # default-deny means the API cannot reach object storage either way.
+    objectStore:
+      app.kubernetes.io/name: minio
+
 # ── Database backup ───────────────────────────────────────────────────────────
 # Nothing backed the application database up before this existed, and
 # HIPAA_COMPLIANCE.md claimed otherwise. Persistence is not backup: losing the


### PR DESCRIPTION
## Summary

Adds default-deny NetworkPolicies with explicit allows to the Helm chart, off by
default. CI renders them enabled and verifies every selector matches a workload
the chart creates.

Closes `OO-5`. Files `OO-18`.

## Why this is not a port

`infra/k8s/namespace.yaml` has carried a policy set since the beginning; the
chart, which is what production deploys from, had none. The k8s copy could not
be transferred, for three reasons found while scoping. Each fails closed and
renders cleanly, which is the combination that reaches production.

| Problem in the k8s copy | Consequence here |
|---|---|
| `allow-workers-egress` selects on `app.kubernetes.io/part-of`, which `_helpers.tpl` never emits | The rule matches nothing; default-deny then severs every worker from Postgres and Redis |
| Workers render four component values (`worker-genomic`, `-ai`, `-notify`, `-gdpr`) | No equality selector reaches them all |
| `component: postgres` is Keycloak's StatefulSet | The application uses the Bitnami sub-chart, so that rule allows the wrong database and denies the right one |

## Design

**Off by default.** A NetworkPolicy fails closed, nothing in this repository can
test one against a real cluster, and Bitnami's pod labels vary by sub-chart
version. Enabling it is a deliberate act by someone able to watch the result.

**Datastore selectors are values, not literals**, with a note to check them
against `kubectl get pod --show-labels` first. A wrong selector denies the
database and renders perfectly.

**The DNS rule comes first because it is load-bearing.** Under default-deny,
egress to kube-dns must be explicit. Without it every lookup fails at once,
which presents as every dependency being down rather than as a policy problem.

**Two allows exist because their absence is silent.** The gdpr worker gets
Keycloak egress, because `erase_patient_data` calls the admin API to delete the
user; a policy modelled on the other three workers breaks the erasure path #130
restored. The backup CronJob from #141 gets Postgres and object storage, because
denying it produces a nightly failure that nothing alerts on until `OO-16`.

## Verification

CI renders the chart a second time with `networkPolicy.enabled=true`, validates
it with kubeconform, and checks that every `podSelector` matches a workload the
chart renders. The check is inline in the workflow rather than a helper under
`scripts/`, which the `PreToolUse` guard covers.

That check was verified against a synthetic manifest carrying the `part-of`
selector: it exits non-zero.

Eight offline assertions added to `test_deployment_manifests.py`. Two were wrong
on the first attempt, both recorded here because the pattern matters:

- One scanned the template's own Helm comments, which quote the `part-of` label
  while explaining why it cannot be used, and so failed on its own
  documentation. It strips comment blocks now.
- One matched only the `matchLabels` form and silently passed a deliberately
  broken `matchExpressions` selector, which is the form this template actually
  uses. Both forms are covered, and the falsification now fails as intended.

| Check | Result |
|---|---|
| `ruff check api/` | Clean |
| api suite | 1242 passed, 4 skipped, 2 xfailed |
| ai suite | 42 passed |
| Coverage | 61.83% against the 52 gate |
| Guard against a `part-of` selector | Fails, as intended |

No cluster was available, so the policies have never been applied. What is
verified is that they render, validate, and select pods that exist.

## OO-18, filed while scoping this

`configmap.yaml` sets `MINIO_ENDPOINT` to `{release}-minio:9000` and
`values.yaml` configures a MinIO with 200Gi of persistence. No template creates
a MinIO Deployment, StatefulSet or Service, and `Chart.yaml` declares only
`postgresql` and `redis`.

A `helm install` therefore produces an application configured to reach object
storage that does not exist. Every VCF upload, report write and GDPR object
deletion fails, as does the backup CronJob, which writes through `mc`.

Filed rather than fixed: deploying object storage is a separate change, and a
NetworkPolicy cannot grant egress to a pod nothing creates.
