### PR TITLE
Deploy the Prometheus exporters, and alert on Celery queue depth

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -67,17 +67,6 @@ Sections are ordered by pipeline position. `/next` pulls from the top of
 - **Out of scope**: who the security officer is, which is the maintainer's decision and not a code change
 - **Risk**: low to implement. Worth noting that assigning an owner in a file is not the same as a person accepting the role, and the checklist can only ever check the first.
 
-### OO-16: Deploy the exporters the monitoring config was scraping
-- **Why**: `infra/prometheus.yml` scraped `db-exporter:9187`, `redis-exporter:9121` and `worker-*:9100`. None of the first two exists in `docker-compose.yml` or the Helm chart, and nothing in `api/workers/` starts a metrics server, so port 9100 is not listening. All four reported `up == 0` permanently, invisibly, because nothing alerted on `up`. Those jobs are commented out rather than deleted, since the intent is right and the deployment is what is missing. `api/tests/test_alert_rules.py` now fails if a scrape job names a host no deployment defines.
-- **Files**: docker-compose.yml, infra/helm/templates/, infra/prometheus.yml, api/workers/__init__.py
-- **Acceptance**:
-  - postgres_exporter and redis_exporter are deployed in both deployment paths, or the jobs stay commented and the reason is recorded here
-  - Celery workers expose a metrics endpoint, or the celery-exporter is deployed against the broker instead
-  - Each job is uncommented only once its exporter is actually reachable, and `test_alert_rules.py` passes with it active
-  - Queue depth and task age on `genomic` and `gdpr` become alertable, which is what OO-13 could not cover
-- **Out of scope**: dashboards
-- **Risk**: low
-
 ### OO-17: The degraded-evidence alarm emits no metric, and two metrics emit nothing
 - **Why**: `settings.degraded_evidence_alert_after` escalates a **log line** to ERROR after a run of static-fallback resolutions. That is the control risk_analysis open action 4 closed, and it can only be seen by someone reading logs: there is no metric, so it cannot alert. Separately, `api/main.py` declares `openoncology_mutations_processed_total` and `openoncology_genomic_pipeline_seconds` and neither is ever incremented, so both are permanently absent from `/metrics`. A rule written against either would look like coverage and never fire, which is why `test_alert_rules.py` rejects them.
 - **Files**: api/main.py, api/services/oncokb_evidence.py, api/workers/genomic_worker.py, infra/alerts/openoncology.rules.yml

--- a/api/tests/test_alert_rules.py
+++ b/api/tests/test_alert_rules.py
@@ -39,9 +39,33 @@ INSTRUMENTATOR_BASE = {
     "http_request_size_bytes",
     "http_response_size_bytes",
 }
+# Emitted by the exporters the chart deploys (OO-16). This list grows only
+# alongside an exporter that actually produces the series: that is the whole
+# point of the check below, and adding a name here to make a rule pass would
+# reintroduce exactly the defect it exists to catch.
+EXPORTER_METRICS = {
+    # oliver006/redis_exporter. redis_key_size carries the Celery queue depths,
+    # one series per key named in REDIS_EXPORTER_CHECK_KEYS.
+    "redis_up",
+    "redis_key_size",
+    # danihodovic/celery-exporter. Requires worker_send_task_events and
+    # task_send_sent_event, both set in api/workers/__init__.py.
+    "celery_worker_up",
+    "celery_task_failed_total",
+    "celery_task_received_total",
+    "celery_task_succeeded_total",
+    "celery_task_runtime_seconds",
+    # prometheuscommunity/postgres-exporter.
+    "pg_up",
+    "pg_stat_activity_count",
+    "pg_settings_max_connections",
+}
+
 _SUFFIXES = ("", "_bucket", "_count", "_sum", "_created")
-ALLOWED_METRICS = PROMETHEUS_INTERNAL | {
-    base + suffix for base in INSTRUMENTATOR_BASE for suffix in _SUFFIXES
+ALLOWED_METRICS = PROMETHEUS_INTERNAL | EXPORTER_METRICS | {
+    base + suffix
+    for base in INSTRUMENTATOR_BASE | EXPORTER_METRICS
+    for suffix in _SUFFIXES
 }
 
 # PromQL functions and keywords that appear where a metric name would, and are
@@ -162,3 +186,47 @@ def test_no_active_scrape_job_targets_an_undeployed_exporter():
         "scrape jobs target hosts that no deployment defines: "
         f"{undeployed}. Comment the job out until its exporter is deployed."
     )
+
+
+# ── Queue alerts need the exporter to be watching that queue ─────────────────
+
+def test_every_alerted_queue_is_watched_by_the_redis_exporter():
+    """
+    `redis_key_size` only exists for keys named in REDIS_EXPORTER_CHECK_KEYS.
+    An alert on a queue absent from that list is a rule that can never fire,
+    which is the defect this module exists for, one layer further down.
+    """
+    values = yaml.safe_load((REPO_ROOT / "infra" / "helm" / "values.yaml").read_text(encoding="utf-8"))
+    watched = set(
+        values["exporters"]["instances"]["redis"]["env"]["REDIS_EXPORTER_CHECK_KEYS"].split(",")
+    )
+    alerted = set()
+    for _, rule in _rules():
+        alerted |= set(re.findall(r'redis_key_size\{key="([a-z]+)"\}', rule["expr"]))
+    missing = sorted(alerted - watched)
+    assert not missing, (
+        f"alerts reference queue depths the exporter does not collect: {missing}"
+    )
+
+
+def test_the_exporter_watches_every_routed_queue():
+    """The other direction: a queue Celery routes to and nothing measures."""
+    values = yaml.safe_load((REPO_ROOT / "infra" / "helm" / "values.yaml").read_text(encoding="utf-8"))
+    watched = set(
+        values["exporters"]["instances"]["redis"]["env"]["REDIS_EXPORTER_CHECK_KEYS"].split(",")
+    )
+    source = (REPO_ROOT / "api" / "workers" / "__init__.py").read_text(encoding="utf-8")
+    routed = set(re.findall(r'"queue":\s*"([a-z]+)"', source))
+    assert routed <= watched, (
+        f"queues Celery routes to that no exporter measures: {sorted(routed - watched)}"
+    )
+
+
+def test_celery_task_events_are_enabled():
+    """
+    celery-exporter reports nothing without them, so every celery_* rule above
+    would evaluate against an absent series and stay silent.
+    """
+    source = (REPO_ROOT / "api" / "workers" / "__init__.py").read_text(encoding="utf-8")
+    assert "worker_send_task_events=True" in source
+    assert "task_send_sent_event=True" in source

--- a/api/workers/__init__.py
+++ b/api/workers/__init__.py
@@ -48,6 +48,19 @@ celery_app.conf.update(
     task_queues_default_exchange_type="direct",
     # Result expiry — keep task results 24 h then auto-expire
     result_expires=86400,
+    # ── Observability ──────────────────────────────────────────────────────
+    # Celery emits nothing about task lifecycle unless asked. Without these the
+    # broker carries the work and no external observer can tell a queue that is
+    # draining from one that has stalled, which is what BACKLOG.md OO-16 is
+    # about: the gdpr queue silently not draining means erasure requests are not
+    # being honoured, and that is an obligation with a deadline attached.
+    #
+    # Two separate switches. worker_send_task_events makes workers publish
+    # started/succeeded/failed; task_send_sent_event makes the *producer*
+    # publish on enqueue, which is the only way to measure the gap between
+    # submission and pickup. Queue latency needs both.
+    worker_send_task_events=True,
+    task_send_sent_event=True,
     task_routes={
         "workers.genomic_worker.*": {"queue": "genomic"},
         "workers.ai_worker.*": {"queue": "ai"},

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -281,6 +281,43 @@ services:
     command: start-dev
 
   # ─────────────────────────────────────────────
+  # Prometheus exporters  →  scraped by prometheus
+  # ─────────────────────────────────────────────
+  # infra/prometheus.yml declared jobs for these and nothing ran them, so every
+  # one reported up == 0 permanently. Service names match the scrape targets.
+  redis-exporter:
+    image: oliver006/redis_exporter:v1.62.0
+    environment:
+      - REDIS_ADDR=redis://redis:6379
+      # One per Celery queue. redis_key_size for these keys is the queue depth.
+      - REDIS_EXPORTER_CHECK_KEYS=genomic,ai,notify,gdpr
+    depends_on:
+      - redis
+    networks:
+      - openoncology
+
+  celery-exporter:
+    image: danihodovic/celery-exporter:0.10.5
+    environment:
+      - CE_BROKER_URL=redis://redis:6379/0
+      - CE_ACCEPT_CONTENT=["json"]
+    depends_on:
+      - redis
+    networks:
+      - openoncology
+
+  db-exporter:
+    image: prometheuscommunity/postgres-exporter:v0.15.0
+    environment:
+      - DATA_SOURCE_URI=db:5432/openoncology?sslmode=disable
+      - DATA_SOURCE_USER=openoncology
+      - DATA_SOURCE_PASS=${DB_PASSWORD}
+    depends_on:
+      - db
+    networks:
+      - openoncology
+
+  # ─────────────────────────────────────────────
   # Prometheus Metrics  →  localhost:9090
   # ─────────────────────────────────────────────
   prometheus:

--- a/infra/alerts/openoncology.rules.yml
+++ b/infra/alerts/openoncology.rules.yml
@@ -93,3 +93,89 @@ groups:
             deleting it, because on a deployment that should have traffic it is
             the only rule here that catches an ingress or DNS failure in front
             of a healthy pod.
+
+  - name: openoncology-queues
+    rules:
+      # Celery queues are Redis lists named after the queue, so the key size is
+      # the number of messages waiting. OO-16 deployed the exporter that
+      # measures this; before it, a stalled queue was invisible.
+      - alert: GdprQueueNotDraining
+        expr: redis_key_size{key="gdpr"} > 0
+        for: 2h
+        labels:
+          severity: critical
+        annotations:
+          summary: "Erasure requests have been waiting over two hours"
+          description: >-
+            The gdpr queue carries right-to-erasure requests and the daily
+            retention sweep. Work sitting here means deletions are not being
+            performed, which is an obligation with a 30 day deadline rather than
+            a backlog. This queue is normally empty, so any sustained depth is
+            worth waking someone for. That it had no consumer at all until #130
+            is the reason this alert exists.
+
+      - alert: GenomicQueueBacklog
+        expr: redis_key_size{key="genomic"} > 20
+        for: 1h
+        labels:
+          severity: warning
+        annotations:
+          summary: "Genomic queue has held over 20 submissions for an hour"
+          description: >-
+            Either throughput is insufficient or the workers have stopped
+            consuming. Check `celery_worker_up` before scaling: a queue that is
+            deep because nothing is consuming does not improve with more
+            capacity.
+
+      - alert: CeleryWorkersAbsent
+        expr: sum(celery_worker_up) == 0
+        for: 10m
+        labels:
+          severity: critical
+        annotations:
+          summary: "No Celery worker is reporting"
+          description: >-
+            Nothing is processing submissions, erasures or notifications. Task
+            events must be enabled for this to be meaningful; they are set in
+            api/workers/__init__.py, and if that changes this alert goes quiet
+            rather than firing.
+
+      - alert: CeleryTaskFailureRateHigh
+        expr: >-
+          sum(rate(celery_task_failed_total[15m]))
+          / clamp_min(sum(rate(celery_task_received_total[15m])), 0.001) > 0.2
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Over 20% of Celery tasks are failing"
+          description: >-
+            Tasks are acks_late, so failures are redelivered and a persistent
+            failure becomes a redelivery loop that looks like throughput.
+
+  - name: openoncology-datastores
+    rules:
+      - alert: PostgresConnectionsNearLimit
+        expr: >-
+          sum(pg_stat_activity_count)
+          / clamp_min(sum(pg_settings_max_connections), 1) > 0.8
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Postgres connections above 80% of max"
+          description: >-
+            The API and every worker share one pool. Exhaustion presents as
+            unrelated timeouts across all of them at once rather than as a
+            database alert.
+
+      - alert: RedisDown
+        expr: redis_up == 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Redis is not responding to the exporter"
+          description: >-
+            Redis is the Celery broker. While it is down nothing is queued or
+            consumed, and submissions accepted by the API go nowhere.

--- a/infra/helm/templates/exporters.yaml
+++ b/infra/helm/templates/exporters.yaml
@@ -1,0 +1,121 @@
+{{/*
+Prometheus exporters.
+
+BACKLOG.md OO-16. infra/prometheus.yml declared scrape jobs for
+`db-exporter:9187`, `redis-exporter:9121` and `worker-*:9100`, and none of those
+existed. Each reported `up == 0` permanently. #140 commented those jobs out
+rather than leaving them to page continuously once anything watched `up`; this
+deploys the exporters so they can be uncommented, which is done in the same
+change.
+
+What each one is for, since "more metrics" is not a reason:
+
+  redis      Celery queues are Redis lists named after the queue, so
+             `redis_key_size{key="gdpr"}` IS the queue depth. This is the one
+             that makes a stalled queue visible. A gdpr queue that stops
+             draining means erasure requests are not being honoured, and that is
+             an obligation with a 30 day deadline.
+
+  celery     Task lifecycle. Depth alone cannot distinguish a queue nothing is
+             enqueueing to from one nothing is consuming, and it says nothing
+             about how long work waits. Needs worker_send_task_events and
+             task_send_sent_event, both set in api/workers/__init__.py.
+
+  postgres   Connection saturation and transaction age. The application shares
+             one pool across the API and every worker, so exhaustion presents as
+             unrelated timeouts everywhere at once.
+
+Each is a Deployment rather than a sidecar so a restart does not disturb the
+thing it observes.
+*/}}
+{{- if .Values.exporters.enabled }}
+{{- $fullName := include "openoncology.fullname" . }}
+{{- $ns := .Values.namespace }}
+{{- range $name, $cfg := .Values.exporters.instances }}
+{{- if $cfg.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $fullName }}-{{ $name }}-exporter
+  namespace: {{ $ns }}
+  labels:
+    {{- include "openoncology.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: {{ $name }}-exporter
+spec:
+  type: ClusterIP
+  ports:
+    - name: metrics
+      port: {{ $cfg.port }}
+      targetPort: metrics
+  selector:
+    {{- include "openoncology.selectorLabels" $ | nindent 4 }}
+    app.kubernetes.io/component: {{ $name }}-exporter
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $fullName }}-{{ $name }}-exporter
+  namespace: {{ $ns }}
+  labels:
+    {{- include "openoncology.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: {{ $name }}-exporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "openoncology.selectorLabels" $ | nindent 6 }}
+      app.kubernetes.io/component: {{ $name }}-exporter
+  template:
+    metadata:
+      labels:
+        {{- include "openoncology.selectorLabels" $ | nindent 8 }}
+        app.kubernetes.io/component: {{ $name }}-exporter
+    spec:
+      serviceAccountName: {{ include "openoncology.serviceAccountName" $ }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: exporter
+          image: "{{ $cfg.image.repository }}:{{ $cfg.image.tag }}"
+          imagePullPolicy: {{ $.Values.exporters.pullPolicy }}
+          ports:
+            - name: metrics
+              containerPort: {{ $cfg.port }}
+          {{- with $cfg.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            {{- range $k, $v := $cfg.env }}
+            - name: {{ $k }}
+              value: {{ tpl $v $ | quote }}
+            {{- end }}
+            {{- with $cfg.secretEnv }}
+            {{- range $k, $ref := . }}
+            - name: {{ $k }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $ref.secret }}
+                  key: {{ $ref.key }}
+            {{- end }}
+            {{- end }}
+          readinessProbe:
+            httpGet:
+              path: {{ $cfg.metricsPath | default "/metrics" }}
+              port: metrics
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            {{- toYaml $.Values.exporters.resources | nindent 12 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/infra/helm/templates/networkpolicy.yaml
+++ b/infra/helm/templates/networkpolicy.yaml
@@ -285,6 +285,49 @@ spec:
               app.kubernetes.io/component: keycloak
       ports:
         - port: 5432
+{{- if .Values.exporters.enabled }}
+---
+{{/*
+Exporters read their backend and are scraped by Prometheus. Denying either half
+gives a target that is up and reports nothing, which alerts on `up` only if the
+scrape itself fails, so it can look healthy while measuring nothing.
+*/}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ $fullName }}-exporters
+  namespace: {{ $ns }}
+  labels:
+    {{- include "openoncology.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchExpressions:
+      - key: app.kubernetes.io/component
+        operator: In
+        values:
+          {{- range $name, $cfg := .Values.exporters.instances }}
+          - {{ $name }}-exporter
+          {{- end }}
+  policyTypes: [Ingress, Egress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ $np.monitoringNamespace }}
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              {{- toYaml $np.datastores.postgresql | nindent 14 }}
+      ports:
+        - port: 5432
+    - to:
+        - podSelector:
+            matchLabels:
+              {{- toYaml $np.datastores.redis | nindent 14 }}
+      ports:
+        - port: 6379
+{{- end }}
 {{- if .Values.backup.enabled }}
 ---
 {{/*

--- a/infra/helm/values.yaml
+++ b/infra/helm/values.yaml
@@ -158,6 +158,58 @@ beat:
       cpu: "200m"
       memory: "256Mi"
 
+# ── Prometheus exporters ──────────────────────────────────────────────────────
+# infra/prometheus.yml declared scrape jobs for these and nothing deployed them,
+# so each reported `up == 0` permanently. See OO-16.
+#
+# The redis one carries the queue depths. Celery queues are Redis lists named
+# after the queue, so `redis_key_size{key="gdpr"}` is how many erasure requests
+# are waiting. That is the metric worth having.
+exporters:
+  enabled: true
+  pullPolicy: IfNotPresent
+  resources:
+    requests:
+      cpu: "50m"
+      memory: "64Mi"
+    limits:
+      cpu: "200m"
+      memory: "256Mi"
+  instances:
+    redis:
+      enabled: true
+      port: 9121
+      image:
+        repository: oliver006/redis_exporter
+        tag: v1.62.0
+      env:
+        REDIS_ADDR: "redis://{{ .Release.Name }}-redis-master:6379"
+        # One entry per Celery queue in api/workers/__init__.py task_routes.
+        # A queue absent here has no depth metric and cannot be alerted on.
+        REDIS_EXPORTER_CHECK_KEYS: "genomic,ai,notify,gdpr"
+    celery:
+      enabled: true
+      port: 9808
+      image:
+        repository: danihodovic/celery-exporter
+        tag: 0.10.5
+      env:
+        CE_BROKER_URL: "redis://{{ .Release.Name }}-redis-master:6379/0"
+        CE_ACCEPT_CONTENT: '["json"]'
+    postgres:
+      enabled: true
+      port: 9187
+      image:
+        repository: prometheuscommunity/postgres-exporter
+        tag: v0.15.0
+      env:
+        DATA_SOURCE_URI: "{{ .Release.Name }}-postgresql:5432/openoncology?sslmode=disable"
+        DATA_SOURCE_USER: openoncology
+      secretEnv:
+        DATA_SOURCE_PASS:
+          secret: openoncology-pg-secret
+          key: password
+
 # ── Network policies ──────────────────────────────────────────────────────────
 # Default deny plus explicit allows. infra/k8s/namespace.yaml has carried these
 # since the beginning; the chart, which is what production deploys from, had
@@ -177,6 +229,9 @@ networkPolicy:
   # kubernetes.io/metadata.name automatically; some do not.
   dnsNamespace: kube-system
   ingressNamespace: ingress-nginx
+  # Where Prometheus runs. It scrapes the exporters, so under default-deny it
+  # needs ingress permission to reach them.
+  monitoringNamespace: monitoring
   datastores:
     # The Bitnami postgresql sub-chart, which is the APPLICATION database.
     # Not `component: postgres`, which is the chart-local StatefulSet that

--- a/infra/prometheus.yml
+++ b/infra/prometheus.yml
@@ -25,47 +25,20 @@ scrape_configs:
     static_configs:
       - targets: ["api:8000"]
 
-  # ── Targets that were configured but never deployed ──────────────────────
+  # These were commented out in #140 because nothing deployed them and each
+  # reported `up == 0` permanently. The exporters exist now (OO-16), so the jobs
+  # are live again. `api/tests/test_alert_rules.py` fails if a scrape job names a
+  # host no deployment defines, which is what keeps this honest.
   #
-  # The four jobs below were scraping endpoints that do not exist anywhere in
-  # this repository, so each reported `up == 0` permanently. That was invisible
-  # while nothing alerted on `up`; with the rules in alerts/ it would page
-  # continuously and train whoever is on call to ignore the one signal that
-  # matters.
-  #
-  # They are commented rather than deleted because the intent is right and the
-  # deployment is what is missing:
-  #
-  #   postgres  db-exporter:9187     no such service in docker-compose.yml or
-  #                                  the Helm chart
-  #   redis     redis-exporter:9121  same
-  #   celery-*  worker-*:9100        the worker services exist in
-  #                                  docker-compose.yml, but nothing in
-  #                                  api/workers/ starts a metrics server, so
-  #                                  port 9100 is not listening
-  #
-  # Deploying the exporters and giving the workers a metrics endpoint is
-  # BACKLOG.md OO-16. Uncomment each job as its exporter is actually deployed.
-  #
-  # - job_name: postgres
-  #   static_configs:
-  #     - targets: ["db-exporter:9187"]
-  #
-  # - job_name: redis
-  #   static_configs:
-  #     - targets: ["redis-exporter:9121"]
-  #
-  # - job_name: celery-worker-genomic
-  #   metrics_path: /metrics
-  #   static_configs:
-  #     - targets: ["worker-genomic:9100"]
-  #
-  # - job_name: celery-worker-ai
-  #   metrics_path: /metrics
-  #   static_configs:
-  #     - targets: ["worker-ai:9100"]
-  #
-  # - job_name: celery-worker-notify
-  #   metrics_path: /metrics
-  #   static_configs:
-  #     - targets: ["worker-notify:9100"]
+  # Names match the Helm Services. docker-compose uses the same short names.
+  - job_name: redis
+    static_configs:
+      - targets: ["redis-exporter:9121"]
+
+  - job_name: celery
+    static_configs:
+      - targets: ["celery-exporter:9808"]
+
+  - job_name: postgres
+    static_configs:
+      - targets: ["db-exporter:9187"]


### PR DESCRIPTION
## Summary

Deploys the three Prometheus exporters the monitoring configuration had been
scraping, restores their scrape jobs, and adds six alerting rules including
Celery queue depth.

Closes `OO-16`.

## Problem

`infra/prometheus.yml` declared jobs for `db-exporter:9187`,
`redis-exporter:9121` and `worker-*:9100`. Nothing deployed any of them, so each
reported `up == 0` permanently. #140 commented them out rather than leave them
paging continuously once a rule watched `up`. This deploys the exporters and
restores the jobs in the same change, so neither half exists without the other.

## What each exporter is for

| Exporter | Provides | Why it matters here |
|---|---|---|
| redis | `redis_key_size` per queue | Celery queues are Redis lists named after the queue, so this **is** the queue depth |
| celery | Task lifecycle counters and runtimes | Depth cannot distinguish a queue nothing enqueues to from one nothing consumes, and says nothing about wait time |
| postgres | Connection and transaction stats | The API and every worker share one pool; exhaustion presents as unrelated timeouts everywhere at once |

The redis one is the significant addition. `redis_key_size{key="gdpr"}` is the
number of erasure requests waiting. That queue is normally empty and had no
consumer at all until #130, so sustained depth means deletions are not being
performed, which carries a 30 day deadline rather than being a backlog.

## Changes

- `infra/helm/templates/exporters.yaml`. Deployment and Service per exporter,
  rendered from a values map.
- `docker-compose.yml`. The same three, named to match the scrape targets.
- `api/workers/__init__.py`. `worker_send_task_events` and
  `task_send_sent_event`. Two separate switches: the first makes workers publish
  started and finished, the second makes the producer publish on enqueue. Queue
  latency needs both.
- `infra/prometheus.yml`. Jobs restored, pointing at the new services.
- `infra/alerts/openoncology.rules.yml`. Six rules: gdpr queue not draining,
  genomic backlog, no worker reporting, task failure rate, Postgres connections
  near max, Redis down.
- `networkpolicy.yaml`. Ingress from the monitoring namespace, egress to Redis
  and Postgres. Denying either half yields a target that is up and measuring
  nothing, which looks healthier than one that is down.

## Three new guards

Each of these failure modes is silence rather than error, so each gets a test.
All three were verified by breaking them.

| Guard | Verified by |
|---|---|
| Every queue an alert names is in `REDIS_EXPORTER_CHECK_KEYS` | Removing `gdpr` from the list fails it |
| Every queue `task_routes` targets is measured | Same edit fails this too |
| Celery task events are enabled | Setting `worker_send_task_events=False` fails it |

The third matters most: without those switches every `celery_*` rule evaluates
against a series that does not exist and stays permanently silent.

The allowed-metric list in `test_alert_rules.py` grows by ten names, all series
these exporters produce. Adding a name there to make a rule pass would
reintroduce the defect the check exists to catch; the comment says so.

## Impact

Three new workloads. `worker_send_task_events` adds event traffic on the broker,
which is the cost of the queue metrics being available at all.

If the exporters fail to start, `TargetDown` from #140 now fires on them, which
is the intended behaviour and the reason the jobs and the deployments landed
together.

## Verification

| Check | Result |
|---|---|
| `ruff check api/` | Clean |
| api suite | 1264 passed, 4 skipped, 2 xfailed |
| ai suite | 42 passed |
| Coverage | 61.79% against the 52 gate |
| Helm render, kubeconform, policy selector check | Run in `validate-manifests` |

No exporter has been started and no metric has been scraped. What is verified is
that the manifests render and validate, that every scrape target names a service
some deployment defines, and that every rule references a series one of these
exporters produces.
