### PR TITLE
Size Keycloak's database from its own values

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -35,16 +35,6 @@ Sections are ordered by pipeline position. `/next` pulls from the top of
 - **Out of scope**: the conda-only modules, which pin exact versions already; choosing different tool versions
 - **Risk**: low
 
-### OO-9: Keycloak's database is sized by the application database's setting
-- **Why**: `templates/postgres.yaml` is Keycloak's database, not the application's, which uses the Bitnami `postgresql` sub-chart. Its `volumeClaimTemplates` requests `.Values.postgresql.primary.persistence.size`, the sub-chart's value. `values.production.yaml` sets that to 200Gi, so Keycloak's realm database, a few megabytes of users and clients, claims a 200Gi volume, and anyone resizing the application database silently resizes Keycloak's too. Found while scoping OO-5.
-- **Files**: infra/helm/templates/postgres.yaml, infra/helm/values.yaml, infra/helm/values.production.yaml
-- **Acceptance**:
-  - Keycloak's database size comes from its own value, defaulted to something proportionate
-  - The two databases are distinguishable by name or comment, so the next reader does not assume `postgres.yaml` is the application's
-  - `helm template` still renders and passes kubeconform
-- **Out of scope**: consolidating the two databases, which is a data-migration decision rather than a chart one
-- **Risk**: low to change, but note `volumeClaimTemplates` is immutable on an existing StatefulSet, so an in-place `helm upgrade` will reject the edit. The entry is only safe on a fresh install or with a documented recreate step, and that caveat is the reason it is filed rather than done in passing.
-
 ### OO-12: There is no backup of patient data, and the compliance checklist said there was
 - **Why**: Nothing in this repository backs up the application database or object storage. No `archive_mode`, `archive_command` or `wal_level`; no MinIO versioning; no `pg_dump`, pgBackRest, wal-g or Velero anywhere. The Bitnami `postgresql` sub-chart has persistence, and persistence is not backup: a deleted PVC, a bad migration or a ransomware event loses every submission, mutation and result permanently, with no recovery path. `HIPAA_COMPLIANCE.md` carried ✅ against §164.308 contingency planning, citing "PostgreSQL WAL + MinIO versioning (see `infra/helm/postgres.yaml`)", and that file is Keycloak's database rather than the application's. The claim has been corrected; the gap it was covering is this entry.
 - **Files**: infra/helm/values.yaml, infra/helm/values.production.yaml, infra/helm/templates/, docs/HIPAA_COMPLIANCE.md, docs/SETUP.md

--- a/api/tests/test_deployment_manifests.py
+++ b/api/tests/test_deployment_manifests.py
@@ -548,3 +548,55 @@ def test_the_network_policy_can_select_the_object_store(helm_values):
             f"minio.yaml sets. Its pods carry the chart selectorLabels plus "
             f"component: minio, so app.kubernetes.io/name is the chart name."
         )
+
+
+# ── The two databases are configured separately ──────────────────────────────
+#
+# OO-9. templates/postgres.yaml is Keycloak's database; the application uses the
+# Bitnami postgresql sub-chart. The first read `postgresql.primary.persistence`
+# and `postgresql.primary.resources`, which belong to the second, so production
+# gave a realm database holding a few megabytes a 200Gi volume and resizing one
+# silently resized the other.
+#
+# The confusion has caused two defects already: HIPAA_COMPLIANCE.md cited this
+# file as evidence of a backup for patient data, and the OO-5 network policy
+# nearly granted the application egress to this database rather than its own.
+
+KEYCLOAK_DB = HELM / "templates" / "postgres.yaml"
+
+
+def test_keycloak_database_is_sized_by_its_own_value(helm_values):
+    assert "keycloakDatabase" in helm_values
+    text = KEYCLOAK_DB.read_text(encoding="utf-8")
+    assert "keycloakDatabase.persistence.size" in text
+    assert "postgresql.primary.persistence" not in text
+
+
+def test_keycloak_database_does_not_borrow_the_application_resources():
+    text = KEYCLOAK_DB.read_text(encoding="utf-8")
+    assert "keycloakDatabase.resources" in text
+    assert "postgresql.primary.resources" not in text
+
+
+def test_the_two_databases_are_sized_independently(helm_values):
+    """
+    Equal sizes would pass the assertions above while still meaning nobody chose
+    either number.
+    """
+    app = helm_values["postgresql"]["primary"]["persistence"]["size"]
+    keycloak = helm_values["keycloakDatabase"]["persistence"]["size"]
+    assert app != keycloak, (
+        "both databases request the same volume size, which suggests one is "
+        "still inheriting the other's number"
+    )
+
+
+def test_the_template_says_which_database_it_is():
+    """
+    A reader arriving at a file called postgres.yaml reasonably assumes it is
+    the application's. Two defects came from exactly that assumption.
+    """
+    text = KEYCLOAK_DB.read_text(encoding="utf-8")
+    head = text[: text.index("apiVersion")]
+    assert "KEYCLOAK" in head.upper()
+    assert "not the application" in head.lower()

--- a/docs/RUNBOOK_BACKUP_RESTORE.md
+++ b/docs/RUNBOOK_BACKUP_RESTORE.md
@@ -128,3 +128,10 @@ Only after the drill has been run at least once.
 - Nothing alerts on a failed backup. The CronJob fails loudly in Kubernetes, and
   Kubernetes tells nobody. `OO-16` deploys the exporters that would make
   `kube_job_failed` alertable.
+- Keycloak's database volume was resized by `OO-9`, from the application
+  database's 200Gi to its own 10Gi. `volumeClaimTemplates` is immutable on an
+  existing StatefulSet, so `helm upgrade` rejects that change against a cluster
+  where it already exists. Applying it needs a fresh install, or deleting the
+  StatefulSet with `--cascade=orphan` and recreating it. Since this database is
+  not covered by the nightly dump, export the realm first:
+  `kubectl exec <keycloak-pod> -- /opt/keycloak/bin/kc.sh export --dir /tmp/realm`.

--- a/infra/helm/templates/postgres.yaml
+++ b/infra/helm/templates/postgres.yaml
@@ -1,3 +1,21 @@
+{{/*
+KEYCLOAK's database. Not the application's.
+
+The application uses the Bitnami `postgresql` sub-chart at
+`{{ .Release.Name }}-postgresql`, reached through `openoncology.databaseUrl`.
+This StatefulSet backs Keycloak alone: users, clients and the realm.
+
+The distinction has already caused two defects. HIPAA_COMPLIANCE.md cited this
+file as evidence of a backup for patient data, and the NetworkPolicy work nearly
+granted the application egress to this database instead of its own. Sizing and
+resources come from `keycloakDatabase` rather than from `postgresql.primary`,
+which is what OO-9 corrected.
+
+Still shared with the application's sub-chart, and not corrected here: the
+username, database name and credentials secret. Splitting those needs new
+secrets to exist before the chart can reference them, so it is a deployment
+change rather than a template one.
+*/}}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -41,7 +59,7 @@ spec:
             - name: PGDATA
               value: /var/lib/postgresql/data/pgdata
           resources:
-            {{- toYaml .Values.postgresql.primary.resources | nindent 12 }}
+            {{- toYaml .Values.keycloakDatabase.resources | nindent 12 }}
           livenessProbe:
             exec:
               command: [pg_isready, -U, {{ .Values.postgresql.auth.username }}]
@@ -65,7 +83,7 @@ spec:
         {{- end }}
         resources:
           requests:
-            storage: {{ .Values.postgresql.primary.persistence.size }}
+            storage: {{ .Values.keycloakDatabase.persistence.size }}
 ---
 apiVersion: v1
 kind: Service

--- a/infra/helm/values.yaml
+++ b/infra/helm/values.yaml
@@ -350,6 +350,40 @@ minio:
   # MINIO_ACCESS_KEY and MINIO_SECRET_KEY the API reads from its own secret.
   secretRef: openoncology-minio-secrets
 
+# ── Keycloak's database ───────────────────────────────────────────────────────
+# This chart runs TWO PostgreSQL instances and they are easy to confuse.
+#
+#   {release}-postgresql            the Bitnami sub-chart. The APPLICATION
+#                                   database: submissions, mutations, results.
+#                                   Configured under `postgresql:` below.
+#   {release}-openoncology-postgres templates/postgres.yaml. KEYCLOAK's
+#                                   database: users, clients, the realm.
+#                                   Configured here.
+#
+# Until now the second read `postgresql.primary.persistence.size` and
+# `postgresql.primary.resources`, which belong to the first. In production that
+# gave a realm database holding a few megabytes a 200Gi volume, and meant
+# resizing the application database silently resized Keycloak's. See OO-9.
+#
+# IMPORTANT for existing deployments. `volumeClaimTemplates` is immutable on a
+# StatefulSet, so `helm upgrade` will reject a changed size against a cluster
+# where this already exists. Applying it needs a fresh install, or deleting the
+# StatefulSet with `--cascade=orphan` and recreating it. Do not attempt that
+# without a backup of the realm; `docs/RUNBOOK_BACKUP_RESTORE.md` records that
+# this database is not covered by the nightly dump.
+keycloakDatabase:
+  persistence:
+    # Proportionate to what it holds. Keycloak's schema is users, clients,
+    # sessions and the realm, not patient data.
+    size: 10Gi
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "256Mi"
+    limits:
+      cpu: "500m"
+      memory: "1Gi"
+
 # ── Keycloak ──────────────────────────────────────────────────────────────────
 keycloak:
   enabled: true


### PR DESCRIPTION
## Summary

`templates/postgres.yaml` provisions Keycloak's database and was sized from the
application database's values. It has its own now.

Closes `OO-9`.

## Problem

The chart runs two PostgreSQL instances:

| Name | Purpose | Configured by |
|---|---|---|
| `{release}-postgresql` | Application: submissions, mutations, results | Bitnami sub-chart, `postgresql:` |
| `{release}-openoncology-postgres` | Keycloak: users, clients, the realm | `templates/postgres.yaml` |

The second read `postgresql.primary.persistence.size` and
`postgresql.primary.resources`, which belong to the first. Two consequences:

- `values.production.yaml` sets 200Gi for the application database, so Keycloak's
  realm database also requested 200Gi.
- Resizing one silently resized the other.

## Changes

- `keycloakDatabase` values block: 10Gi and its own resource requests.
- `templates/postgres.yaml` reads from it.
- A header comment on that file stating which database it is.
- Four assertions in `test_deployment_manifests.py`.
- The upgrade caveat recorded in `docs/RUNBOOK_BACKUP_RESTORE.md`.

`values.production.yaml` is unchanged. Its 200Gi now reaches only the database it
was written for.

## Why the header comment is part of the fix

A reader arriving at a file called `postgres.yaml` reasonably assumes it is the
application's. That assumption has produced two defects already:

- `HIPAA_COMPLIANCE.md` cited this file as evidence of a backup for patient data
  (corrected in #137).
- The `OO-5` network policy nearly granted the application egress to this
  database rather than its own (caught while scoping #143).

## Not corrected here

The username, database name and credentials secret are still shared with the
application's sub-chart, so Keycloak's database uses the application's
credentials. Splitting them requires new secrets to exist before the chart can
reference them, which is a deployment change rather than a template one. The
template says so rather than leaving it to be found.

## Upgrade impact

`volumeClaimTemplates` is immutable on a StatefulSet, so `helm upgrade` will
**reject** this against a cluster where the StatefulSet already exists. Applying
it needs a fresh install, or deleting the StatefulSet with `--cascade=orphan`
and recreating it.

This database is not covered by the nightly backup, so the realm should be
exported first. The runbook records both points together.

## Verification

| Check | Result |
|---|---|
| `ruff check api/` | Clean |
| api suite | 1268 passed, 4 skipped, 2 xfailed |
| ai suite | 42 passed |
| Coverage | 61.83% against the 52 gate |
| Helm render and kubeconform | Run in `validate-manifests` |

Both guards were verified by breaking them: pointing the size back at the
application's value fails one, and setting both sizes equal fails another. The
second exists because equal numbers would satisfy the first check while still
meaning nobody had chosen either.
