### PR TITLE
Make the degraded-evidence condition alertable

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -57,15 +57,6 @@ Sections are ordered by pipeline position. `/next` pulls from the top of
 - **Out of scope**: who the security officer is, which is the maintainer's decision and not a code change
 - **Risk**: low to implement. Worth noting that assigning an owner in a file is not the same as a person accepting the role, and the checklist can only ever check the first.
 
-### OO-17: The degraded-evidence alarm emits no metric, and two metrics emit nothing
-- **Why**: `settings.degraded_evidence_alert_after` escalates a **log line** to ERROR after a run of static-fallback resolutions. That is the control risk_analysis open action 4 closed, and it can only be seen by someone reading logs: there is no metric, so it cannot alert. Separately, `api/main.py` declares `openoncology_mutations_processed_total` and `openoncology_genomic_pipeline_seconds` and neither is ever incremented, so both are permanently absent from `/metrics`. A rule written against either would look like coverage and never fire, which is why `test_alert_rules.py` rejects them.
-- **Files**: api/main.py, api/services/oncokb_evidence.py, api/workers/genomic_worker.py, infra/alerts/openoncology.rules.yml
-- **Acceptance**:
-  - A counter or gauge reflects consecutive static-fallback resolutions, and an alert fires on a sustained run
-  - The two declared metrics are either incremented at the points they describe, or removed
-  - `test_alert_rules.py`'s allowed-metric set grows only alongside the code that emits them
-- **Out of scope**: what the alert threshold should be, which is the same policy question as `degraded_evidence_alert_after` itself
-- **Risk**: low to implement. Worth noting the evidence path is adjacent to ranking, so the metric should be emitted where the fallback is already logged rather than anywhere new.
 ### OO-7: Decide whether `civic_supplement_enabled` should default to True
 - **Why**: Asked as "how do we raise the benchmark", and the measurements already
   in the repository answer it in a way that rules ranking work out. In

--- a/api/main.py
+++ b/api/main.py
@@ -167,20 +167,21 @@ app.state.limiter = limiter
 # ── Prometheus metrics ────────────────────────────────────────────────────
 try:
     from prometheus_fastapi_instrumentator import Instrumentator
-    from prometheus_client import Counter, Histogram
     Instrumentator(excluded_handlers=["/health", "/ready", "/metrics"]).instrument(app).expose(
         app, endpoint="/metrics", include_in_schema=False
     )
-    MUTATIONS_PROCESSED = Counter(
-        "openoncology_mutations_processed_total",
-        "Total mutations analysed by the AI pipeline",
-        ["oncokb_level"],
-    )
-    PIPELINE_DURATION = Histogram(
-        "openoncology_genomic_pipeline_seconds",
-        "End-to-end genomic pipeline duration in seconds",
-        ["cancer_type"],
-    )
+    # Two metrics used to be declared here, openoncology_mutations_processed_total
+    # and openoncology_genomic_pipeline_seconds, and neither was ever
+    # incremented. They describe work the Celery workers do, and workers are
+    # separate processes: a counter registered in this one could never carry
+    # their data no matter where it was incremented. They were absent from
+    # /metrics for as long as they existed, so an alert written against either
+    # would have stayed silent forever, which is why test_alert_rules.py rejects
+    # them by name.
+    #
+    # Task-level observability comes from celery-exporter against the broker
+    # (OO-16), and the evidence-base signal from a postgres_exporter query over
+    # results.evidence_provenance (OO-17). Both read where the data actually is.
 except ImportError:
     pass  # prometheus-fastapi-instrumentator not installed
 

--- a/api/tests/test_alert_rules.py
+++ b/api/tests/test_alert_rules.py
@@ -59,6 +59,21 @@ EXPORTER_METRICS = {
     "pg_up",
     "pg_stat_activity_count",
     "pg_settings_max_connections",
+    # Custom queries from templates/exporter-queries.yaml (OO-17). Named for the
+    # query block plus the column, which is how postgres_exporter composes them.
+    "openoncology_evidence_results_last_hour",
+    "openoncology_evidence_degraded_last_hour",
+    "openoncology_evidence_withheld_last_hour",
+}
+
+# Declared in api/main.py and never incremented, for as long as they existed.
+# They described work the Celery workers do, and workers are separate processes,
+# so a counter registered in the API could never have carried their data. Both
+# are removed; these names are kept here so a rule written against them fails
+# loudly rather than evaluating against an absent series forever.
+REMOVED_METRICS = {
+    "openoncology_mutations_processed_total",
+    "openoncology_genomic_pipeline_seconds",
 }
 
 _SUFFIXES = ("", "_bucket", "_count", "_sum", "_created")
@@ -230,3 +245,53 @@ def test_celery_task_events_are_enabled():
     source = (REPO_ROOT / "api" / "workers" / "__init__.py").read_text(encoding="utf-8")
     assert "worker_send_task_events=True" in source
     assert "task_send_sent_event=True" in source
+
+
+# ── Metrics that were removed must not come back in a rule ───────────────────
+
+@pytest.mark.parametrize("rule_id,rule", _rules(), ids=[r[0] for r in _rules()])
+def test_no_rule_references_a_removed_metric(rule_id, rule):
+    used = _metric_names(rule["expr"]) & REMOVED_METRICS
+    assert not used, (
+        f"{rule_id} references {sorted(used)}, which api/main.py declared and "
+        "never incremented. They are removed; a rule on them can never fire."
+    )
+
+
+def test_the_removed_metrics_are_actually_gone_from_the_app():
+    """The allowlist rejecting them is only meaningful while nothing emits them."""
+    main = (REPO_ROOT / "api" / "main.py").read_text(encoding="utf-8")
+    for name in REMOVED_METRICS:
+        assert f'"{name}"' not in main, f"{name} is declared again in api/main.py"
+
+
+# ── The degraded-evidence signal is queried, not counted in-process ──────────
+
+def test_the_evidence_query_is_shipped_and_mounted():
+    """
+    OO-17. The worker's counter is a module global in a process nothing scrapes,
+    and it resets on restart, which is exactly when a sustained run of fallbacks
+    would look like it had stopped. The signal comes from the database instead.
+    """
+    queries = REPO_ROOT / "infra" / "helm" / "templates" / "exporter-queries.yaml"
+    assert queries.exists()
+    text = queries.read_text(encoding="utf-8")
+    assert "evidence_provenance" in text
+    assert "is_current" in text
+
+    values = yaml.safe_load((REPO_ROOT / "infra" / "helm" / "values.yaml").read_text(encoding="utf-8"))
+    pg = values["exporters"]["instances"]["postgres"]
+    assert pg.get("queriesConfigMap") is True
+    assert pg["env"].get("PG_EXPORTER_EXTEND_QUERY_PATH"), (
+        "the query file is shipped but the exporter is not told to read it"
+    )
+
+
+def test_absent_provenance_is_treated_as_degraded():
+    """
+    A result predating provenance capture cannot be shown to have used current
+    evidence, and the safe reading of absent is not-current. `coalesce(..., false)`
+    is what makes null count; without it those rows would be silently excluded.
+    """
+    text = (REPO_ROOT / "infra" / "helm" / "templates" / "exporter-queries.yaml").read_text(encoding="utf-8")
+    assert "coalesce" in text.lower()

--- a/infra/alerts/openoncology.rules.yml
+++ b/infra/alerts/openoncology.rules.yml
@@ -179,3 +179,40 @@ groups:
           description: >-
             Redis is the Celery broker. While it is down nothing is queued or
             consumed, and submissions accepted by the API go nowhere.
+
+  - name: openoncology-evidence
+    rules:
+      # risk_analysis.md open action 4. A degraded evidence base means
+      # recommendations are produced from an undated source, and the control
+      # that noticed it was a log line nobody reads. The signal is queried from
+      # results.evidence_provenance rather than counted in the worker, because
+      # the worker's counter is a module global in a process nothing scrapes and
+      # it resets on restart, which is when a sustained run would look like it
+      # had stopped.
+      - alert: EvidenceBaseDegraded
+        expr: openoncology_evidence_degraded_last_hour > 0
+        for: 30m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Results are being produced from an undated evidence base"
+          description: >-
+            One or more results in the last hour resolved actionability from the
+            built-in static table rather than a current source, and that has
+            persisted for half an hour. Recommendations are still being returned
+            unless require_current_evidence is set. Absent provenance counts
+            here: a result that cannot be shown to have used current evidence is
+            treated as not having done so.
+
+      - alert: RecommendationsBeingWithheld
+        expr: openoncology_evidence_withheld_last_hour > 0
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "The degraded-evidence policy is suppressing recommendations"
+          description: >-
+            require_current_evidence is enabled and results are coming back with
+            recommendations withheld. This is the policy working, not failing,
+            but patients and clinicians are receiving empty result sets and
+            somebody should know why.

--- a/infra/helm/templates/exporter-queries.yaml
+++ b/infra/helm/templates/exporter-queries.yaml
@@ -1,0 +1,67 @@
+{{/*
+Custom postgres_exporter queries.
+
+BACKLOG.md OO-17. `settings.degraded_evidence_alert_after` escalates a log line
+to ERROR after a run of static-fallback resolutions. That is the control open
+action 4 closed, and a log line reaches nobody: there was no metric, so it could
+not alert.
+
+The obvious fix, a Prometheus counter beside the log call, does not work here.
+`_CONSECUTIVE_STATIC_FALLBACKS` is a module global in `oncokb_evidence.py`,
+which runs inside the ai worker. Workers are separate processes from the API and
+expose no metrics endpoint, so a counter incremented there would never appear on
+the API's `/metrics`. That is the same constraint that made #145 use
+celery-exporter against the broker rather than instrumenting the workers.
+
+What does survive the process boundary is the database. Every result carries
+`evidence_provenance`, and `is_current` is False whenever the answer came from
+the undated static table. So the signal is queried where it is durably recorded
+rather than where it happened to be computed, which also means it survives a
+worker restart, and a restart is exactly when an in-memory counter resets and
+the run of fallbacks looks like it stopped.
+*/}}
+{{- if and .Values.exporters.enabled .Values.exporters.instances.postgres.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "openoncology.fullname" . }}-exporter-queries
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "openoncology.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres-exporter
+data:
+  queries.yaml: |
+    openoncology_evidence:
+      query: |
+        SELECT
+          count(*) FILTER (
+            WHERE created_at > now() - interval '1 hour'
+          ) AS results_last_hour,
+          count(*) FILTER (
+            WHERE created_at > now() - interval '1 hour'
+              AND coalesce((evidence_provenance ->> 'is_current')::boolean, false) = false
+          ) AS degraded_last_hour,
+          count(*) FILTER (
+            WHERE created_at > now() - interval '1 hour'
+              AND coalesce((evidence_provenance ->> 'recommendations_withheld')::boolean, false)
+          ) AS withheld_last_hour
+        FROM results
+      master: true
+      metrics:
+        - results_last_hour:
+            usage: "GAUGE"
+            description: "Results produced in the last hour"
+        - degraded_last_hour:
+            usage: "GAUGE"
+            description: >-
+              Results in the last hour whose actionability evidence came from an
+              undated source. Null provenance counts as degraded: a result that
+              predates provenance capture cannot be shown to have used current
+              evidence, and the safe reading of absent is not-current.
+        - withheld_last_hour:
+            usage: "GAUGE"
+            description: >-
+              Results in the last hour where the degraded-evidence policy
+              suppressed recommendations. Non-zero means require_current_evidence
+              is on and being exercised.
+{{- end }}

--- a/infra/helm/templates/exporters.yaml
+++ b/infra/helm/templates/exporters.yaml
@@ -116,6 +116,18 @@ spec:
               drop: ["ALL"]
           resources:
             {{- toYaml $.Values.exporters.resources | nindent 12 }}
+          {{- if $cfg.queriesConfigMap }}
+          volumeMounts:
+            - name: queries
+              mountPath: /etc/postgres-exporter
+              readOnly: true
+          {{- end }}
+      {{- if $cfg.queriesConfigMap }}
+      volumes:
+        - name: queries
+          configMap:
+            name: {{ include "openoncology.fullname" $ }}-exporter-queries
+      {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/infra/helm/values.yaml
+++ b/infra/helm/values.yaml
@@ -205,6 +205,12 @@ exporters:
       env:
         DATA_SOURCE_URI: "{{ .Release.Name }}-postgresql:5432/openoncology?sslmode=disable"
         DATA_SOURCE_USER: openoncology
+        # The degraded-evidence query lives in templates/exporter-queries.yaml.
+        # It is read from the database rather than counted in the worker,
+        # because the worker's counter is a module global in a process nothing
+        # scrapes, and it resets on restart. See OO-17.
+        PG_EXPORTER_EXTEND_QUERY_PATH: /etc/postgres-exporter/queries.yaml
+      queriesConfigMap: true
       secretEnv:
         DATA_SOURCE_PASS:
           secret: openoncology-pg-secret


### PR DESCRIPTION
## Summary

Makes the degraded-evidence condition alertable by querying it from the
database, and removes two metrics that were declared and never incremented.

Closes `OO-17`.

## Problem

`settings.degraded_evidence_alert_after` escalates a log line to ERROR after a
run of static-fallback resolutions. That is the control `risk_analysis.md` open
action 4 closed, and it reaches nobody: there was no metric, so the condition
could not alert.

Separately, `api/main.py` declared `openoncology_mutations_processed_total` and
`openoncology_genomic_pipeline_seconds`. Neither was ever incremented, so both
were absent from `/metrics` for as long as they existed.

## Why a counter beside the log call does not work

`_CONSECUTIVE_STATIC_FALLBACKS` is a module global in `oncokb_evidence.py`,
which runs inside the ai worker. Workers are separate processes from the API and
expose no metrics endpoint, so a counter incremented there could never appear on
the API's `/metrics`. This is the same constraint that led #145 to use
celery-exporter against the broker rather than instrument the workers.

It also would not survive a restart, and a restart resets the counter, which is
precisely when a sustained run of fallbacks would appear to have stopped.

## Approach

Every result carries `evidence_provenance`, and `is_current` is False whenever
the answer came from the undated static table. The signal is read from where it
is durably recorded rather than from where it was computed, as a
postgres_exporter custom query mounted into the exporter deployed in #145.

Null provenance counts as degraded, via `coalesce`. A result that cannot be
shown to have used current evidence is treated as not having done so, matching
the default `EvidenceProvenanceOut` already applies.

## Changes

- `templates/exporter-queries.yaml`: a ConfigMap with three gauges over
  `results` — total in the last hour, degraded in the last hour, withheld in the
  last hour.
- The postgres exporter mounts it and is told to read it.
- Two rules: `EvidenceBaseDegraded` and `RecommendationsBeingWithheld`. The
  second is the policy working rather than failing, but it means patients are
  receiving empty result sets and somebody should know why.
- Both dead metrics removed from `api/main.py`, with their names retained in
  `test_alert_rules.py` so a rule written against them fails loudly.

## A disclosure note

`openoncology_genomic_pipeline_seconds` carried a `cancer_type` label. On a
low-volume deployment that publishes which cancers were processed and when,
which is not something an unauthenticated metrics endpoint should carry. #130
closed that endpoint at the ingress; removing the metric closes it at the
source.

## Impact

One ConfigMap and a volume mount on an existing exporter. No application
behaviour changes.

The removed metrics were never populated, so nothing that worked before stops
working.

## Verification

| Check | Result |
|---|---|
| `ruff check api/` | Clean |
| api suite | 1288 passed, 4 skipped, 2 xfailed |
| ai suite | 42 passed |
| Coverage | 61.81% against the 52 gate |
| Helm render and kubeconform | Run in `validate-manifests` |

Four guards, each verified by breaking it: a rule referencing a removed metric
fails two of them, dropping `PG_EXPORTER_EXTEND_QUERY_PATH` fails the mount
check, and the `coalesce` assertion covers the null-provenance reading.

The query has not been executed against a database. What is verified is that it
is shipped, mounted, and that the exporter is told to read it.
