### PR TITLE
Apply the Keycloak session lifetimes the checklist had been quoting

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,38 @@
+# Code owners for OpenOncology.
+#
+# BACKLOG.md OO-15. HIPAA_COMPLIANCE.md recorded a security officer as assigned
+# and cited this file, which did not exist. It exists now, and what it records is
+# review ownership.
+#
+# Naming an owner here is not the same as a person having accepted the HIPAA
+# §164.308(a)(2) security officer role. That is an appointment, not a file, and
+# the compliance checklist says so rather than treating this file as evidence of
+# it.
+
+# Default owner for everything not matched below.
+*                           @immortal71
+
+# ── Paths the PreToolUse guard protects ──────────────────────────────────────
+# .claude/protected-paths.json hard-blocks agent writes here because this
+# repository's four real defects all passed the test suite. Human review is the
+# only control on these, which makes ownership load-bearing rather than
+# administrative.
+/api/ai/                    @immortal71
+/api/services/benchmark.py  @immortal71
+/scripts/                   @immortal71
+/data/                      @immortal71
+/validation_results/        @immortal71
+/test-fixtures/             @immortal71
+/PAPER.md                   @immortal71
+
+# ── Quality gates ────────────────────────────────────────────────────────────
+# Changing a gate is how a gate stops being one.
+/.github/workflows/         @immortal71
+/pyproject.toml             @immortal71
+
+# ── Risk and regulatory documents ────────────────────────────────────────────
+/docs/risk_analysis.md            @immortal71
+/docs/RISK_REGISTER.md            @immortal71
+/docs/REGULATORY_FRAMEWORK.md     @immortal71
+/docs/HIPAA_COMPLIANCE.md         @immortal71
+/docs/ROADMAP_TO_CLINICAL_USE.md  @immortal71

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -55,6 +55,8 @@ Sections are ordered by pipeline position. `/next` pulls from the top of
   - Session lifetimes are set explicitly in the realm configuration the chart deploys, at values someone has chosen, rather than inherited
   - Both rows return to implemented only once `test_compliance_claims.py` passes with them marked so
 - **Out of scope**: who the security officer is, which is the maintainer's decision and not a code change
+- **Progress 2026-08-29**: session lifetimes are applied by `infra/helm/templates/keycloak-session-policy.yaml`, a post-install and post-upgrade Job running `kcadm`, at the 1800s / 28800s the checklist had been quoting without setting. That half is closed and the row is back to implemented. `.github/CODEOWNERS` now exists, naming review ownership for every guard-protected path and every risk document.
+- **Still open**: the security-officer half. A file naming a code owner is not a person accepting the §164.308(a)(2) role. That is an appointment, and it stays at not-implemented until it is recorded somewhere a reviewer can check. Nothing an agent does can close it.
 - **Risk**: low to implement. Worth noting that assigning an owner in a file is not the same as a person accepting the role, and the checklist can only ever check the first.
 
 ### OO-7: Decide whether `civic_supplement_enabled` should default to True

--- a/api/tests/test_compliance_claims.py
+++ b/api/tests/test_compliance_claims.py
@@ -27,6 +27,7 @@ import re
 from pathlib import Path
 
 import pytest
+import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DOC = REPO_ROOT / "docs" / "HIPAA_COMPLIANCE.md"
@@ -260,3 +261,48 @@ def test_every_exemption_still_corresponds_to_a_claimed_control():
 def test_exemptions_carry_a_reason():
     for control, reason in EXEMPT.items():
         assert len(reason.strip()) > 40, f"exemption for {control!r} needs a real reason"
+
+
+# ── Session lifetimes are set, not inherited ─────────────────────────────────
+
+def test_session_lifetimes_are_configured_not_defaulted():
+    """
+    OO-15. The row quoted "30 min idle / 8 hr max" while nothing set either
+    value, so sessions ran at the Keycloak image's defaults. Relying on an
+    upstream default is not configuring one, and the quoted maximum was not that
+    default anyway.
+    """
+    values = yaml.safe_load(
+        (REPO_ROOT / "infra" / "helm" / "values.yaml").read_text(encoding="utf-8")
+    )
+    policy = values["keycloak"]["sessionPolicy"]
+    assert policy["enabled"] is True
+    assert policy["ssoSessionIdleTimeout"] > 0
+    assert policy["ssoSessionMaxLifespan"] > policy["ssoSessionIdleTimeout"]
+
+
+def test_the_session_policy_job_fails_rather_than_reporting_false_success():
+    """
+    A Job that cannot authenticate and exits zero would leave the compliance row
+    claiming a control that is not applied, which is the defect this closes.
+    """
+    job = REPO_ROOT / "infra" / "helm" / "templates" / "keycloak-session-policy.yaml"
+    assert job.exists()
+    text = job.read_text(encoding="utf-8")
+    assert "set -euo pipefail" in text
+    assert "ssoSessionIdleTimeout" in text and "ssoSessionMaxLifespan" in text
+
+
+def test_the_documented_session_figures_match_the_configured_ones():
+    """The row quoting one number while the chart applies another is how this
+    started."""
+    values = yaml.safe_load(
+        (REPO_ROOT / "infra" / "helm" / "values.yaml").read_text(encoding="utf-8")
+    )
+    policy = values["keycloak"]["sessionPolicy"]
+    row = [impl for c, impl in _claimed() if "log-off" in c.lower()]
+    if not row:
+        pytest.skip("automatic log-off is not currently claimed as implemented")
+    text = row[0]
+    assert str(policy["ssoSessionIdleTimeout"]) in text
+    assert str(policy["ssoSessionMaxLifespan"]) in text

--- a/docs/HIPAA_COMPLIANCE.md
+++ b/docs/HIPAA_COMPLIANCE.md
@@ -31,7 +31,7 @@
 
 | Control | Status | Implementation |
 |---|---|---|
-| Security Officer assigned | ⬜ | No CODEOWNERS file exists in this repository, at the root, under `.github/` or under `docs/`. The role is unassigned rather than assigned elsewhere. See BACKLOG.md OO-15 |
+| Security Officer assigned | ⬜ | `.github/CODEOWNERS` now exists and names review ownership, including every guard-protected path. That is not the same as a person having accepted the §164.308(a)(2) role, which is an appointment rather than a file, and this row stays open until that appointment is recorded somewhere a reviewer can check |
 | Risk Analysis performed | ✅ | See `docs/risk_analysis.md` |
 | Workforce training policy | ⬜ | Annual HIPAA training required for all contributors |
 | Sanction policy | ⬜ | Document disciplinary procedure for policy violations |
@@ -60,7 +60,7 @@
 |---|---|---|
 | Unique user identification | ✅ | Keycloak user UUID (`sub`) in every JWT |
 | Emergency access procedure | ⬜ | Document break-glass procedure for oncologist emergency access |
-| Automatic log-off | ⬜ | Nothing here configures `ssoSessionIdleTimeout` or `ssoSessionMaxLifespan`. Sessions run at whatever the Keycloak image defaults to, which is not the 8 hour maximum this row previously stated. Relying on an upstream default is not the same as configuring one. See BACKLOG.md OO-15 |
+| Automatic log-off | ✅ | `ssoSessionIdleTimeout` 1800s and `ssoSessionMaxLifespan` 28800s, applied to the realm by `infra/helm/templates/keycloak-session-policy.yaml` on every install and upgrade. §164.312(a)(2)(iii) requires automatic logoff and names no duration, so these figures are a judgement rather than a finding; they are set in `values.yaml` under `keycloak.sessionPolicy` |
 | Encryption + decryption | ✅ | TLS 1.3 in transit (NGINX ingress); AES-256 at rest (cloud disk encryption) |
 
 ### 3.2 Audit Controls (§164.312(b))

--- a/infra/helm/templates/keycloak-session-policy.yaml
+++ b/infra/helm/templates/keycloak-session-policy.yaml
@@ -1,0 +1,123 @@
+{{/*
+Set session lifetimes on the Keycloak realm.
+
+BACKLOG.md OO-15. HIPAA_COMPLIANCE.md recorded automatic log-off as implemented,
+citing "Keycloak session timeout: 30 min idle / 8 hr max". Nothing in this
+repository set either value, so sessions ran at whatever the image defaults to,
+and the quoted maximum was not that default. The row was corrected to
+not-implemented in #138; this is the gap behind it.
+
+A post-install Job running kcadm rather than a realm import. Importing a realm
+replaces it wholesale, and this chart does not carry the clients, roles and
+mappers a real deployment has accumulated, so an import would silently discard
+them. Updating two attributes on whatever realm exists is the operation actually
+wanted, and it is idempotent: running it twice sets the same values twice.
+
+The hook is post-install and post-upgrade so the values are reasserted on every
+deploy. A setting that drifts because someone changed it in the admin console is
+the same class of problem as the compliance row that claimed it was set.
+
+Not a substitute for the realm existing. If the realm has not been created this
+Job fails, which is the correct outcome: silently succeeding against a realm
+that is not there would recreate exactly the defect being fixed.
+*/}}
+{{- if .Values.keycloak.sessionPolicy.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "openoncology.fullname" . }}-keycloak-session-policy
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "openoncology.labels" . | nindent 4 }}
+    app.kubernetes.io/component: keycloak-session-policy
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  backoffLimit: 4
+  template:
+    metadata:
+      labels:
+        {{- include "openoncology.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: keycloak-session-policy
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ include "openoncology.serviceAccountName" . }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: kcadm
+          image: "{{ .Values.keycloak.image.repository }}:{{ .Values.keycloak.image.tag }}"
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          env:
+            - name: KC_URL
+              value: {{ printf "http://%s-keycloak:8080" (include "openoncology.fullname" .) | quote }}
+            - name: KC_REALM
+              value: {{ .Values.api.env.KEYCLOAK_REALM | quote }}
+            - name: KEYCLOAK_ADMIN
+              value: {{ .Values.keycloak.adminUser | default "admin" | quote }}
+            - name: KEYCLOAK_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.keycloak.secretRef }}
+                  key: {{ .Values.keycloak.adminPasswordKey | default "admin-password" }}
+            - name: IDLE_TIMEOUT
+              value: {{ .Values.keycloak.sessionPolicy.ssoSessionIdleTimeout | quote }}
+            - name: MAX_LIFESPAN
+              value: {{ .Values.keycloak.sessionPolicy.ssoSessionMaxLifespan | quote }}
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+              KCADM=/opt/keycloak/bin/kcadm.sh
+
+              # Keycloak may still be starting when the hook fires.
+              for attempt in $(seq 1 30); do
+                if "$KCADM" config credentials \
+                     --server "$KC_URL" --realm master \
+                     --user "$KEYCLOAK_ADMIN" --password "$KEYCLOAK_ADMIN_PASSWORD" \
+                     >/dev/null 2>&1; then
+                  break
+                fi
+                echo "waiting for Keycloak (${attempt}/30)"
+                sleep 10
+              done
+
+              # Fail rather than continue unauthenticated: a Job that reports
+              # success without having set anything is the defect being fixed.
+              "$KCADM" config credentials \
+                --server "$KC_URL" --realm master \
+                --user "$KEYCLOAK_ADMIN" --password "$KEYCLOAK_ADMIN_PASSWORD"
+
+              "$KCADM" update "realms/${KC_REALM}" \
+                -s "ssoSessionIdleTimeout=${IDLE_TIMEOUT}" \
+                -s "ssoSessionMaxLifespan=${MAX_LIFESPAN}"
+
+              echo "realm ${KC_REALM}: idle=${IDLE_TIMEOUT}s max=${MAX_LIFESPAN}s"
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: kc-home
+              mountPath: /opt/keycloak/.kcadm
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "256Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: kc-home
+          emptyDir: {}
+{{- end }}

--- a/infra/helm/values.yaml
+++ b/infra/helm/values.yaml
@@ -398,6 +398,21 @@ keycloak:
     tag: "24.0"
   replicaCount: 1
   secretRef: openoncology-keycloak-secrets
+  adminUser: admin
+  adminPasswordKey: admin-password
+  # HIPAA_COMPLIANCE.md recorded automatic log-off as implemented and quoted
+  # "30 min idle / 8 hr max". Nothing set either value, so sessions ran at the
+  # image defaults and the quoted maximum was not one of them. See OO-15.
+  #
+  # These are the quoted figures, now actually applied. They are a starting
+  # point rather than a finding: §164.312(a)(2)(iii) requires automatic logoff
+  # and does not name a duration, so the numbers are someone's judgement about
+  # how long a clinician's session should survive unattended. Change them
+  # deliberately rather than inheriting them from this file.
+  sessionPolicy:
+    enabled: true
+    ssoSessionIdleTimeout: 1800    # 30 minutes
+    ssoSessionMaxLifespan: 28800   # 8 hours
 
 # ── Ingress ───────────────────────────────────────────────────────────────────
 ingress:


### PR DESCRIPTION
## Summary

Applies the Keycloak session lifetimes that `HIPAA_COMPLIANCE.md` had been
quoting without setting, and adds the `CODEOWNERS` file that document cited.

Closes the applicable half of `OO-15`. The security-officer half stays open by
design; see below.

## Problem

The automatic log-off row recorded "Keycloak session timeout: 30 min idle / 8 hr
max" as implemented. Nothing in the repository set `ssoSessionIdleTimeout` or
`ssoSessionMaxLifespan`, so sessions ran at the image defaults, and the quoted
maximum was not one of them. The row was corrected in #138; this is the gap
behind it.

The security-officer row cited `CODEOWNERS`, which did not exist.

## Approach: a Job, not a realm import

Importing a realm replaces it wholesale. This chart does not carry the clients,
roles and mappers a real deployment accumulates, so an import would discard them
silently. A post-install and post-upgrade hook running `kcadm` updates two
attributes on whatever realm exists, which is the operation actually wanted, and
is idempotent.

Running on upgrade as well as install means a value changed by hand in the admin
console is reasserted. A setting that drifts is the same class of problem as a
row claiming it was set.

The Job authenticates before acting and fails if it cannot. A hook that exits
zero without setting anything would leave the compliance row claiming a control
that is not applied.

## Changes

- `infra/helm/templates/keycloak-session-policy.yaml`
- `keycloak.sessionPolicy` in `values.yaml`: 1800s idle, 28800s maximum
- `.github/CODEOWNERS`, covering every guard-protected path and every risk
  document, since human review is the only control on those
- Automatic log-off returns to implemented; the security-officer row does not
- Three assertions in `test_compliance_claims.py`

## On the figures

§164.312(a)(2)(iii) requires automatic logoff and names no duration. 1800 and
28800 are the numbers the document had been quoting, now actually applied. They
are a judgement about how long a clinician's session should survive unattended,
not a finding, and `values.yaml` says to change them deliberately rather than
inherit them.

## Why the security-officer row stays open

`CODEOWNERS` records review ownership. It is not a person accepting the
§164.308(a)(2) security officer role, which is an appointment rather than a
file. Nothing in a pull request can record that, so the row stays at
not-implemented until it is recorded somewhere a reviewer can check.

Marking it satisfied because a file now exists would repeat the original defect
in a subtler form.

## Verification

| Check | Result |
|---|---|
| `ruff check api/` | Clean |
| api suite | 1293 passed, 3 skipped, 2 xfailed |
| ai suite | 42 passed |
| Coverage | 61.81% against the 52 gate |
| Helm render and kubeconform | Run in `validate-manifests` |

Guards verified by breaking them: quoting a figure the chart does not apply
fails one, disabling the policy while still claiming it fails another.

The compliance guard from #138 also caught this change while it was being
written. The new row initially cited `templates/keycloak-session-policy.yaml`
rather than the repo-relative path, and the test rejected it.

The Job has not been executed. No cluster is available, so what is verified is
that it renders, validates, and that the figures in the document match the ones
the chart applies.
