### PR TITLE
Restore the backlog sections that entry removals deleted

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -59,6 +59,28 @@ Sections are ordered by pipeline position. `/next` pulls from the top of
 - **Still open**: the security-officer half. A file naming a code owner is not a person accepting the §164.308(a)(2) role. That is an appointment, and it stays at not-implemented until it is recorded somewhere a reviewer can check. Nothing an agent does can close it.
 - **Risk**: low to implement. Worth noting that assigning an owner in a file is not the same as a person accepting the role, and the checklist can only ever check the first.
 
+---
+
+## In progress
+
+<!-- One entry maximum. An entry stranded here means a session died mid-work;
+     /standup will surface it. -->
+
+---
+
+## In review
+
+<!-- Entry plus PR URL. Cleared by hand when merged. -->
+
+---
+
+## Needs human decision
+
+<!-- Anything an agent declined to do unattended: guard-hook blocks, validator
+     BLOCKs, mis-scoped entries, and anything the planner marked
+     Risk: scientific. This section is the safety valve. When it grows, that is
+     the system working, not failing. -->
+
 ### OO-7: Decide whether `civic_supplement_enabled` should default to True
 - **Why**: Asked as "how do we raise the benchmark", and the measurements already
   in the repository answer it in a way that rules ranking work out. In
@@ -101,7 +123,53 @@ Sections are ordered by pipeline position. `/next` pulls from the top of
 
 ## Done
 
+
 <!-- Merged entries, newest first. Trim periodically. -->
+
+### OO-15: Session lifetimes applied; security officer still unassigned
+Half closed in [#148](https://github.com/immortal71/openoncology/pull/148). A
+`kcadm` Job applies `ssoSessionIdleTimeout` 1800s and `ssoSessionMaxLifespan`
+28800s on install and upgrade, which are the figures HIPAA_COMPLIANCE.md had been
+quoting without setting. `.github/CODEOWNERS` now exists.
+
+The entry stays in Ready. A file naming a code owner is not a person accepting
+the §164.308(a)(2) role, and nothing in a pull request can record an appointment.
+
+### OO-17: The degraded-evidence condition is alertable
+Merged in [#147](https://github.com/immortal71/openoncology/pull/147). A counter
+beside the log call could not work: the fallback count is a module global in the
+ai worker, a separate process from the API with no metrics endpoint, and it
+resets on restart, which is when a sustained run would look like it had stopped.
+The signal is read from `results.evidence_provenance` by a postgres_exporter
+query instead. Two metrics declared in `api/main.py` and never incremented were
+removed rather than wired up.
+
+### OO-9: Keycloak's database sized from its own values
+Merged in [#146](https://github.com/immortal71/openoncology/pull/146). It read
+the application sub-chart's values, so production gave a realm database a 200Gi
+volume and resizing one silently resized the other. `volumeClaimTemplates` is
+immutable, so applying this to an existing cluster needs a recreate; the runbook
+records that next to the note that this database is not backed up.
+
+### OO-16: Exporters deployed, queue depth alertable
+Merged in [#145](https://github.com/immortal71/openoncology/pull/145).
+`redis_key_size{key="gdpr"}` is the number of erasure requests waiting. Celery
+task events had to be enabled for any task metric to exist at all, which is
+guarded, because without them every `celery_*` rule evaluates against an absent
+series and stays silent.
+
+### OO-18: The chart deploys the object storage it pointed at
+Merged in [#144](https://github.com/immortal71/openoncology/pull/144).
+`MINIO_ENDPOINT` named `{release}-minio:9000` and nothing created it, so every
+upload, report write and object deletion failed, as did the backup job. Found
+while scoping OO-5, because a policy cannot grant egress to a pod nothing
+creates.
+
+### OO-5: Network policies for the chart, off by default
+Merged in [#143](https://github.com/immortal71/openoncology/pull/143). Not a port
+of the `infra/k8s` set: that selects on a label `_helpers.tpl` never emits, uses
+equality where workers render four component values, and points at Keycloak's
+database rather than the application's. All three fail closed and render clean.
 
 ### OO-14: A compliance mark must cite something that exists
 Merged in [#138](https://github.com/immortal71/openoncology/pull/138).

--- a/api/tests/test_deployment_manifests.py
+++ b/api/tests/test_deployment_manifests.py
@@ -600,3 +600,98 @@ def test_the_template_says_which_database_it_is():
     head = text[: text.index("apiVersion")]
     assert "KEYCLOAK" in head.upper()
     assert "not the application" in head.lower()
+
+
+# ── The backlog's safety valve still exists ──────────────────────────────────
+#
+# BACKLOG.md lost three section headers across #144 to #148. Each of those PRs
+# removed a completed entry with a helper that located the end of a block by
+# searching for the next "### ", which skips over "## " section headers. Removing
+# the last entry in a section therefore swallowed the following header and its
+# comment.
+#
+# The consequence was not cosmetic. OO-7 and OO-8 are both Risk: scientific and
+# belong in "Needs human decision", which CLAUDE.md calls the safety valve and
+# which /next never pulls from. With the header gone they sat under "## Ready",
+# which /next pulls from the top of. An agent could have taken a decision about
+# which drugs the system recommends.
+#
+# Every check stayed green throughout, because nothing asserted the structure.
+
+BACKLOG = REPO_ROOT / "BACKLOG.md"
+_REQUIRED_SECTIONS = [
+    "Ready",
+    "In progress",
+    "In review",
+    "Needs human decision",
+    "Done",
+]
+
+
+def _backlog_entries() -> list[tuple[str, str]]:
+    """(section, entry title) for every ### entry."""
+    out, section = [], None
+    for line in BACKLOG.read_text(encoding="utf-8").splitlines():
+        if line.startswith("## "):
+            section = line[3:].strip()
+        elif line.startswith("### ") and section:
+            out.append((section, line[4:].strip()))
+    return out
+
+
+def test_every_backlog_section_is_present():
+    offsets = _heading_offsets()
+    missing = [s for s in _REQUIRED_SECTIONS if s not in offsets]
+    assert not missing, (
+        f"BACKLOG.md is missing sections: {missing}. Entries that belonged to "
+        "them are now filed under whichever section precedes them."
+    )
+
+
+def _heading_offsets() -> dict:
+    """
+    Line-anchored, because the file's own preamble mentions `## Ready` and
+    `## Needs human decision` in prose. A substring search finds those first,
+    which is the same mistake as scanning a template's comments for selectors.
+    """
+    text = BACKLOG.read_text(encoding="utf-8")
+    return {
+        m.group(1).strip(): m.start()
+        for m in re.finditer(r"^## (.+)$", text, re.M)
+    }
+
+
+def test_the_sections_are_in_pipeline_order():
+    """Order carries meaning: /next pulls from the top of Ready."""
+    offsets = _heading_offsets()
+    positions = [offsets[s] for s in _REQUIRED_SECTIONS if s in offsets]
+    assert len(positions) == len(_REQUIRED_SECTIONS), "a section heading is missing"
+    assert positions == sorted(positions), "backlog sections are out of order"
+
+
+def test_no_scientific_risk_entry_sits_in_ready():
+    """
+    The safety valve. CLAUDE.md: anything Risk: scientific stays in "Needs human
+    decision", and nothing pulls from there. An entry that drifts into Ready is
+    one an agent may pick up unattended.
+    """
+    text = BACKLOG.read_text(encoding="utf-8")
+    offsets = _heading_offsets()
+    ready = text[offsets["Ready"]:offsets["In progress"]]
+    offenders = re.findall(r"^### (.+)$", ready, re.M)
+    scientific = []
+    for title in offenders:
+        start = ready.index(f"### {title}")
+        nxt = ready.find("### ", start + 4)
+        block = ready[start: nxt if nxt != -1 else len(ready)]
+        if re.search(r"\*\*Risk\*\*:.*scientific", block):
+            scientific.append(title)
+    assert not scientific, (
+        f"Risk: scientific entries are in Ready, which /next pulls from: {scientific}"
+    )
+
+
+def test_in_progress_holds_at_most_one_entry():
+    """The file says one maximum; more than one means a session died mid-work."""
+    in_progress = [t for sec, t in _backlog_entries() if sec == "In progress"]
+    assert len(in_progress) <= 1, f"In progress holds {len(in_progress)} entries"


### PR DESCRIPTION
## Summary

`BACKLOG.md` lost three section headers across #144 to #148, which moved two
`Risk: scientific` entries into `Ready`. This restores the structure, moves them
back, and adds guards.

Documentation and tests only.

## Problem

Each of #144 through #148 removed a completed entry from `Ready` using a helper
that located the end of a block by searching for the next `### `. That search
skips `## ` section headers, so removing the **last** entry in a section
swallowed the following header and its comment.

Three sections were lost: `In progress`, `In review`, `Needs human decision`.

## Why this mattered

`OO-7` and `OO-8` are both `Risk: scientific` and belong in
`Needs human decision`, which `CLAUDE.md` calls the safety valve and which
`/next` never pulls from. With the header gone they sat under `## Ready`, which
`/next` pulls from the top of.

| Entry | Decides |
|---|---|
| `OO-7` | Whether to widen the actionability table, and so which drugs the system can recommend |
| `OO-8` | Whether results are produced at all from an undated evidence base |

Both were one `/next` invocation away from being picked up unattended.

Every check stayed green across five merges, because nothing asserted the
structure. This is the same shape as F11, F14, F18 and the compliance rows: a
control that disappeared, with every existing assertion pointed at something
present.

## Changes

- Sections restored from `3be5fd5`, the last intact version, with their comments.
- `OO-7` and `OO-8` moved back to `Needs human decision`.
- `Done` gains an entry for each of #143 through #148.
- Four guards in `test_deployment_manifests.py`.

## The guards

| Guard | Catches |
|---|---|
| Every section present | The failure that occurred |
| Sections in pipeline order | A section reinserted in the wrong place |
| No `Risk: scientific` entry in `Ready` | The consequence, independently of the cause |
| `In progress` holds at most one entry | What the file already says, now enforced |

They match headings line-anchored rather than by substring, because the file's
own preamble mentions two section names in prose and a substring search finds
those first. That surfaced as the order guard failing against a correct file. It
is the same mistake as scanning a template's comments for selectors, which
happened in #143, so it has now been made twice in this area and is worth
recording rather than quietly fixing.

## Verification

| Check | Result |
|---|---|
| `ruff check api/` | Clean |
| api suite | 1297 passed, 3 skipped, 2 xfailed |
| ai suite | 42 passed |
| Coverage | 61.81% against the 52 gate |
| Guards against `main`'s damaged file | Three of four fail |

The last row is the one that matters: the guards were run against the actual
broken file rather than a synthetic one.
