### PR TITLE
A staging environment that is hardened rather than relaxed

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -1,6 +1,25 @@
 from pydantic import field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+# Environments where the hardening checks below are deliberately relaxed, because
+# they hold no real data and are not reachable from outside.
+#
+# The list is of the RELAXED ones on purpose. Every guard used to be written as
+# `environment == "production"`, so `staging` fell into a third state with the
+# development conveniences off and the safety checks off as well: it accepted the
+# literal default SECRET_KEY, the default MinIO password, and no audience claim.
+# It failed open and silently, which is the wrong direction for the one
+# environment that most resembles production.
+#
+# Keyed this way, an unrecognised value gets the guards rather than losing them,
+# so a typo like "prod" or "Production" is hardened rather than wide open.
+_RELAXED_ENVIRONMENTS = {"development", "test"}
+
+
+def is_hardened(environment: str) -> bool:
+    """True for any environment that is not explicitly a local or CI one."""
+    return (environment or "").strip().lower() not in _RELAXED_ENVIRONMENTS
+
 
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
@@ -150,16 +169,18 @@ class Settings(BaseSettings):
     @classmethod
     def _validate_secret_key(cls, v: str, info) -> str:
         env = (info.data or {}).get("environment", "development")
-        if env == "production" and v == "dev-secret-key-change-in-production":
+        if is_hardened(env) and v == "dev-secret-key-change-in-production":
             raise ValueError(
-                "SECRET_KEY must be changed from the default value in production. "
+                f"SECRET_KEY must be changed from the default value in {env!r}. "
                 "Generate one with: python -c \"import secrets; print(secrets.token_hex(32))\""
             )
         return v
 
     @model_validator(mode="after")
     def _validate_production_settings(self) -> "Settings":
-        if self.environment == "production":
+        # Applies to staging as much as production. Staging for a system holding
+        # patient genomic data is not a scratch environment.
+        if is_hardened(self.environment):
             if not self.sentry_dsn:
                 import logging
                 logging.getLogger("openoncology.config").warning(

--- a/api/main.py
+++ b/api/main.py
@@ -10,7 +10,7 @@ from redis import asyncio as redis_asyncio
 from slowapi.errors import RateLimitExceeded
 from sqlalchemy import select, text
 
-from config import settings
+from config import settings, is_hardened
 from database import engine, Base, AsyncSessionLocal
 from middleware.audit import AuditMiddleware
 from middleware.rate_limit import limiter
@@ -136,8 +136,10 @@ async def _seed_local_demo_data() -> None:
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    # ── Production safety guards ───────────────────────────────────────────
-    if settings.environment == "production":
+    # ── Safety guards for any non-local environment ────────────────────────
+    # Keyed on the environment class rather than the literal string
+    # "production", so staging gets them too. See config.is_hardened.
+    if is_hardened(settings.environment):
         if settings.secret_key == "dev-secret-key-change-in-production":
             raise RuntimeError("SECRET_KEY must be set to a secure value in production")
         if any("localhost" in o or "127.0.0.1" in o for o in settings.cors_allow_origins):
@@ -230,7 +232,8 @@ async def add_security_headers(request: Request, call_next):
     response.headers.setdefault("Referrer-Policy", "no-referrer")
     response.headers.setdefault("Permissions-Policy", "camera=(), microphone=(), geolocation=()")
     response.headers.setdefault("Content-Security-Policy", "default-src 'self'; frame-ancestors 'none'; base-uri 'self'")
-    if settings.environment == "production":
+    # Staging is served over TLS through the same ingress, so it gets HSTS too.
+    if is_hardened(settings.environment):
         response.headers.setdefault("Strict-Transport-Security", "max-age=63072000; includeSubDomains; preload")
     return response
 

--- a/api/tests/test_deployment_manifests.py
+++ b/api/tests/test_deployment_manifests.py
@@ -695,3 +695,77 @@ def test_in_progress_holds_at_most_one_entry():
     """The file says one maximum; more than one means a session died mid-work."""
     in_progress = [t for sec, t in _backlog_entries() if sec == "In progress"]
     assert len(in_progress) <= 1, f"In progress holds {len(in_progress)} entries"
+
+
+# ── Staging is hardened, not relaxed ─────────────────────────────────────────
+#
+# Every safety check used to read `environment == "production"` while every
+# convenience read `environment == "development"`, so `staging` landed in a third
+# state with the conveniences off and the guards off too. It accepted the literal
+# default SECRET_KEY, the default MinIO password, and an empty audience, and it
+# did so silently. That is the wrong direction for the environment that most
+# resembles production.
+
+STAGING_VALUES = HELM / "values.staging.yaml"
+
+
+def test_a_staging_values_file_exists():
+    """
+    values.yaml calls itself the base for development and staging while setting
+    ENVIRONMENT: production, so a staging deploy from it ran as production under
+    a different name.
+    """
+    assert STAGING_VALUES.exists()
+
+
+def test_staging_names_its_environment_honestly():
+    values = yaml.safe_load(STAGING_VALUES.read_text(encoding="utf-8"))
+    assert values["api"]["env"]["ENVIRONMENT"] == "staging"
+
+
+def test_staging_is_treated_as_hardened():
+    from config import is_hardened
+
+    assert is_hardened("staging")
+    assert is_hardened("production")
+    assert not is_hardened("development")
+    assert not is_hardened("test")
+
+
+def test_an_unrecognised_environment_is_hardened():
+    """A typo must lose the conveniences, not the guards."""
+    from config import is_hardened
+
+    for typo in ("prod", "Production", "stagng", ""):
+        assert is_hardened(typo), f"{typo!r} would run without the safety checks"
+
+
+def test_staging_rejects_the_default_credentials():
+    """The concrete hole: Settings(environment='staging') used to accept all three."""
+    from config import Settings
+
+    with pytest.raises(ValueError):
+        Settings(environment="staging")
+
+    with pytest.raises(ValueError, match="KEYCLOAK_AUDIENCE"):
+        Settings(
+            environment="staging",
+            secret_key="x" * 64,
+            minio_secret_key="not-the-default",
+            sentry_dsn="https://example@sentry.invalid/1",
+            keycloak_audience="",
+        )
+
+
+def test_staging_relaxes_capacity_and_not_security():
+    """
+    The file is allowed to shrink replicas and volumes. It must not turn off a
+    control that production keeps, other than the disruption budget, which
+    cannot be satisfied by a single replica.
+    """
+    staging = yaml.safe_load(STAGING_VALUES.read_text(encoding="utf-8"))
+    assert staging["backup"]["enabled"] is True
+    assert staging["exporters"]["enabled"] is True
+    assert staging.get("ingress", {}).get("tls", {}).get("enabled") is True
+    assert staging["api"]["podDisruptionBudget"]["enabled"] is False
+    assert staging["api"]["replicaCount"] == 1

--- a/infra/helm/values.staging.yaml
+++ b/infra/helm/values.staging.yaml
@@ -1,0 +1,105 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# OpenOncology Helm Values — STAGING overrides
+# Usage: helm upgrade --install openoncology-staging ./infra/helm \
+#          -f infra/helm/values.yaml \
+#          -f infra/helm/values.staging.yaml \
+#          --namespace openoncology-staging
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# Why this file exists. values.yaml describes itself as the base for
+# "development / staging" and sets ENVIRONMENT: production, so a staging deploy
+# from the base file alone ran as production while being called staging. Naming
+# the environment honestly is the point of this file.
+#
+# ENVIRONMENT: staging is NOT a relaxation. `config.is_hardened` treats anything
+# outside {development, test} as hardened, so staging enforces the same
+# requirements production does: a real SECRET_KEY, a non-default MinIO password,
+# KEYCLOAK_AUDIENCE set, no localhost in CORS, and HSTS on responses. That is
+# deliberate. Staging for a system handling patient genomic data is not a
+# scratch environment, and the point of staging is to find what breaks under
+# production rules before production does.
+#
+# What this file relaxes is capacity and blast radius, not security.
+
+api:
+  replicaCount: 1
+  autoscaling:
+    enabled: false
+  env:
+    ENVIRONMENT: staging
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "256Mi"
+    limits:
+      cpu: "500m"
+      memory: "1Gi"
+  # One replica, so a disruption budget requiring one available blocks every
+  # node drain. Off here; production keeps it.
+  podDisruptionBudget:
+    enabled: false
+
+web:
+  replicaCount: 1
+  resources:
+    requests:
+      cpu: "50m"
+      memory: "128Mi"
+    limits:
+      cpu: "250m"
+      memory: "512Mi"
+
+workers:
+  genomic:
+    replicaCount: 1
+  ai:
+    replicaCount: 1
+  notify:
+    replicaCount: 1
+  gdpr:
+    replicaCount: 1
+
+postgresql:
+  primary:
+    persistence:
+      size: 20Gi
+
+keycloakDatabase:
+  persistence:
+    size: 5Gi
+
+minio:
+  persistence:
+    size: 20Gi
+
+redis:
+  master:
+    persistence:
+      size: 2Gi
+
+# Backups stay on. A staging deploy is where the restore drill in
+# docs/RUNBOOK_BACKUP_RESTORE.md should be exercised, and OO-12 stays open until
+# somebody has. Shorter retention because these dumps are for practising the
+# restore, not for keeping.
+backup:
+  enabled: true
+  retentionDays: 7
+  schedule: "0 2 * * *"
+
+exporters:
+  enabled: true
+
+# Off, as in production, until someone has watched what it does to a running
+# deployment. Staging is the right place to turn it on first: a wrong selector
+# fails closed, and finding that here is the entire purpose of this environment.
+networkPolicy:
+  enabled: false
+
+ingress:
+  hosts:
+    api: api.staging.openoncology.org
+    web: staging.openoncology.org
+    keycloak: auth.staging.openoncology.org
+  tls:
+    enabled: true
+    secretName: openoncology-staging-tls


### PR DESCRIPTION
## Summary

Adds `values.staging.yaml`, and fixes what `ENVIRONMENT=staging` did before that
file could safely exist.

## Problem

`values.yaml` describes itself as the base for "development / staging" and sets
`ENVIRONMENT: production`. A staging deploy from it therefore ran as production
under a different name.

Naming the environment honestly turned out to be unsafe, because of how the
environment string was used:

| Check | Was keyed on | Effect for `staging` |
|---|---|---|
| Default `SECRET_KEY` rejected | `== "production"` | Skipped |
| Default MinIO password rejected | `== "production"` | Skipped |
| `KEYCLOAK_AUDIENCE` required | `== "production"` | Skipped |
| localhost in CORS rejected | `== "production"` | Skipped |
| HSTS header sent | `== "production"` | Skipped |
| API docs exposed | `== "development"` | Correctly off |
| Demo auth bypass | `== "development"` | Correctly off |

Every safety check read `production`; every convenience read `development`. So
`staging` fell into a third state with the conveniences off and the guards off
as well.

Demonstrated before the fix:

```
Settings(environment='staging')
  secret_key       : dev-secret-key-change-in-production
  minio_secret_key : password
  keycloak_audience: ''
  -> accepted without complaint
```

It failed open, silently, in the environment that most resembles production.

## Fix

`config.is_hardened()` decides, and it names the **relaxed** set rather than the
hardened one: `{development, test}` are relaxed, everything else is hardened.

That direction matters twice. Staging inherits production's requirements, which
is the point of having a staging environment. And an unrecognised value gets the
guards rather than losing them, so `prod`, `Production` or a typo is hardened
instead of wide open.

The relaxed set is enumerated rather than written as "not production" because CI
runs with `ENVIRONMENT=test` and would otherwise have to satisfy production's
secret requirements to run its own suite. Confirmed still booting.

`main.py`'s lifespan guards and HSTS header now use the same predicate.

## values.staging.yaml

Relaxes capacity and blast radius, not security. Replicas and volumes shrink;
backups, exporters and TLS stay on.

The one control it disables is the API PodDisruptionBudget, because a single
replica with a budget requiring one available blocks every node drain.

`networkPolicy` stays off, as in production. Staging is where it should be
enabled first: a wrong selector fails closed, and finding that in staging is
what staging is for.

## Impact

Behaviour changes for any deployment whose `ENVIRONMENT` is not `development`,
`test` or `production`. There are none in this repository today, so nothing
currently deployed changes.

A staging deploy now requires real secrets. That is the intended effect.

## Verification

| Check | Result |
|---|---|
| `ruff check api/` | Clean |
| api suite | 1303 passed, 3 skipped, 2 xfailed |
| ai suite | 42 passed |
| Coverage | 61.84% against the 52 gate |
| `ENVIRONMENT=test` still boots | Confirmed |

Three of the six new guards were verified by reverting `is_hardened` to
production-only, which fails them.

## What this does not do

This does not make a staging deploy possible. Nothing in this repository
publishes container images: the CI job is `Docker build (no push)`, and the chart
pulls `ghcr.io/openoncology/api:latest`, which is never produced. A `helm
install` still gets `ImagePullBackOff` before any of this is reached.
