### PR TITLE
Publish container images, so a deploy can pull something

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,18 +376,86 @@ jobs:
       - name: Validate docker-compose
         run: docker compose -f docker-compose.yml config --quiet
 
-  # ── Docker build check ────────────────────────────────────────────────────
-  docker-build:
-    name: Docker build (no push)
+  # ── Container images ──────────────────────────────────────────────────────
+  # Until this job existed, CI built both images and discarded them. Nothing in
+  # the repository ever published one, so the chart's ghcr.io/... references
+  # named images that had never been produced and a helm install could only ever
+  # reach ImagePullBackOff.
+  #
+  # It runs on pull requests too, with push disabled. A publish job that only
+  # runs after merge is one whose first execution is also its first test, and
+  # the failure lands on main.
+  #
+  # `needs:` is kept deliberately. An image that reaches the registry without
+  # passing the benchmark gate and both test suites is an image somebody can
+  # deploy.
+  publish-images:
+    name: Build and publish container images
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: [lint-frontend, test-frontend, e2e-frontend, test-backend]
+
+    permissions:
+      contents: read
+      # GITHUB_TOKEN is enough for GHCR on a repository in the same account, so
+      # there is no secret to create, store or rotate.
+      packages: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: api
+            context: .
+            dockerfile: api/Dockerfile
+          - name: web
+            context: ./web
+            dockerfile: ./web/Dockerfile
 
     steps:
       - uses: actions/checkout@v7
 
-      - name: Build API image
-        run: docker build -t openoncology-api:ci -f api/Dockerfile .
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
 
-      - name: Build web image
-        run: docker build -t openoncology-web:ci ./web
+      - name: Log in to GHCR
+        # Skipped on pull requests, where nothing is pushed and a fork would
+        # have no token with package scope.
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # sha- and version tags are immutable and are what a values file should
+      # pin. `latest` is published as a convenience and deliberately points at
+      # nothing anyone deploys: a mutable tag means a pod restart can change the
+      # running version, and this system's output is clinical evidence whose
+      # provenance has to be answerable.
+      - name: Compute tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}/${{ matrix.name }}
+          tags: |
+            type=sha,prefix=sha-,format=short
+            type=ref,event=tag
+            type=semver,pattern=v{{version}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.name }}
+          cache-to: type=gha,scope=${{ matrix.name }},mode=max
+
+      - name: Report what was published
+        if: github.event_name != 'pull_request'
+        run: |
+          echo "Published:"
+          echo "${{ steps.meta.outputs.tags }}" | sed 's/^/  /'

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -59,6 +59,18 @@ Sections are ordered by pipeline position. `/next` pulls from the top of
 - **Still open**: the security-officer half. A file naming a code owner is not a person accepting the §164.308(a)(2) role. That is an appointment, and it stays at not-implemented until it is recorded somewhere a reviewer can check. Nothing an agent does can close it.
 - **Risk**: low to implement. Worth noting that assigning an owner in a file is not the same as a person accepting the role, and the checklist can only ever check the first.
 
+### OO-19: Pin the deployed image tags once images exist
+- **Why**: `values.yaml` uses `latest` for the api and web images. That is mutable: a pod restart can change the running version, and nothing records which code produced a given result. For software whose output is clinical evidence this is the same defect as the mutable pipeline container tags in OO-6, on the images that run the ranking. #151 added `publish-images`, which emits an immutable `sha-<short>` on every push to main and a `v*` tag on a git tag, so the tags to pin will exist after the first merge.
+- **Not done in #151 on purpose**: no image has been published yet, and pinning a tag that does not exist is worse than pinning a mutable one. It has to follow the first successful publish rather than accompany it.
+- **Files**: infra/helm/values.staging.yaml, infra/helm/values.production.yaml, api/tests/test_deployment_manifests.py
+- **Acceptance**:
+  - `values.staging.yaml` pins `api.image.tag` and `web.image.tag` to a `sha-` tag that exists in the registry
+  - `values.production.yaml` pins a `v*` tag
+  - A test fails if either file uses `latest`, or omits a tag and so inherits it
+  - `values.yaml` may keep `latest`, since it is the base and is never deployed from alone
+- **Out of scope**: digest pinning for these two images, which is stricter again and belongs with OO-6's decision about how digests get refreshed
+- **Risk**: low. Worth noting the first pin cannot be verified from this repository: whether the tag resolves is a property of the registry.
+
 ---
 
 ## In progress

--- a/api/tests/test_deployment_manifests.py
+++ b/api/tests/test_deployment_manifests.py
@@ -769,3 +769,67 @@ def test_staging_relaxes_capacity_and_not_security():
     assert staging.get("ingress", {}).get("tls", {}).get("enabled") is True
     assert staging["api"]["podDisruptionBudget"]["enabled"] is False
     assert staging["api"]["replicaCount"] == 1
+
+
+# ── Images are published, and the chart names ones that exist ────────────────
+#
+# Until publish-images existed, CI built both images and discarded them. The job
+# was called "Docker build (no push)" and did exactly that, so the chart's
+# ghcr.io references named images the repository had never produced. A helm
+# install could only reach ImagePullBackOff, before any other configuration
+# mattered.
+
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def _workflow() -> dict:
+    return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+
+
+def test_ci_publishes_images():
+    jobs = _workflow()["jobs"]
+    assert "publish-images" in jobs, "nothing publishes container images"
+    steps = jobs["publish-images"]["steps"]
+    uses = [s.get("uses", "") for s in steps]
+    assert any("build-push-action" in u for u in uses)
+
+
+def test_publishing_waits_for_the_gates():
+    """
+    An image that reaches the registry without passing the benchmark gate and
+    both test suites is an image somebody can deploy.
+    """
+    needs = _workflow()["jobs"]["publish-images"]["needs"]
+    assert "test-backend" in needs, "images could publish without the backend gates"
+
+
+def test_publishing_has_package_write_permission():
+    perms = _workflow()["jobs"]["publish-images"]["permissions"]
+    assert perms.get("packages") == "write"
+
+
+def test_the_build_is_exercised_on_pull_requests():
+    """
+    A publish job that only runs after merge has its first execution and its
+    first test on main. The push is disabled on pull requests; the build is not.
+    """
+    steps = _workflow()["jobs"]["publish-images"]["steps"]
+    push = [s for s in steps if "build-push-action" in s.get("uses", "")]
+    assert push, "no build step found"
+    assert "pull_request" in str(push[0]["with"]["push"]), (
+        "the build step pushes unconditionally, or does not run on pull requests"
+    )
+
+
+@pytest.mark.parametrize("component", ["api", "web"])
+def test_the_chart_names_an_image_this_repository_publishes(component, helm_values):
+    """
+    The chart named `ghcr.io/openoncology/...`, an account that does not own this
+    repository, so the reference could not resolve even once images existed.
+    GHCR paths are ghcr.io/<owner>/<repo>/<component>.
+    """
+    repo = helm_values[component]["image"]["repository"]
+    assert repo.startswith("ghcr.io/immortal71/openoncology/"), (
+        f"{component} image {repo!r} is not a path publish-images produces"
+    )
+    assert repo.endswith(f"/{component}")

--- a/infra/helm/values.yaml
+++ b/infra/helm/values.yaml
@@ -14,7 +14,18 @@ namespace: openoncology
 # ── API (FastAPI) ─────────────────────────────────────────────────────────────
 api:
   image:
-    repository: ghcr.io/openoncology/api
+    # ghcr.io/<owner>/<repo>/<component>, which is what publish-images in ci.yml
+    # produces. This previously named ghcr.io/openoncology, an account that does
+    # not own this repository, so the reference could not have resolved even
+    # once images existed.
+    repository: ghcr.io/immortal71/openoncology/api
+    # `latest` is a placeholder, not a deployment choice. It is mutable, so a pod
+    # restart can change the running version, and this system's output is
+    # clinical evidence whose provenance has to be answerable. Pin `sha-<short>`
+    # for staging and a `v*` tag for production once images exist; BACKLOG.md
+    # OO-19 tracks that, and it is deliberately not done here because no image
+    # has been published yet and pinning a tag that does not exist is worse than
+    # pinning a mutable one.
     tag: latest
     pullPolicy: IfNotPresent
   replicaCount: 2
@@ -61,7 +72,7 @@ api:
 # ── Web (Next.js) ─────────────────────────────────────────────────────────────
 web:
   image:
-    repository: ghcr.io/openoncology/web
+    repository: ghcr.io/immortal71/openoncology/web
     tag: latest
     pullPolicy: IfNotPresent
   replicaCount: 2


### PR DESCRIPTION
## Summary

Adds a job that publishes the API and web images to GHCR, and corrects the
chart's image paths, which named a registry account that does not own this
repository.

This is gate 1 of a staging deploy. Files `OO-19`.

## Problem

No image has ever been published from this repository. The existing job was
named `Docker build (no push)` and did exactly that: it proved both Dockerfiles
compile and discarded the result.

The chart referenced `ghcr.io/openoncology/api:latest`, which was never
produced. A `helm install` reached `ImagePullBackOff` before any other
configuration was exercised, which put this upstream of every deployment fix
landed this week.

The paths were also wrong independently. `ghcr.io/openoncology` is not an
account that owns this repository; GHCR paths are
`ghcr.io/<owner>/<repo>/<component>`. The reference could not have resolved even
once images existed.

## Design decisions

**GHCR with `GITHUB_TOKEN`.** The repository is public and on GitHub, so this
needs no account, no stored secret, and no billing. It needs `packages: write`
on the job, which is the entirety of the setup. Docker Hub would mean an account
and a PAT to rotate.

**Three tags.**

| Tag | When | Intended use |
|---|---|---|
| `sha-<short>` | push to main | Immutable. What staging should pin |
| `v*` | git tag | Immutable. What production should pin |
| `latest` | push to main | Convenience. Nothing should deploy from it |

`latest` is mutable, so a pod restart can change the running version. For
software whose output is clinical evidence and whose risk register turns on
provenance, that is the same defect as the mutable pipeline container tags in
`OO-6`, on the images that run the ranking.

**Builds on pull requests, pushes only after merge.** A publish job whose first
execution is also its first test puts that failure on `main`. Here the build,
the context, the Dockerfile and the cache are all exercised by this PR; only the
push is skipped.

**`needs:` retained.** An image cannot reach the registry without both test
suites, the E2E run and the hard benchmark gate passing. An image in a registry
is one somebody can deploy.

## Two things left for you

**Package visibility.** After the first publish the packages appear under the
repository. They default to private, which means the cluster needs an
`imagePullSecret`. Making them public removes that, and means anyone can pull
your API image. That is a deliberate choice and I have not made it.

**Tag pinning is `OO-19`, not this PR.** No image has been published yet, and
pinning a tag that does not exist is worse than pinning a mutable one. It has to
follow the first successful publish.

## Verification

| Check | Result |
|---|---|
| `ruff check api/` | Clean |
| api suite | 1309 passed, 3 skipped, 2 xfailed |
| ai suite | 42 passed |
| Coverage | 61.84% against the 52 gate |
| `ci.yml` parses | Yes |

Five guards, all verified by breaking them: reverting the job to build-only
fails four of them, and restoring the wrong registry org fails the fifth.

The push path itself is unverified, and cannot be verified from a pull request.
The first real test is the run on `main` after this merges. If the token scope or
the package path is wrong, that is where it will show.
