### PR TITLE
Pin staging to an immutable image tag, and document the install

### DIFF
--- a/api/tests/test_deployment_manifests.py
+++ b/api/tests/test_deployment_manifests.py
@@ -833,3 +833,116 @@ def test_the_chart_names_an_image_this_repository_publishes(component, helm_valu
         f"{component} image {repo!r} is not a path publish-images produces"
     )
     assert repo.endswith(f"/{component}")
+
+
+# ── Deployed image tags are immutable ────────────────────────────────────────
+#
+# OO-19. `latest` is mutable, so a pod restart can change the running version and
+# nothing records which code produced a result. For software whose output is
+# clinical evidence that is the same defect as the mutable pipeline container
+# tags in OO-6, applied to the images that run the ranking.
+#
+# values.yaml keeps `latest`. It is the base, is never deployed from alone, and
+# an environment file always overrides it.
+
+_MUTABLE_TAGS = {"latest", "main", "master", "edge", "stable"}
+_ENV_VALUES = {
+    "staging": HELM / "values.staging.yaml",
+    "production": HELM / "values.production.yaml",
+}
+
+
+def _pinned_tags(path: Path) -> dict:
+    values = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    return {
+        component: values.get(component, {}).get("image", {}).get("tag")
+        for component in ("api", "web")
+    }
+
+
+def test_staging_pins_immutable_image_tags():
+    """
+    A `sha-` tag exists for every commit on main, so staging has no reason to
+    inherit a mutable one.
+    """
+    tags = _pinned_tags(_ENV_VALUES["staging"])
+    for component, tag in tags.items():
+        assert tag, f"staging does not pin an image tag for {component}"
+        assert tag not in _MUTABLE_TAGS, (
+            f"staging pins {component} to the mutable tag {tag!r}"
+        )
+
+
+@pytest.mark.parametrize("env", sorted(_ENV_VALUES))
+def test_no_environment_pins_a_mutable_tag(env):
+    """
+    Covers both directions: a file that pins must not pin something mutable.
+    Production currently sets no tag and so inherits `latest` from the base,
+    which is why this asserts on what is set rather than on what is absent.
+    Pinning production needs a `v*` release tag to exist first, and none does.
+    """
+    for component, tag in _pinned_tags(_ENV_VALUES[env]).items():
+        if tag is None:
+            continue
+        assert tag not in _MUTABLE_TAGS, (
+            f"{env} pins {component} to the mutable tag {tag!r}"
+        )
+
+
+def test_the_pinned_tag_matches_what_publish_images_produces():
+    """
+    The job emits `sha-<short>` and `v*`. A tag in another shape is one the
+    registry does not have, which fails at pull time rather than here.
+    """
+    for component, tag in _pinned_tags(_ENV_VALUES["staging"]).items():
+        assert re.fullmatch(r"(sha-[0-9a-f]{7,}|v\d+\.\d+\.\d+)", tag), (
+            f"staging pins {component} to {tag!r}, which publish-images does not emit"
+        )
+
+
+# ── The staging runbook matches the chart ────────────────────────────────────
+#
+# A deploy runbook that omits a required secret sends someone into a
+# CrashLoopBackOff with no idea why. It drifts the moment the chart gains a
+# dependency, and nothing about a stale runbook looks wrong.
+
+STAGING_RUNBOOK = REPO_ROOT / "docs" / "RUNBOOK_STAGING_DEPLOY.md"
+
+
+def test_the_staging_runbook_exists():
+    assert STAGING_RUNBOOK.exists()
+
+
+def test_the_runbook_documents_every_secret_the_chart_requires(helm_values):
+    """
+    Five secrets must exist before install. Two of them stop the API booting at
+    all, because staging is hardened.
+    """
+    required = {
+        helm_values["api"]["secretRef"],
+        helm_values["minio"]["secretRef"],
+        helm_values["keycloak"]["secretRef"],
+        helm_values["postgresql"]["auth"]["existingSecret"],
+        helm_values["backup"]["objectStore"]["credentialsSecret"],
+    }
+    text = STAGING_RUNBOOK.read_text(encoding="utf-8")
+    missing = sorted(s for s in required if s not in text)
+    assert not missing, f"the runbook does not tell anyone to create: {missing}"
+
+
+def test_the_runbook_covers_every_worker_queue(helm_values):
+    """A queue nobody checks for is one nobody notices is absent, which is how
+    the gdpr queue went unconsumed."""
+    text = STAGING_RUNBOOK.read_text(encoding="utf-8")
+    missing = [q for q in helm_values["workers"] if q not in text]
+    assert not missing, f"the runbook's checks omit queues: {missing}"
+
+
+def test_the_runbook_names_the_audience_the_chart_expects(helm_values):
+    """
+    The audience mapper is the step most easily missed, and missing it makes
+    every request 401.
+    """
+    text = STAGING_RUNBOOK.read_text(encoding="utf-8")
+    assert helm_values["api"]["env"]["KEYCLOAK_AUDIENCE"] in text
+    assert "audience mapper" in text.lower()

--- a/docs/RUNBOOK_STAGING_DEPLOY.md
+++ b/docs/RUNBOOK_STAGING_DEPLOY.md
@@ -1,0 +1,280 @@
+# Runbook: first staging deploy
+
+**Status.** Gates 1 and 3 are done. Images publish to GHCR on every push to
+`main`, and `values.staging.yaml` names the environment honestly and pins an
+immutable tag. What remains needs a cluster and secrets, which is what this
+document is for.
+
+**Read this first.** Nothing in the chart has ever run. Every manifest renders
+and passes `kubeconform`, and not one has been applied to a cluster. MinIO has
+never started, the backup CronJob has never dumped anything, the `kcadm` Job has
+never authenticated, and no Prometheus has loaded the alert rules. Expect the
+first install to find things. That is what it is for.
+
+**This is research-use software.** `docs/ROADMAP_TO_CLINICAL_USE.md` is the
+authority on what that means. Staging must not receive real patient data.
+
+---
+
+## Step 0: decide package visibility
+
+The `publish-images` job pushes to GHCR, and packages default to **private**.
+
+- **Private**, the safer default. The cluster needs an `imagePullSecret`, added
+  in step 3.
+- **Public**, simpler. Anyone can pull your API and web images. The images
+  contain your application code; the repository is already public, so this
+  mostly changes how easily someone runs it, not what they can read.
+
+To make them public: repository → Packages → select the package → Package
+settings → Change visibility.
+
+Decide now, because step 3 differs.
+
+---
+
+## Step 1: cluster prerequisites
+
+```bash
+kubectl create namespace openoncology-staging
+```
+
+You need:
+
+- An ingress controller. The chart assumes **ingress-nginx**; the network policy
+  values name its namespace as `ingress-nginx`.
+- A default **StorageClass**. Four volumes are claimed: Postgres, Keycloak's
+  Postgres, MinIO and Redis.
+- **cert-manager** with a `letsencrypt-prod` ClusterIssuer, or change
+  `ingress.annotations` and supply your own TLS secret.
+
+Confirm:
+
+```bash
+kubectl get storageclass
+kubectl get ns ingress-nginx
+kubectl get clusterissuer letsencrypt-prod
+```
+
+---
+
+## Step 2: create the five secrets
+
+The API refuses to start in staging without a real `SECRET_KEY` and a
+`KEYCLOAK_AUDIENCE`. That is deliberate: `config.is_hardened()` treats staging
+like production, so a staging deploy exercises production's requirements.
+
+Generate values that are not the defaults:
+
+```bash
+NS=openoncology-staging
+
+SECRET_KEY=$(python -c "import secrets; print(secrets.token_hex(32))")
+PG_PASSWORD=$(python -c "import secrets; print(secrets.token_urlsafe(24))")
+PG_ADMIN=$(python -c "import secrets; print(secrets.token_urlsafe(24))")
+MINIO_USER=openoncology
+MINIO_PASSWORD=$(python -c "import secrets; print(secrets.token_urlsafe(24))")
+KC_ADMIN_PASSWORD=$(python -c "import secrets; print(secrets.token_urlsafe(24))")
+```
+
+Then:
+
+```bash
+# 1. API. KEYCLOAK_AUDIENCE must match the audience mapper created in step 4.
+kubectl -n "$NS" create secret generic openoncology-api-secrets \
+  --from-literal=SECRET_KEY="$SECRET_KEY" \
+  --from-literal=KEYCLOAK_AUDIENCE=openoncology-api \
+  --from-literal=MINIO_ACCESS_KEY="$MINIO_USER" \
+  --from-literal=MINIO_SECRET_KEY="$MINIO_PASSWORD"
+
+# 2. Postgres, used by the Bitnami sub-chart and by Keycloak's database.
+kubectl -n "$NS" create secret generic openoncology-pg-secret \
+  --from-literal=password="$PG_PASSWORD" \
+  --from-literal=postgres-password="$PG_ADMIN"
+
+# 3. MinIO. Must match the API's MINIO_ACCESS_KEY and MINIO_SECRET_KEY above;
+#    nothing in the chart can check that they agree.
+kubectl -n "$NS" create secret generic openoncology-minio-secrets \
+  --from-literal=MINIO_ROOT_USER="$MINIO_USER" \
+  --from-literal=MINIO_ROOT_PASSWORD="$MINIO_PASSWORD"
+
+# 4. Keycloak admin.
+kubectl -n "$NS" create secret generic openoncology-keycloak-secrets \
+  --from-literal=admin-password="$KC_ADMIN_PASSWORD"
+
+# 5. Backup. An mc alias URL pointing at the in-cluster MinIO.
+kubectl -n "$NS" create secret generic openoncology-backup-secrets \
+  --from-literal=mc-host-url="http://${MINIO_USER}:${MINIO_PASSWORD}@openoncology-staging-minio:9000"
+```
+
+**Record these somewhere.** Losing `SECRET_KEY` invalidates sessions; losing the
+Postgres password locks you out of the database, which has no backup until the
+CronJob has run at least once.
+
+Optional, if you want the corresponding features: add `STRIPE_SECRET_KEY`,
+`RESEND_API_KEY`, `OPENAI_API_KEY` and `ONCOKB_API_TOKEN` to
+`openoncology-api-secrets`. Without `ONCOKB_API_TOKEN` the system uses the
+curated static table, which is a supported mode rather than a degraded one, but
+`EvidenceBaseDegraded` will fire because provenance is correctly recorded as not
+current.
+
+---
+
+## Step 3: image pull secret, only if packages are private
+
+Skip if you made them public in step 0.
+
+```bash
+kubectl -n "$NS" create secret docker-registry ghcr-pull \
+  --docker-server=ghcr.io \
+  --docker-username=immortal71 \
+  --docker-password=<a PAT with read:packages>
+```
+
+Then add to your install:
+
+```
+--set global.imagePullSecrets[0].name=ghcr-pull
+```
+
+---
+
+## Step 4: Keycloak realm and the audience mapper
+
+Keycloak deploys with the chart, but the realm is not created for you.
+
+1. Reach the admin console at `https://auth.staging.openoncology.org`, logging in
+   as `admin` with `KC_ADMIN_PASSWORD`.
+2. Create a realm named `openoncology`.
+3. Create a confidential client `openoncology-api` and a public client
+   `openoncology-web`.
+4. **Add an audience mapper** to `openoncology-api`: Client scopes → the
+   client's dedicated scope → Add mapper → By configuration → Audience → set
+   *Included Client Audience* to `openoncology-api`, and *Add to access token*
+   on.
+
+Step 4.4 is the one people miss. Keycloak puts the client id in `azp` and
+`"account"` in `aud` by default, so without the mapper every token fails the
+audience check added in #130 and the API returns 401 for everything.
+
+Verify a token carries the right audience before installing:
+
+```bash
+# after obtaining a token, decode the payload
+python -c "import base64,json,sys; p=sys.argv[1].split('.')[1]; print(json.loads(base64.urlsafe_b64decode(p+'==')).get('aud'))" <token>
+```
+
+---
+
+## Step 5: install
+
+```bash
+helm dependency update infra/helm
+
+helm upgrade --install openoncology-staging ./infra/helm \
+  --namespace openoncology-staging \
+  -f infra/helm/values.yaml \
+  -f infra/helm/values.staging.yaml
+```
+
+Watch it come up:
+
+```bash
+kubectl -n openoncology-staging get pods -w
+```
+
+---
+
+## Step 6: what to check, in this order
+
+Each of these is a control added recently that has never executed.
+
+**Pods start and the API is ready.** Readiness is `/ready`, which round-trips
+Postgres and Redis, so a Ready pod means both are reachable.
+
+```bash
+kubectl -n openoncology-staging get pods
+kubectl -n openoncology-staging exec deploy/openoncology-staging-openoncology-api -- \
+  wget -qO- localhost:8000/ready
+```
+
+**Every queue has a consumer.** Four worker deployments must exist: `genomic`,
+`ai`, `notify`, `gdpr`. The last one is the reason `DELETE /api/me` used to
+promise a deletion that never happened.
+
+```bash
+kubectl -n openoncology-staging get deploy | grep worker
+```
+
+**Beat is scheduling.** Without it neither the GDPR retention sweep nor the
+stale-submission recovery ever runs.
+
+```bash
+kubectl -n openoncology-staging logs deploy/openoncology-staging-openoncology-beat --tail=20
+```
+
+**Object storage answers.** If this fails, every upload fails.
+
+```bash
+kubectl -n openoncology-staging exec sts/openoncology-staging-minio -- \
+  mc --version
+```
+
+**The backup runs.** Do not wait for 02:00; trigger it.
+
+```bash
+kubectl -n openoncology-staging create job --from=cronjob/openoncology-staging-openoncology-db-backup backup-test
+kubectl -n openoncology-staging logs job/backup-test
+```
+
+**Then restore from it.** This is the step that closes `OO-12`, and until
+somebody does it, `HIPAA_COMPLIANCE.md` correctly says there is no contingency
+plan. `docs/RUNBOOK_BACKUP_RESTORE.md` has the procedure. Staging is exactly
+where it should happen.
+
+**Session lifetimes were applied.** The `kcadm` Job runs post-install.
+
+```bash
+kubectl -n openoncology-staging logs job/openoncology-staging-openoncology-keycloak-session-policy
+```
+
+---
+
+## Step 7: after it works
+
+- **Turn on NetworkPolicies.** `--set networkPolicy.enabled=true`. They are off
+  by default because a wrong selector fails closed, and staging is where you
+  want to discover that. Check the datastore selectors against
+  `kubectl get pod --show-labels` first, because Bitnami's labels vary by
+  sub-chart version.
+- **Point Prometheus at the alert rules** and set an Alertmanager address.
+  `infra/prometheus.yml` leaves `alertmanagers: []` deliberately, because a
+  wrong address fails silently: rules evaluate, alerts fire, nothing receives
+  them.
+- **Cut a release tag** so production has an immutable tag to pin, which is what
+  `OO-19` still has open:
+
+  ```bash
+  git tag v1.0.0 && git push origin v1.0.0
+  ```
+
+  That produces `ghcr.io/immortal71/openoncology/api:v1.0.0`, after which
+  `values.production.yaml` can pin it.
+
+---
+
+## If something fails
+
+Most likely, in rough order:
+
+| Symptom | Cause |
+|---|---|
+| `ImagePullBackOff` | Packages are private and no `imagePullSecret` was set. Step 3 |
+| API `CrashLoopBackOff` | `SECRET_KEY` or `KEYCLOAK_AUDIENCE` missing. The log says which |
+| Every request returns 401 | The audience mapper in step 4.4 |
+| Uploads fail | MinIO credentials do not match between the two secrets |
+| Backup job fails | `mc-host-url` wrong, or MinIO not yet ready |
+| Pods pending | No StorageClass, or the volumes exceed the cluster's capacity |
+
+Record what actually broke. An install that revealed three misconfigurations is
+a successful staging deploy, and the list is worth more than a clean run.

--- a/infra/helm/values.staging.yaml
+++ b/infra/helm/values.staging.yaml
@@ -21,7 +21,15 @@
 #
 # What this file relaxes is capacity and blast radius, not security.
 
+# Immutable tags. `latest` is mutable, so a pod restart can change the running
+# version and nothing records which code produced a given result. Both images
+# below were published by the `publish-images` job from commit 770ce3f.
+#
+# Bump these deliberately. Deploying becomes an explicit act of changing a tag,
+# which is also what makes a rollback a one-line revert.
 api:
+  image:
+    tag: sha-770ce3f
   replicaCount: 1
   autoscaling:
     enabled: false
@@ -40,6 +48,8 @@ api:
     enabled: false
 
 web:
+  image:
+    tag: sha-770ce3f
   replicaCount: 1
   resources:
     requests:


### PR DESCRIPTION
## Summary

Pins staging to the immutable image tag that now exists, and adds a runbook for
the remaining gates.

Closes `OO-19` for staging. Production stays open; see below.

## Pinning

`publish-images` ran on `main` and pushed
`ghcr.io/immortal71/openoncology/{api,web}:sha-770ce3f`, so an immutable tag
exists for the first time. `values.staging.yaml` pins it.

It previously inherited `latest` from the base values. That is mutable: a pod
restart can change the running version, and nothing records which code produced
a given result. For software whose output is clinical evidence, that is the same
defect as the mutable pipeline container tags in `OO-6`, applied to the images
that run the ranking.

**Production is not pinned.** It needs a `v*` tag and none exists. Pinning a tag
that does not exist is worse than pinning a mutable one, so it waits on:

```bash
git tag v1.0.0 && git push origin v1.0.0
```

The guard covers both directions: staging must pin, and must pin a shape
`publish-images` emits; any environment file that sets a tag must not set a
mutable one. `values.yaml` keeps `latest`, being the base and never deployed
from alone.

## Runbook

`docs/RUNBOOK_STAGING_DEPLOY.md` covers gates 0, 2, 4, 5 and 6: package
visibility, the five secrets with generation commands, cluster prerequisites,
the Keycloak realm, the install, and what to verify afterwards.

Two parts worth reading rather than skimming.

**Step 4.4, the audience mapper.** Keycloak puts the client id in `azp` and
`"account"` in `aud` by default. Without an explicit mapper, every token fails
the audience check added in #130 and the API returns 401 for everything. It is
the step most easily missed and the hardest to diagnose.

**Step 6 is ordered by what has never executed.** Every control landed this week
renders and passes `kubeconform` and has never run: MinIO has not started, the
backup CronJob has not dumped anything, the `kcadm` Job has not authenticated,
no Prometheus has loaded the alert rules. The runbook says to expect the first
install to find things, and that an install revealing three misconfigurations is
a successful one.

It also points at the restore drill, since staging is where `OO-12` should be
closed and `HIPAA_COMPLIANCE.md` correctly reports no contingency plan until
someone has restored from a backup.

## Guards

Four assertions keep the runbook from drifting: every secret the chart requires
is documented, every worker queue appears in the verification steps, and the
audience it names matches the chart's value. A runbook omitting a secret sends
someone into a `CrashLoopBackOff` with no idea why, and nothing about a stale one
looks wrong.

## Verification

| Check | Result |
|---|---|
| `ruff check api/` | Clean |
| api suite | 1317 passed, 3 skipped, 2 xfailed |
| ai suite | 42 passed |
| Coverage | 61.84% against the 52 gate |
| Runbook secrets vs chart | All five present, checked programmatically |

The pinned tag's existence in the registry cannot be verified from this
repository. It was confirmed from the `publish-images` run on `main`, which
reported both tags.
