### PR TITLE
FHIR export reported every variant as uncertain significance

### DIFF
--- a/api/services/fhir_export.py
+++ b/api/services/fhir_export.py
@@ -30,6 +30,23 @@ from services.intended_use import (
 )
 
 
+
+def _enum_value(value, default: str = "") -> str:
+    """
+    The string form of a model field, unwrapping SQLAlchemy enums.
+
+    `str(SubmissionStatus.complete)` is "SubmissionStatus.complete", not
+    "complete". Every value read here arrives as an enum from the ORM and as a
+    plain string from a test fixture, and the difference was invisible until the
+    export was run against a real row: statuses fell through to "unknown" and
+    every variant was reported as uncertain significance regardless of its
+    classification.
+    """
+    if value is None:
+        return default
+    return str(getattr(value, "value", value))
+
+
 def build_diagnostic_report(
     submission: object,
     result: object,
@@ -58,7 +75,7 @@ def build_diagnostic_report(
         issued_str = str(issued)
 
     clinician_reviewed = bool(getattr(result, "oncologist_reviewed", False)) if result else False
-    status = _map_status(getattr(submission, "status", "unknown"), clinician_reviewed)
+    status = _map_status(_enum_value(getattr(submission, "status", None), "unknown"), clinician_reviewed)
 
     observation_refs = [
         {"reference": f"Observation/mutation-{m.id}"}
@@ -159,8 +176,8 @@ def build_observation(mutation: object, clinician_reviewed: bool = False) -> dic
     """
     gene = getattr(mutation, "gene", "UNKNOWN")
     hgvs = getattr(mutation, "hgvs_notation", None) or ""
-    classification = str(getattr(mutation, "classification", "uncertain"))
-    oncokb_level = str(getattr(mutation, "oncokb_level", "unknown"))
+    classification = _enum_value(getattr(mutation, "classification", None), "uncertain")
+    oncokb_level = _enum_value(getattr(mutation, "oncokb_level", None), "unknown")
     alphamissense = getattr(mutation, "alphamissense_score", None)
     is_targetable = getattr(mutation, "is_targetable", False)
     chromosome = getattr(mutation, "chromosome", None)

--- a/api/tests/test_intended_use_coverage.py
+++ b/api/tests/test_intended_use_coverage.py
@@ -211,3 +211,97 @@ async def test_intended_use_survives_a_failed_patient_summary(
     assert "patient_summary" in body["generation_errors"]
     assert body["intended_use"]["intended_use"] == "research"
     assert "RESEARCH USE ONLY" in body["intended_use"]["statement"]
+
+
+# ── The export reads ORM enums, not strings ──────────────────────────────────
+#
+# The fixtures above use plain strings for status, classification and
+# oncokb_level. SQLAlchemy hands the export enum members, and
+# `str(SubmissionStatus.complete)` is "SubmissionStatus.complete", not
+# "complete". Everything below passed against strings and was wrong against a
+# real row:
+#
+#   DiagnosticReport.status  fell through to "unknown" for every submission,
+#                            so the #131 preliminary/final distinction never
+#                            took effect at all.
+#   Observation interpretation  fell through to "Uncertain significance" for
+#                            every variant, so a likely-pathogenic targetable
+#                            KRAS variant was exported to an EMR as uncertain
+#                            while the report's own conclusionCode said
+#                            Pathogenic. The two contradicted each other.
+#
+# Found by running the API and reading the output, which no test had done.
+
+from models.mutation import MutationClassification, OncoKBLevel  # noqa: E402
+from models.submission import SubmissionStatus  # noqa: E402
+
+
+class _OrmSubmission(_Submission):
+    """As SQLAlchemy actually presents it."""
+    status = SubmissionStatus.complete
+
+
+class _OrmMutation(_Mutation):
+    classification = MutationClassification.likely_pathogenic
+    oncokb_level = OncoKBLevel.level_4
+
+
+def _orm_report(reviewed: bool = False) -> dict:
+    result = _Result()
+    result.oncologist_reviewed = reviewed
+    return build_diagnostic_report(
+        submission=_OrmSubmission(),
+        result=result,
+        mutations=[_OrmMutation()],
+        patient_id_fhir="Patient/p-1",
+    )
+
+
+def test_status_is_mapped_from_an_orm_enum():
+    """`unknown` for a completed submission is what this looked like."""
+    assert _orm_report(reviewed=False)["status"] == "preliminary"
+    assert _orm_report(reviewed=True)["status"] == "final"
+
+
+def test_a_pathogenic_variant_is_not_exported_as_uncertain():
+    """
+    The clinically significant half. A likely-pathogenic, targetable variant
+    reported to an EMR as uncertain significance understates it in the format
+    designed to be filed in a patient's chart.
+    """
+    obs = build_observation(_OrmMutation())
+    codings = [c for i in obs.get("interpretation", []) for c in i.get("coding", [])]
+    displays = [c.get("display") for c in codings]
+    assert "Uncertain significance" not in displays, (
+        f"a likely-pathogenic variant is reported as {displays}"
+    )
+    assert "Pathogenic" in displays
+
+
+def test_the_report_and_its_observations_agree():
+    """
+    conclusionCode came from a bool and was right; the interpretation came from
+    a stringified enum and was wrong, so the two disagreed on the same variant.
+    """
+    report = _orm_report()
+    obs = build_observation(_OrmMutation())
+    report_says = [c["coding"][0]["display"] for c in report.get("conclusionCode", [])]
+    obs_says = [c.get("display") for i in obs.get("interpretation", []) for c in i.get("coding", [])]
+    assert set(report_says) & set(obs_says), (
+        f"report says {report_says}, observation says {obs_says}"
+    )
+
+
+@pytest.mark.parametrize(
+    "status,expected",
+    [
+        (SubmissionStatus.queued, "registered"),
+        (SubmissionStatus.processing, "partial"),
+        (SubmissionStatus.failed, "cancelled"),
+    ],
+)
+def test_every_submission_status_maps_from_its_enum(status, expected):
+    """All of them returned `unknown`, not just the completed case."""
+    from services.fhir_export import _enum_value
+
+    assert _map_status(_enum_value(status)) == expected


### PR DESCRIPTION
## Summary

The FHIR export stringified SQLAlchemy enum members instead of reading their
values, so every DiagnosticReport reported `status: unknown` and every variant
was exported as `Uncertain significance` regardless of its classification.

Found by running the API against its own seeded database and reading the output.
No test had done that.

## What a real row produced

| Field | Database | FHIR export said |
|---|---|---|
| `submissions.status` | `complete` | `unknown` |
| `mutations.classification` | `likely_pathogenic` | `Uncertain significance` |
| `mutations.oncokb_level` | `4` | ignored |
| `results.has_targetable_mutation` | `True` | `Pathogenic` (correct) |

The last row is a boolean, so it worked. The result is a report whose
`conclusionCode` says **Pathogenic** while its own Observation says **Uncertain
significance**, about the same variant, in the format designed to be filed in a
patient's chart.

## Cause

`str(SubmissionStatus.complete)` is `"SubmissionStatus.complete"`, not
`"complete"`.

- `_map_status` lowercased that to `"submissionstatus.complete"`, matched no
  key, and returned the `"unknown"` fallback. Every submission, in every state.
- `_interpretation_coding` compared `"MutationClassification.likely_pathogenic"`
  against `"likely_pathogenic"`, and `"OncoKBLevel.level_4"` against
  `("1", "2", "3A")`. Neither matched, so every variant fell through to
  uncertain.

`_enum_value()` unwraps `.value` when present and falls back to `str`, so both
ORM members and the plain strings a fixture supplies work.

## Why the tests missed it

The fixtures in `test_intended_use_coverage.py` set `status`, `classification`
and `oncokb_level` as plain strings. That is not what SQLAlchemy produces, so
every assertion passed against values the code never receives in production.

Added `_OrmSubmission` and `_OrmMutation` using the real enums. The three new
tests fail against the previous stringification, verified by reverting it.

## Two things about the shape of this

**It predates #131.** That change added a `preliminary` / `final` distinction to
a function whose input never matched any branch, so the distinction was correct
and unreachable. The PR was not wrong; it was inert.

**The two failures point in opposite directions.** `unknown` instead of `final`
errs safe: it understates completeness. `Uncertain significance` instead of
`Pathogenic` errs unsafe: it understates a variant's significance to whoever
reads the chart.

## Verified against a running server

Before:

```
DiagnosticReport.status : unknown
interpretation          : Uncertain significance
conclusionCode          : Pathogenic
```

After:

```
DiagnosticReport.status : preliminary
Observation.status      : preliminary
interpretation          : Pathogenic
conclusionCode          : Pathogenic
```

## Verification

| Check | Result |
|---|---|
| `ruff check api/` | Clean |
| api suite | 1323 passed, 3 skipped, 2 xfailed |
| ai suite | 42 passed |
| Coverage | 61.84% against the 52 gate |
| New tests against the old code | 3 fail, as intended |
| Live API against the seeded database | Correct on all four fields |
