### PR TITLE
A submitted sample never reached the end of the chain

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -141,6 +141,23 @@ Sections are ordered by pipeline position. `/next` pulls from the top of
   unsafe clinical one.
 - **Risk**: scientific / policy — this is a hazard control, not a config tidy
 
+### OO-21: VCF ingestion feeds coding notation to a lookup keyed on protein notation
+- **Why**: `_parse_and_annotate_vcf` stores `INFO/HGVS_C` as `mutations.hgvs_notation`. The evidence table is keyed on protein alterations: `_normalise_alteration("p.Thr790Met")` gives `t790m`, and `_normalise_alteration("c.2369C>T")` gives `c2369c>t`, which matches nothing. Measured directly against the shipped table:
+
+  ```
+  get_all_drugs_for_variant("EGFR", "T790M")     -> 7 drugs  ['osimertinib', 'erlotinib', 'gefitinib', ...]
+  get_all_drugs_for_variant("EGFR", "c.2369C>T") -> 0 drugs  []
+  ```
+
+  So a VCF carrying EGFR T790M, which the table knows maps to seven drugs, yields no recommendation. Submitting `samples/egfr_t790m_demo.vcf` end to end produces `recommendation_state: no_targetable_mutation`, with both EGFR and TP53 stored as `classification: uncertain`, `is_targetable: 0`, `oncokb_level: unknown`.
+
+  Three things make it look deliberate until you check. `INFO/HGVS_P` is present in the sample VCFs and is read nowhere in the application. The `mutations.hgvs_p` column existed in `0001_initial_schema` and was dropped by `a8bf7eb4833c`. And `ai_worker._hgvs_to_short(hgvs_p: str)` names its parameter for protein notation, does `hgvs_p.lstrip("p.")`, and is passed `mutation.hgvs_notation`, which holds the coding form.
+
+  This is hazard H2, an actionable variant present and not surfaced, and it is F2's shape reaching the same outcome by a different route. The benchmarks do not see it because they feed protein notation straight to the ranker and never pass through VCF ingestion, which is why the suite reports P@3 0.80 while the ingestion path returns nothing.
+- **Risk**: scientific. Changing which notation reaches the evidence table changes which drugs are recommended for every submission, so it is not an agent's call, and it wants a decision about whether to store both notations, prefer `HGVS_P`, or derive protein from coding.
+- **Files to consider**: api/workers/genomic_worker.py `_parse_and_annotate_vcf`, api/models/mutation.py, a migration restoring a protein column, api/workers/ai_worker.py `_hgvs_to_short`
+- **Worth checking alongside**: whether any real submission has ever produced a recommendation, and whether the concordance and holdout numbers were computed through ingestion or around it.
+
 ---
 
 ## Done

--- a/api/routes/submit.py
+++ b/api/routes/submit.py
@@ -128,10 +128,20 @@ async def submit_sample(
     )
     db.add(submission)
     await db.flush()  # get submission.id before commit
+    submission_id = submission.id
+
+    # Commit BEFORE enqueueing. The worker opens its own session and looks the
+    # submission up by id, so a task that starts before this transaction commits
+    # finds nothing. That was not a narrow race: with Celery eager, which is how
+    # development runs when Redis is unreachable, apply_async executes inline and
+    # the lookup failed every time, so no submission made in development was ever
+    # processed. In production the window is small and real, and losing it is
+    # silent in all three places that could have caught it.
+    await db.commit()
 
     # Queue genomic pipeline background job
     job = run_genomic_pipeline.apply_async(
-        args=[submission.id, patient.id, biopsy_key, dna_key, cancer_type, dna_r2_key],
+        args=[submission_id, patient.id, biopsy_key, dna_key, cancer_type, dna_r2_key],
         queue="genomic",
     )
     submission.pipeline_job_id = job.id

--- a/api/tests/test_submission_pipeline_path.py
+++ b/api/tests/test_submission_pipeline_path.py
@@ -1,0 +1,145 @@
+"""
+A submission reaches the worker, and the worker can read what was uploaded.
+
+Found by submitting `samples/egfr_t790m_demo.vcf` through the running API. The
+chain failed at four separate points, none of which any test covered, because
+nothing had ever submitted anything.
+
+  1. `submit.py` enqueued the pipeline task before committing the transaction
+     that creates the submission. The worker opens its own session and looks the
+     row up by id, so it found nothing. With Celery eager, which is how
+     development runs when Redis is unreachable, that is deterministic: no
+     submission made in development was ever processed. In production the window
+     is small and real.
+
+  2. The worker treated a missing row as success. It logged and returned, so
+     Celery marked the task succeeded and nothing retried.
+
+  3. `sweep_stale_submissions` covered only `processing`. A submission whose task
+     never started stays `queued`, which the sweeper that exists to catch stuck
+     work did not look at. Between them, 1 to 3 meant a lost submission produced
+     no error, no retry and no sweep.
+
+  4. `services/storage.py` writes uploads to the local filesystem when MinIO is
+     unreachable in development, and both S3 helpers in `genomic_worker` went
+     straight to boto3. The API put the file on disk and the worker looked for it
+     in S3.
+"""
+import inspect
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SUBMIT = REPO_ROOT / "api" / "routes" / "submit.py"
+WORKER = REPO_ROOT / "api" / "workers" / "genomic_worker.py"
+NOTIFY = REPO_ROOT / "api" / "workers" / "notify_worker.py"
+
+
+# ── 1. The row is committed before anything is told about it ─────────────────
+
+def test_the_task_is_enqueued_after_the_commit():
+    """
+    Ordering, asserted on the source, because reproducing the race in a test
+    means reproducing a race. The worker cannot see an uncommitted row, so the
+    commit has to come first.
+    """
+    source = SUBMIT.read_text(encoding="utf-8")
+    commit = source.index("await db.commit()")
+    enqueue = source.index("run_genomic_pipeline.apply_async")
+    assert commit < enqueue, (
+        "the pipeline task is enqueued before the transaction commits, so a "
+        "worker that starts promptly finds no submission"
+    )
+
+
+# ── 2 and 3. A lost submission is noticed ────────────────────────────────────
+
+def test_a_missing_submission_is_retried_not_reported_as_success():
+    source = WORKER.read_text(encoding="utf-8")
+    start = source.index("Submission %s not found")
+    window = source[start:start + 400]
+    assert "self.retry" in window, (
+        "a missing submission still returns, which marks the task succeeded"
+    )
+
+
+def test_the_sweeper_covers_queued_as_well_as_processing():
+    """
+    A submission whose task never ran is stuck in queued, not processing. The
+    sweeper looked only at work that had started.
+    """
+    source = WORKER.read_text(encoding="utf-8")
+    start = source.index("def sweep_stale_submissions")
+    body = source[start:start + 1600]
+    assert "SubmissionStatus.queued" in body, (
+        "the stale-submission sweeper ignores queued submissions"
+    )
+    assert "SubmissionStatus.processing" in body
+
+
+# ── 4. Upload and download agree about where files are ───────────────────────
+
+@pytest.mark.parametrize("helper", ["_download_from_minio", "_upload_vcf_to_minio"])
+def test_worker_storage_helpers_honour_the_local_fallback(helper):
+    """
+    `services.storage` has a documented fallback for development. A consumer
+    that ignores it disagrees with the half that wrote the file.
+    """
+    from workers import genomic_worker
+
+    source = inspect.getsource(getattr(genomic_worker, helper))
+    assert "_use_local_storage" in source, (
+        f"{helper} goes straight to boto3, so it cannot read or write what "
+        "services/storage.py placed on the local filesystem"
+    )
+
+
+def test_the_fallback_uses_the_same_layout_as_the_uploader():
+    """
+    storage.py writes to `<local_root>/<bucket>/<key>`. A reader using a
+    different layout fails in a way that looks like a missing upload.
+    """
+    from workers import genomic_worker
+
+    download = inspect.getsource(genomic_worker._download_from_minio)
+    assert "_local_root()" in download
+    assert "bucket_raw" in download
+
+
+# ── The notification query names a column that exists ────────────────────────
+
+def test_the_notification_query_uses_the_current_foreign_key():
+    """
+    RepurposingCandidate keys off result_id. notify_worker queried
+    submission_id, which the model has not had since it moved to Result as its
+    parent, so every notification raised AttributeError before it could be sent:
+    the analysis completed and the patient was never told.
+
+    gdpr_worker.py carries a comment about exactly this, so the correction had
+    been made once already, in one of the two places that needed it.
+    """
+    source = NOTIFY.read_text(encoding="utf-8")
+    assert "RepurposingCandidate.submission_id" not in source, (
+        "notify_worker still filters on a column the model does not have"
+    )
+    assert "RepurposingCandidate.result_id" in source
+
+
+def test_no_module_filters_repurposing_on_submission_id():
+    """The same mistake anywhere else would be equally silent."""
+    offenders = []
+    for path in (REPO_ROOT / "api").rglob("*.py"):
+        if "__pycache__" in path.parts or "tests" in path.parts:
+            continue
+        if "RepurposingCandidate.submission_id" in path.read_text(encoding="utf-8"):
+            offenders.append(str(path.relative_to(REPO_ROOT)))
+    assert not offenders, f"stale column reference in: {offenders}"
+
+
+def test_the_repurposing_model_really_keys_off_result_id():
+    """If the model moves back, the assertions above are checking the wrong thing."""
+    from models.repurposing import RepurposingCandidate
+
+    assert hasattr(RepurposingCandidate, "result_id")
+    assert not hasattr(RepurposingCandidate, "submission_id")

--- a/api/workers/genomic_worker.py
+++ b/api/workers/genomic_worker.py
@@ -57,8 +57,20 @@ def run_genomic_pipeline(
     with get_sync_session() as db:
         submission = db.get(Submission, submission_id)
         if not submission:
-            logger.error(f"[genomic] Submission {submission_id} not found")
-            return
+            # Returning here marks the task succeeded, so a submission that was
+            # enqueued before its transaction committed was lost with no retry
+            # and no failure anywhere. Retry instead: the row usually appears
+            # moments later, and if it genuinely never does the task ends failed
+            # rather than pretending it did the work.
+            logger.error(
+                "[genomic] Submission %s not found; retrying in case its "
+                "transaction has not committed yet", submission_id,
+            )
+            raise self.retry(
+                exc=RuntimeError(f"submission {submission_id} not visible"),
+                countdown=10,
+                max_retries=3,
+            )
         submission.status = SubmissionStatus.processing
         db.commit()
 
@@ -144,6 +156,24 @@ def _download_from_minio(s3_key: str, workdir: str) -> str:
     import boto3
     from botocore.config import Config
     from config import settings
+
+    # services/storage.py writes uploads to the local filesystem when MinIO is
+    # unreachable in development, and this read went straight to boto3. The two
+    # halves disagreed: the API put the file on disk and the worker looked for it
+    # in S3, so no submission could be processed without MinIO running even
+    # though the upload had deliberately avoided needing it.
+    from services.storage import _local_root, _use_local_storage
+
+    if _use_local_storage():
+        source = _local_root() / settings.bucket_raw / s3_key
+        if not source.exists():
+            raise FileNotFoundError(
+                f"{source} not found. Uploads went to local storage because MinIO "
+                "was unreachable; this read expects the same layout."
+            )
+        local_path = os.path.join(workdir, os.path.basename(s3_key))
+        shutil.copyfile(source, local_path)
+        return local_path
 
     scheme = "https" if settings.minio_secure else "http"
     s3 = boto3.client(
@@ -388,6 +418,20 @@ def _upload_vcf_to_minio(vcf_path: str, patient_id: str, submission_id: str) -> 
     from botocore.exceptions import ClientError
     from config import settings
 
+    key = f"{patient_id}/{submission_id}/annotated.vcf"
+
+    # Same fallback as the download above and as services/storage.py. Both S3
+    # helpers in this module went straight to boto3, so a development run that
+    # had deliberately avoided needing MinIO for the upload still could not
+    # store its result.
+    from services.storage import _local_root, _use_local_storage
+
+    if _use_local_storage():
+        dest = _local_root() / settings.bucket_vcf / key
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(vcf_path, dest)
+        return key
+
     scheme = "https" if settings.minio_secure else "http"
     s3 = boto3.client(
         "s3",
@@ -402,7 +446,6 @@ def _upload_vcf_to_minio(vcf_path: str, patient_id: str, submission_id: str) -> 
     except ClientError:
         s3.create_bucket(Bucket=settings.bucket_vcf)
 
-    key = f"{patient_id}/{submission_id}/annotated.vcf"
     s3.upload_file(
         vcf_path,
         settings.bucket_vcf,
@@ -421,7 +464,7 @@ def _upload_vcf_to_minio(vcf_path: str, patient_id: str, submission_id: str) -> 
     acks_late=True,
 )
 def sweep_stale_submissions(self):
-    """Re-queue or fail submissions that have been stuck in 'processing' > 6 hours."""
+    """Fail submissions stuck in 'queued' or 'processing' for more than 6 hours."""
     from datetime import datetime, timedelta, UTC
     from sqlalchemy import select
     from workers._db_sync import get_sync_session
@@ -431,7 +474,12 @@ def sweep_stale_submissions(self):
     with get_sync_session() as db:
         stale = db.execute(
             select(Submission).where(
-                Submission.status == SubmissionStatus.processing,
+                # queued as well as processing. A submission whose task never
+                # started stays queued forever, and the sweeper that exists to
+                # catch stuck work was looking only at work that had started.
+                Submission.status.in_(
+                    (SubmissionStatus.processing, SubmissionStatus.queued)
+                ),
                 Submission.created_at < cutoff,
             )
         ).scalars().all()

--- a/api/workers/notify_worker.py
+++ b/api/workers/notify_worker.py
@@ -75,6 +75,7 @@ def notify_results_ready(self, submission_id: str, patient_id: str):
     from models.submission import Submission
     from models.mutation import Mutation
     from models.repurposing import RepurposingCandidate
+    from models.result import Result
     from sqlalchemy import select
 
     try:
@@ -89,12 +90,22 @@ def notify_results_ready(self, submission_id: str, patient_id: str):
                 select(Mutation).where(Mutation.submission_id == submission_id)
             ).scalars().all()
             targetable = [m for m in mutations if m.is_targetable]
+            # RepurposingCandidate keys off result_id, not submission_id: it
+            # moved to Result as its parent and this query was not updated, so
+            # every notification raised AttributeError before it could be sent.
+            # gdpr_worker.py carries the same note against the same model, which
+            # is where the correction was made the first time.
+            result_ids = [
+                rid for (rid,) in db.execute(
+                    select(Result.id).where(Result.submission_id == submission_id)
+                ).all()
+            ]
             drugs = db.execute(
                 select(RepurposingCandidate)
-                .where(RepurposingCandidate.submission_id == submission_id)
+                .where(RepurposingCandidate.result_id.in_(result_ids))
                 .order_by(RepurposingCandidate.rank_score.desc())
                 .limit(3)
-            ).scalars().all()
+            ).scalars().all() if result_ids else []
             top_drug_names = [d.drug_name for d in drugs if d.drug_name]
 
         email = _get_patient_email_from_keycloak(patient.keycloak_id)


### PR DESCRIPTION
## Summary

Submitting `samples/egfr_t790m_demo.vcf` through the running API failed at five
separate points. No test covered any of them, because nothing had ever submitted
anything.

With these fixed, a sample goes from submit to `status: complete` for the first
time.

Files `OO-21`.

## 1. The task was enqueued before the transaction committed

```python
db.add(submission)
await db.flush()
job = run_genomic_pipeline.apply_async(...)   # <- worker starts here
submission.pipeline_job_id = job.id
await db.commit()                              # <- row becomes visible here
```

The worker opens its own session and looks the submission up by id. With Celery
eager, which is how development runs when Redis is unreachable, the task
executes inline at `apply_async` and the lookup failed **every time**. In
production the window is small and real.

## 2, 3. Losing it was silent in all three places that could have caught it

| Layer | Behaviour |
|---|---|
| Worker | Row missing → log, `return` → Celery marks the task **succeeded** |
| Sweeper | Covered `processing` > 6h only. A task that never started leaves the row in **`queued`** |
| API | Already returned `202` |

So a patient uploads a sample, gets a 202, and it is never analysed: no error,
no retry, no sweep, no record that anything went wrong.

The commit now precedes the enqueue, the worker retries three times before
failing rather than reporting success, and the sweeper covers `queued`.

## 4. Upload and download disagreed about where files live

`services/storage.py` writes uploads to the local filesystem when MinIO is
unreachable in development. Both S3 helpers in `genomic_worker` went straight to
boto3.

The API put the file on disk and the worker looked for it in S3, so a run that
had deliberately avoided needing MinIO for the upload could neither read its
input nor store its output. Both helpers now use the same predicate and the same
`<local_root>/<bucket>/<key>` layout.

## 5. The notification queried a column that does not exist

`notify_worker` filtered `RepurposingCandidate.submission_id`. The model has
keyed off `result_id` since it moved to `Result` as its parent, so every
notification raised `AttributeError` before it could be sent: the analysis
completed and the patient was never told.

`gdpr_worker.py` carries a comment about exactly this, so the correction had
already been made once, in one of the two places that needed it. A test now
fails on that reference anywhere under `api/`.

## Verification

| Check | Result |
|---|---|
| `ruff check api/` | Clean |
| api suite | 1342 passed, 3 skipped, 2 xfailed |
| ai suite | 42 passed |
| Coverage | 61.76% against the 52 gate |
| New assertions against `main` | 8 of 9 fail |
| Live submit to complete | Verified with `samples/egfr_t790m_demo.vcf` |

The ordering assertion is made on the source rather than by reproducing the
race, since reproducing a race in a test means reproducing a race.

## Filed, not fixed: OO-21

The same run surfaced something I have deliberately left alone.

Ingestion stores `INFO/HGVS_C` as `mutations.hgvs_notation`, and the evidence
table is keyed on protein notation:

```
get_all_drugs_for_variant("EGFR", "T790M")     -> 7 drugs  ['osimertinib', ...]
get_all_drugs_for_variant("EGFR", "c.2369C>T") -> 0 drugs  []
```

So the completed run reports `no_targetable_mutation` for a sample whose variant
the shipped table maps to seven drugs. `INFO/HGVS_P` is present in the sample
VCFs and read nowhere; the `mutations.hgvs_p` column was dropped by
`a8bf7eb4833c`; and `ai_worker._hgvs_to_short(hgvs_p: str)` is passed the coding
form.

That is hazard H2 and it changes which drugs are recommended for every
submission, so it belongs in `Needs human decision` rather than in this PR. It
also explains why the benchmarks do not see it: they feed protein notation
straight to the ranker and never pass through ingestion.
