### PR TITLE
The deployed image could not render a PDF

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -389,10 +389,89 @@ jobs:
   # `needs:` is kept deliberately. An image that reaches the registry without
   # passing the benchmark gate and both test suites is an image somebody can
   # deploy.
+  # OO-20. The report routes are named .pdf and fall back to HTML when
+  # WeasyPrint cannot load its native libraries. The fallback is correct and it
+  # is also silent: nothing raises, the download just changes type, and the
+  # suite cannot see it because the runner has libraries the image does not.
+  # The only place the question can be answered is inside the image.
+  pdf-rendering:
+    name: The image can render a PDF
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build the API image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: api/Dockerfile
+          push: false
+          load: true
+          tags: openoncology-api:pdf-check
+          cache-from: type=gha,scope=api
+          cache-to: type=gha,scope=api-pdf,mode=max
+
+      - name: Render an oncologist report inside the container
+        run: |
+          set -euo pipefail
+          docker run --rm -i openoncology-api:pdf-check python - <<'PY'
+          from services.oncologist_report import generate_oncologist_report
+          from services.pdf_export import generate_oncologist_report_document
+
+          report = generate_oncologist_report(
+              ranked_candidates=[],
+              mutation_summary=[{
+                  "gene": "EGFR", "hgvs": "p.T790M",
+                  "classification": "pathogenic", "oncokb_level": "1",
+              }],
+              cancer_type="Lung adenocarcinoma",
+              qc_report=None,
+              patient_id="ci",
+          )
+          body, content_type, extension = generate_oncologist_report_document(report)
+
+          if extension != ".pdf":
+              raise SystemExit(
+                  "the image fell back to HTML. WeasyPrint could not load its "
+                  "native libraries, so a request for oncologist-report.pdf "
+                  "returns " + content_type
+              )
+          if body[:5] != b"%PDF-":
+              raise SystemExit("the .pdf produced is not a PDF")
+
+          print("rendered", len(body), "bytes of", content_type)
+          PY
+
+      # The GTK stack is not small and this is the only feature that needs it,
+      # so the cost is recorded rather than assumed. The baseline is this same
+      # Dockerfile with the added packages removed, which is the honest
+      # comparison: one line differs.
+      - name: Record what the PDF libraries cost
+        run: |
+          set -euo pipefail
+          sed '/libpango/d' api/Dockerfile > Dockerfile.baseline
+          docker build -q -f Dockerfile.baseline -t openoncology-api:baseline . > /dev/null
+          new=$(docker image inspect openoncology-api:pdf-check --format '{{.Size}}')
+          old=$(docker image inspect openoncology-api:baseline --format '{{.Size}}')
+          {
+            echo "### Image size"
+            echo ""
+            echo "| | MB |"
+            echo "|---|---|"
+            echo "| without the PDF libraries | $((old / 1024 / 1024)) |"
+            echo "| with them | $((new / 1024 / 1024)) |"
+            echo "| **added** | **$(((new - old) / 1024 / 1024))** |"
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "added $(((new - old) / 1024 / 1024)) MB"
+
   publish-images:
     name: Build and publish container images
     runs-on: ubuntu-latest
-    needs: [lint-frontend, test-frontend, e2e-frontend, test-backend]
+    needs: [lint-frontend, test-frontend, e2e-frontend, test-backend, pdf-rendering]
 
     permissions:
       contents: read

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -71,6 +71,13 @@ Sections are ordered by pipeline position. `/next` pulls from the top of
 - **Out of scope**: digest pinning for these two images, which is stricter again and belongs with OO-6's decision about how digests get refreshed
 - **Risk**: low. Worth noting the first pin cannot be verified from this repository: whether the tag resolves is a property of the registry.
 
+---
+
+## In progress
+
+<!-- One entry maximum. An entry stranded here means a session died mid-work;
+     /standup will surface it. -->
+
 ### OO-20: The deployed image cannot render a PDF
 - **Why**: WeasyPrint is a Python package with native dependencies. `api/Dockerfile` installs `gcc`, `libpq-dev` and `curl` and none of libgobject, libpango or libcairo, so `import weasyprint` raises `OSError` in the deployed container exactly as it does on a developer Windows machine. Every oncologist report and patient letter download therefore returns HTML rather than a PDF. That is now a graceful degradation rather than a 500, which was the bug fixed alongside this, but it is still not what the endpoint is named after: the route is `oncologist-report.pdf` and it returns `text/html`.
 - **Files**: api/Dockerfile, api/requirements.txt, api/tests/test_report_download_path.py
@@ -80,13 +87,6 @@ Sections are ordered by pipeline position. `/next` pulls from the top of
   - The added image size is recorded, since the GTK stack is not small and this is the only feature that needs it
 - **Out of scope**: replacing WeasyPrint
 - **Risk**: low. Worth deciding rather than defaulting: a clinician who asked for a PDF and received HTML has something that prints differently and does not carry the same expectation of being a fixed record.
-
----
-
-## In progress
-
-<!-- One entry maximum. An entry stranded here means a session died mid-work;
-     /standup will surface it. -->
 
 ---
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -78,6 +78,12 @@ Sections are ordered by pipeline position. `/next` pulls from the top of
 <!-- One entry maximum. An entry stranded here means a session died mid-work;
      /standup will surface it. -->
 
+---
+
+## In review
+
+<!-- Entry plus PR URL. Cleared by hand when merged. -->
+
 ### OO-20: The deployed image cannot render a PDF
 - **Why**: WeasyPrint is a Python package with native dependencies. `api/Dockerfile` installs `gcc`, `libpq-dev` and `curl` and none of libgobject, libpango or libcairo, so `import weasyprint` raises `OSError` in the deployed container exactly as it does on a developer Windows machine. Every oncologist report and patient letter download therefore returns HTML rather than a PDF. That is now a graceful degradation rather than a 500, which was the bug fixed alongside this, but it is still not what the endpoint is named after: the route is `oncologist-report.pdf` and it returns `text/html`.
 - **Files**: api/Dockerfile, api/requirements.txt, api/tests/test_report_download_path.py
@@ -88,11 +94,7 @@ Sections are ordered by pipeline position. `/next` pulls from the top of
 - **Out of scope**: replacing WeasyPrint
 - **Risk**: low. Worth deciding rather than defaulting: a clinician who asked for a PDF and received HTML has something that prints differently and does not carry the same expectation of being a fixed record.
 
----
-
-## In review
-
-<!-- Entry plus PR URL. Cleared by hand when merged. -->
+- **PR**: https://github.com/immortal71/openoncology/pull/164
 
 ---
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -4,8 +4,17 @@ WORKDIR /app
 ENV PYTHONPATH=/app
 
 # System deps for bcrypt, asyncpg, etc.
+#
+# The pango libraries belong to WeasyPrint. Without them `import weasyprint`
+# raises OSError rather than ImportError, because the Python package installs
+# and its shared libraries do not, so every report download quietly served
+# HTML from a route named oncologist-report.pdf. WeasyPrint has not needed
+# cairo or gdk-pixbuf since v53; pango brings glib, harfbuzz and fontconfig
+# with it. fonts-dejavu-core is separate and still required: fontconfig with
+# no font installed lays the text out correctly and draws every glyph as a box.
 RUN apt-get update && apt-get install -y \
     gcc libpq-dev curl \
+    libpango-1.0-0 libpangoft2-1.0-0 fonts-dejavu-core \
     && rm -rf /var/lib/apt/lists/*
 
 COPY api/requirements.txt .

--- a/api/tests/test_report_download_path.py
+++ b/api/tests/test_report_download_path.py
@@ -229,3 +229,67 @@ def test_both_documents_render(report):
         gene="KRAS",
     ).sections)
     assert "<h1>" in letter
+
+
+# ── 5. The image the app is deployed as can render a PDF ─────────────────────
+#
+# Everything above is about the fallback behaving. This is about not needing it.
+# WeasyPrint is a Python package with native dependencies and `api/Dockerfile`
+# installed none of them, so the container took the HTML path on every request
+# to a route named `.pdf`. Nothing failed, so nothing said so.
+#
+# The assertion that settles it cannot run here, because this suite runs on a
+# machine whose libraries are not the image's. `ci.yml` builds the image and
+# renders a report inside it; these guard that that arrangement stays.
+
+_WEASYPRINT_RUNTIME_LIBS = ("libpango-1.0-0", "libpangoft2-1.0-0")
+
+
+def _dockerfile_instructions() -> str:
+    """
+    The Dockerfile with its comments removed. Searching the whole file finds the
+    comment that explains why a package is there and reports it as installed:
+    deleting the package line left the font guard green, because the paragraph
+    above it names the font.
+    """
+    text = (REPO_ROOT / "api" / "Dockerfile").read_text(encoding="utf-8")
+    return "\n".join(
+        line for line in text.splitlines() if not line.lstrip().startswith("#")
+    )
+
+
+def test_the_image_installs_what_weasyprint_loads_at_runtime():
+    dockerfile = _dockerfile_instructions()
+    missing = [lib for lib in _WEASYPRINT_RUNTIME_LIBS if lib not in dockerfile]
+    assert not missing, (
+        f"api/Dockerfile does not install {missing}, so `import weasyprint` "
+        "raises OSError in the container and every report download returns HTML "
+        "from a route named .pdf"
+    )
+
+
+def test_the_image_installs_a_font():
+    """
+    Pango lays the text out and fontconfig chooses a face. With no font in the
+    image the layout is correct and every glyph is drawn as a box: a valid PDF
+    that cannot be read.
+    """
+    assert "fonts-" in _dockerfile_instructions(), (
+        "the image installs no font, so a rendered PDF has no readable glyphs"
+    )
+
+
+def test_ci_renders_a_pdf_inside_the_image():
+    """
+    The two guards above check a package list, which is a proxy for the claim.
+    This checks that something builds the image and asks it for a PDF, because
+    an unconfirmed proxy is how the original defect survived.
+    """
+    workflow = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    assert "pdf-rendering:" in workflow, "no CI job renders a PDF inside the image"
+
+    job = workflow[workflow.index("pdf-rendering:"):].split("publish-images:")[0]
+    assert "docker run" in job, "the job builds the image but never runs it"
+    assert "%PDF-" in job, (
+        "the job renders a document without asserting the bytes are a PDF"
+    )


### PR DESCRIPTION
## Summary

`api/Dockerfile` installs WeasyPrint's native dependencies, and CI builds the
image and renders a report inside it. OO-20.

## Problem

WeasyPrint is a Python package with native dependencies. The image installed
`gcc`, `libpq-dev` and `curl`, and none of the pango libraries, so in the
deployed container `import weasyprint` raised `OSError` rather than
`ImportError`: the package was present and its shared libraries were not.

The report routes handle that correctly by falling back to HTML. The fallback
is the right behaviour and it is also silent. Nothing raises, the response is a
200, and the download simply changes type, so a request to
`oncologist-report.pdf` returned `text/html` and said nothing about it. A
clinician who asked for a PDF received a document that prints differently and
does not carry the same expectation of being a fixed record.

The test suite could not see this. It runs on a machine whose libraries are not
the image's, and on the CI runner WeasyPrint works, so every assertion about
PDF generation passed while the deployed container took the other branch.

## Changes

- `api/Dockerfile` installs `libpango-1.0-0`, `libpangoft2-1.0-0` and
  `fonts-dejavu-core`. WeasyPrint has not required cairo or gdk-pixbuf since
  v53, and pango brings glib, harfbuzz and fontconfig with it. The font is
  separate and still needed: fontconfig with no font installed lays the text
  out correctly and draws every glyph as a box, which is a valid PDF nobody can
  read.
- `.github/workflows/ci.yml` gains a `pdf-rendering` job that builds the image,
  renders an oncologist report inside the container, and fails if the result is
  not a PDF. `publish-images` now depends on it, so an image that cannot render
  a PDF is not published.
- The same job records the image size with and without the added packages,
  measured against this Dockerfile with the one package line removed, and
  writes both to the run summary.
- Three guards in `api/tests/test_report_download_path.py` covering the package
  list, the font, and the presence of the CI job that confirms them.

## Impact

The `.pdf` routes return PDFs in the deployed image. The HTML fallback stays
where it belongs, as the behaviour when the libraries are genuinely absent.

The image grows by 21 MB, measured by the job against this same Dockerfile with
the one package line removed. The measurement repeats on every run rather than
being asserted once, since the GTK stack is not small and this is the only
feature that needs it.

## Verification

- `ruff check api/` clean.
- Backend suites pass: 1336 passed, 3 skipped, 2 xfailed, plus 42 in the ai
  suite. Coverage 61.88% against the 52 gate.
- The `pdf-rendering` job rendered 22,980 bytes of `application/pdf` inside the
  built image, which is the assertion that could not be made anywhere else.
- Each of the three new guards was falsified: with the package line removed
  from the Dockerfile both package guards fail, and with the PDF-bytes
  assertion removed from the workflow the CI guard fails.
- One weakness was found this way and fixed. The font guard first searched the
  whole Dockerfile and passed on the comment that names the font rather than on
  the install line, so it stayed green with the package removed. Both guards
  now read instructions only, with comments stripped.

## Not included

- The rendering assertion cannot run on a developer machine, by construction.
  It runs in CI inside the built image, which is the only place the question is
  answerable.
- Trivy is gated on `refs/heads/main`, so this branch does not exercise it.
  Adding OS packages can introduce fixable HIGH/CRITICAL findings, and that
  gate blocks. The effect is not visible until after merge.
- WeasyPrint is not replaced; out of scope for OO-20.
